### PR TITLE
Fix bugs in the Upload API point

### DIFF
--- a/src/controllers/csv-processor.ts
+++ b/src/controllers/csv-processor.ts
@@ -56,17 +56,17 @@ function validateParams(page_number: number, max_page_number: number, page_size:
     return errors;
 }
 
-export const uploadCSV = async (buff: Buffer | undefined, datafile: string | undefined): Promise<ProcessedCSV> => {
+export const uploadCSV = async (buff: Buffer, datafile: Datafile): Promise<ProcessedCSV> => {
     const dataLateService = new DataLakeService();
     if (buff) {
         try {
             logger.debug(`Uploading file ${datafile} to datalake`);
-            await dataLateService.uploadFile(datafile, buff);
+            await dataLateService.uploadFile(`${datafile.id}.csv`, buff);
             return {
                 success: true,
-                datafile_id: datafile,
-                datafile_name: undefined,
-                datafile_description: undefined,
+                datafile_id: datafile.id,
+                datafile_name: datafile.name,
+                datafile_description: datafile.description,
                 page_size: undefined,
                 page_info: undefined,
                 pages: undefined,
@@ -78,9 +78,10 @@ export const uploadCSV = async (buff: Buffer | undefined, datafile: string | und
             };
         } catch (err) {
             logger.error(err);
+            datafile.remove();
             return {
                 success: false,
-                datafile_id: datafile,
+                datafile_id: undefined,
                 datafile_name: undefined,
                 datafile_description: undefined,
                 page_size: undefined,
@@ -95,9 +96,10 @@ export const uploadCSV = async (buff: Buffer | undefined, datafile: string | und
         }
     } else {
         logger.debug('No buffer to upload to datalake');
+        datafile.remove();
         return {
             success: false,
-            datafile_id: datafile,
+            datafile_id: datafile.id,
             datafile_name: undefined,
             datafile_description: undefined,
             page_size: undefined,

--- a/src/route/api.ts
+++ b/src/route/api.ts
@@ -22,12 +22,22 @@ apiRoute.get('/', (req, res) => {
 });
 
 apiRoute.post('/csv', upload.single('csv'), async (req: Request, res: Response) => {
-    // const page_number_str: string = req.query.page_number || req.body?.page_number;
-    // const page_size_str: string = req.query.page_size || req.body?.page_size;
-    // const page_number: number = Number.parseInt(page_number_str, 10) || 1;
-    // const page_size: number = Number.parseInt(page_size_str, 10) || 100;
-    const filemame: string | undefined = req.query.filename?.toString() || req.file?.originalname;
-    if (filemame === undefined) {
+    if (!req.file) {
+        res.status(400);
+        res.json({
+            success: false,
+            headers: undefined,
+            data: undefined,
+            errors: [
+                {
+                    field: 'csv',
+                    message: 'No CSV data available'
+                }
+            ]
+        });
+        return;
+    }
+    if (!req.body?.filename) {
         res.status(400);
         res.json({
             success: false,
@@ -36,13 +46,32 @@ apiRoute.post('/csv', upload.single('csv'), async (req: Request, res: Response) 
             errors: [
                 {
                     field: 'filename',
-                    message: 'No filename provided'
+                    message: 'No datasetname provided'
                 }
             ]
         });
         return;
     }
-    const processedCSV = await uploadCSV(req.file?.buffer, filemame);
+    if (!req.body?.description) {
+        res.status(400);
+        res.json({
+            success: false,
+            headers: undefined,
+            data: undefined,
+            errors: [
+                {
+                    field: 'description',
+                    message: 'No datasetname provided'
+                }
+            ]
+        });
+        return;
+    }
+    const datafile = new Datafile();
+    datafile.name = req.body?.filename;
+    datafile.description = req.body?.description;
+    const saved_datafile_record = await datafile.save();
+    const processedCSV = await uploadCSV(req.file?.buffer, saved_datafile_record);
     if (!processedCSV.success) {
         res.status(400);
     }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -42,9 +42,6 @@ describe('API Endpoints', () => {
         expect(res.status).toBe(400);
         expect(res.body).toEqual({
             success: false,
-            datafile_id: 'test-data-1.csv',
-            headers: undefined,
-            data: undefined,
             errors: [
                 {
                     field: 'csv',
@@ -55,16 +52,15 @@ describe('API Endpoints', () => {
     });
 
     test('Upload returns 400 if no filename is given', async () => {
-        const res = await request(app).post('/en-GB/api/csv');
+        const csvfile = path.resolve(__dirname, `./test-data-1.csv`);
+        const res = await request(app).post('/en-GB/api/csv').attach('csv', csvfile);
         expect(res.status).toBe(400);
         expect(res.body).toEqual({
             success: false,
-            headers: undefined,
-            data: undefined,
             errors: [
                 {
                     field: 'filename',
-                    message: 'No filename provided'
+                    message: 'No datasetname provided'
                 }
             ]
         });
@@ -76,12 +72,17 @@ describe('API Endpoints', () => {
         const res = await request(app)
             .post('/en-GB/api/csv')
             .attach('csv', csvfile)
-            .query({ filename: 'bdc40218-af89-424b-b86e-d21710bc92f1' });
+            .field('filename', 'test-upload-data-1')
+            .field('description', 'Test Data File 1');
+        const datafile: Datafile | null = await Datafile.findOneBy({ name: 'test-upload-data-1' });
         expect(res.status).toBe(200);
         expect(res.body).toEqual({
             success: true,
-            datafile_id: 'bdc40218-af89-424b-b86e-d21710bc92f1'
+            datafile_id: datafile?.id,
+            datafile_name: datafile?.name,
+            datafile_description: datafile?.description
         });
+        datafile?.remove();
     });
 
     test('Get a filelist list returns 200 with a file list', async () => {


### PR DESCRIPTION
Through the various iterations of Alpha the API layer and frontend layers stopped working in the same way at the point of file upload.  Now the frontend is entirely dependant on the backend it was important to fix the backend to behave as the old alpha frontend had.

This should fix issues with uploading files using the API layer not having IDs, being recorded in the Database and not showing up in the file list.