### PR TITLE
Changed the API route to Dataset, improved the API

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,7 @@ import Backend from 'i18next-fs-backend';
 import i18nextMiddleware from 'i18next-http-middleware';
 import { DataSourceOptions } from 'typeorm';
 
-import { apiRoute } from './route/api';
+import { apiRoute } from './route/dataset';
 import { healthcheck } from './route/healthcheck';
 import DatabaseManager from './database-manager';
 
@@ -45,10 +45,9 @@ export const logger = pino({
 });
 
 app.use(i18nextMiddleware.handle(i18next));
-app.use('/:lang/api', apiRoute);
+app.use('/:lang/dataset', apiRoute);
 app.use('/:lang/healthcheck', healthcheck);
 app.use('/healthcheck', healthcheck);
-app.use('/public', express.static(`${__dirname}/public`));
 
 app.get('/', (req: Request, res: Response) => {
     const lang = req.headers['accept-language'] || req.headers['Accept-Language'] || req.i18n.language || 'en-GB';

--- a/src/models/datafile-dto.ts
+++ b/src/models/datafile-dto.ts
@@ -1,0 +1,9 @@
+export interface DatafileDTO {
+    id: string;
+    name: string;
+    description: string;
+    creation_date: Date;
+    csv_link: string;
+    xslx_link: string;
+    view_link: string;
+}


### PR DESCRIPTION
As part of improving the backend api layer it was time to rename CSV to dataset and remove the redundant API route as the backend service no longer provides any views just API endpoints.