### PR TITLE
regen migration file to match latest entities

### DIFF
--- a/src/migrations/1727256918658-initial-schema.ts
+++ b/src/migrations/1727256918658-initial-schema.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class Migration1726079883728 implements MigrationInterface {
-    name = 'Migration1726079883728';
+export class InitialSchema1727256918658 implements MigrationInterface {
+    name = 'InitialSchema1727256918658';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
@@ -13,28 +13,16 @@ export class Migration1726079883728 implements MigrationInterface {
             `CREATE UNIQUE INDEX "UX_user_provider_provider_user_id" ON "users" ("provider", "provider_user_id") `
         );
         await queryRunner.query(
-            `CREATE TABLE "dataset_info" ("dataset_id" uuid NOT NULL, "language" character varying(5) NOT NULL, "title" text, "description" text, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), CONSTRAINT "PK_dataset_info_dataset_id_language" PRIMARY KEY ("dataset_id", "language"))`
+            `CREATE TABLE "dataset_info" ("dataset_id" uuid NOT NULL, "language" character varying(5) NOT NULL, "title" text, "description" text, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_dataset_info_dataset_id_language" PRIMARY KEY ("dataset_id", "language"))`
         );
         await queryRunner.query(
-            `CREATE TABLE "dimension_info" ("dimension_id" uuid NOT NULL, "language" character varying(5) NOT NULL, "name" text, "description" text, "notes" text, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), CONSTRAINT "PK_dimension_info_dimension_id_language" PRIMARY KEY ("dimension_id", "language"))`
-        );
-        await queryRunner.query(
-            `CREATE TABLE "csv_info" ("import_id" uuid NOT NULL, "delimiter" character varying(1) NOT NULL, "quote" character varying(1) NOT NULL, "linebreak" character varying(2) NOT NULL, CONSTRAINT "PK_csv_info_import_id" PRIMARY KEY ("import_id"))`
-        );
-        await queryRunner.query(
-            `CREATE TYPE "public"."file_import_type_enum" AS ENUM('Draft', 'FactTable', 'LookupTable')`
-        );
-        await queryRunner.query(
-            `CREATE TYPE "public"."file_import_location_enum" AS ENUM('BlobStorage', 'Datalake', 'Unknown')`
-        );
-        await queryRunner.query(
-            `CREATE TABLE "file_import" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "mime_type" character varying(255) NOT NULL, "filename" character varying(255) NOT NULL, "hash" character varying(255) NOT NULL, "uploaded_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "type" "public"."file_import_type_enum" NOT NULL, "location" "public"."file_import_location_enum" NOT NULL, "revision_id" uuid, CONSTRAINT "PK_import_id" PRIMARY KEY ("id"))`
+            `CREATE TABLE "dimension_info" ("dimension_id" uuid NOT NULL, "language" character varying(5) NOT NULL, "name" text NOT NULL, "description" text, "notes" text, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_dimension_info_dimension_id_language" PRIMARY KEY ("dimension_id", "language"))`
         );
         await queryRunner.query(
             `CREATE TYPE "public"."source_action_enum" AS ENUM('CREATE', 'APPEND', 'TRUNCATE-THEN-LOAD', 'IGNORE', 'UNKNOWN')`
         );
         await queryRunner.query(
-            `CREATE TYPE "public"."source_type_enum" AS ENUM('DATAVALUES', 'FOOTNOTES', 'DIMENSION', 'IGNORE')`
+            `CREATE TYPE "public"."source_type_enum" AS ENUM('DATAVALUES', 'FOOTNOTES', 'DIMENSION', 'IGNORE', 'UNKNOWN')`
         );
         await queryRunner.query(
             `CREATE TABLE "source" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "column_index" integer NOT NULL, "csv_field" text NOT NULL, "action" "public"."source_action_enum", "type" "public"."source_type_enum", "dimension_id" uuid, "import_id" uuid NOT NULL, "revision_id" uuid, CONSTRAINT "PK_source_id" PRIMARY KEY ("id"))`
@@ -52,22 +40,28 @@ export class Migration1726079883728 implements MigrationInterface {
             `CREATE TABLE "revision" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "revision_index" integer NOT NULL, "creation_date" TIMESTAMP NOT NULL DEFAULT now(), "online_cube_filename" character varying(255), "publish_date" TIMESTAMP WITH TIME ZONE, "approval_date" TIMESTAMP WITH TIME ZONE, "dataset_id" uuid, "previous_revision_id" uuid, "approved_by" uuid, "created_by" uuid, CONSTRAINT "PK_revision_id" PRIMARY KEY ("id"))`
         );
         await queryRunner.query(
+            `CREATE TABLE "csv_info" ("import_id" uuid NOT NULL, "delimiter" character varying(1) NOT NULL, "quote" character varying(1) NOT NULL, "linebreak" character varying(2) NOT NULL, CONSTRAINT "PK_csv_info_import_id" PRIMARY KEY ("import_id"))`
+        );
+        await queryRunner.query(
+            `CREATE TYPE "public"."file_import_type_enum" AS ENUM('Draft', 'FactTable', 'LookupTable')`
+        );
+        await queryRunner.query(
+            `CREATE TYPE "public"."file_import_location_enum" AS ENUM('BlobStorage', 'Datalake', 'Unknown')`
+        );
+        await queryRunner.query(
+            `CREATE TABLE "file_import" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "mime_type" character varying(255) NOT NULL, "filename" character varying(255) NOT NULL, "hash" character varying(255) NOT NULL, "uploaded_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "type" "public"."file_import_type_enum" NOT NULL, "location" "public"."file_import_location_enum" NOT NULL, "revision_id" uuid, CONSTRAINT "PK_import_id" PRIMARY KEY ("id"))`
+        );
+        await queryRunner.query(
             `ALTER TABLE "dataset_info" ADD CONSTRAINT "FK_dataset_info_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
             `ALTER TABLE "dimension_info" ADD CONSTRAINT "FK_dimension_info_dimension_id" FOREIGN KEY ("dimension_id") REFERENCES "dimension"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
-            `ALTER TABLE "csv_info" ADD CONSTRAINT "FK_csv_info_import_id" FOREIGN KEY ("import_id") REFERENCES "file_import"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
-        );
-        await queryRunner.query(
-            `ALTER TABLE "file_import" ADD CONSTRAINT "FK_import_revision_id" FOREIGN KEY ("revision_id") REFERENCES "revision"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
-        );
-        await queryRunner.query(
             `ALTER TABLE "source" ADD CONSTRAINT "FK_source_dimension_id" FOREIGN KEY ("dimension_id") REFERENCES "dimension"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
-            `ALTER TABLE "source" ADD CONSTRAINT "FK_source_import_id" FOREIGN KEY ("import_id") REFERENCES "file_import"("id") ON DELETE CASCADE ON UPDATE CASCADE`
+            `ALTER TABLE "source" ADD CONSTRAINT "FK_source_import_id" FOREIGN KEY ("import_id") REFERENCES "file_import"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
             `ALTER TABLE "source" ADD CONSTRAINT "FK_source_revision_id" FOREIGN KEY ("revision_id") REFERENCES "revision"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
@@ -76,10 +70,10 @@ export class Migration1726079883728 implements MigrationInterface {
             `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
-            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_start_revision_id" FOREIGN KEY ("start_revision_id") REFERENCES "revision"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_start_revision_id" FOREIGN KEY ("start_revision_id") REFERENCES "revision"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
-            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_finish_revision_id" FOREIGN KEY ("finish_revision_id") REFERENCES "revision"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_finish_revision_id" FOREIGN KEY ("finish_revision_id") REFERENCES "revision"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
         );
         await queryRunner.query(
             `ALTER TABLE "dataset" ADD CONSTRAINT "FK_dataset_created_by" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
@@ -96,9 +90,17 @@ export class Migration1726079883728 implements MigrationInterface {
         await queryRunner.query(
             `ALTER TABLE "revision" ADD CONSTRAINT "FK_revision_created_by" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
         );
+        await queryRunner.query(
+            `ALTER TABLE "csv_info" ADD CONSTRAINT "FK_csv_info_import_id" FOREIGN KEY ("import_id") REFERENCES "file_import"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "file_import" ADD CONSTRAINT "FK_import_revision_id" FOREIGN KEY ("revision_id") REFERENCES "revision"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "file_import" DROP CONSTRAINT "FK_import_revision_id"`);
+        await queryRunner.query(`ALTER TABLE "csv_info" DROP CONSTRAINT "FK_csv_info_import_id"`);
         await queryRunner.query(`ALTER TABLE "revision" DROP CONSTRAINT "FK_revision_created_by"`);
         await queryRunner.query(`ALTER TABLE "revision" DROP CONSTRAINT "FK_revision_approved_by"`);
         await queryRunner.query(`ALTER TABLE "revision" DROP CONSTRAINT "FK_revision_previous_revision_id"`);
@@ -110,10 +112,12 @@ export class Migration1726079883728 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "source" DROP CONSTRAINT "FK_source_revision_id"`);
         await queryRunner.query(`ALTER TABLE "source" DROP CONSTRAINT "FK_source_import_id"`);
         await queryRunner.query(`ALTER TABLE "source" DROP CONSTRAINT "FK_source_dimension_id"`);
-        await queryRunner.query(`ALTER TABLE "file_import" DROP CONSTRAINT "FK_import_revision_id"`);
-        await queryRunner.query(`ALTER TABLE "csv_info" DROP CONSTRAINT "FK_csv_info_import_id"`);
         await queryRunner.query(`ALTER TABLE "dimension_info" DROP CONSTRAINT "FK_dimension_info_dimension_id"`);
         await queryRunner.query(`ALTER TABLE "dataset_info" DROP CONSTRAINT "FK_dataset_info_dataset_id"`);
+        await queryRunner.query(`DROP TABLE "file_import"`);
+        await queryRunner.query(`DROP TYPE "public"."file_import_location_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."file_import_type_enum"`);
+        await queryRunner.query(`DROP TABLE "csv_info"`);
         await queryRunner.query(`DROP TABLE "revision"`);
         await queryRunner.query(`DROP TABLE "dataset"`);
         await queryRunner.query(`DROP TABLE "dimension"`);
@@ -121,10 +125,6 @@ export class Migration1726079883728 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE "source"`);
         await queryRunner.query(`DROP TYPE "public"."source_type_enum"`);
         await queryRunner.query(`DROP TYPE "public"."source_action_enum"`);
-        await queryRunner.query(`DROP TABLE "file_import"`);
-        await queryRunner.query(`DROP TYPE "public"."file_import_location_enum"`);
-        await queryRunner.query(`DROP TYPE "public"."file_import_type_enum"`);
-        await queryRunner.query(`DROP TABLE "csv_info"`);
         await queryRunner.query(`DROP TABLE "dimension_info"`);
         await queryRunner.query(`DROP TABLE "dataset_info"`);
         await queryRunner.query(`DROP INDEX "public"."UX_user_provider_provider_user_id"`);


### PR DESCRIPTION
The current migration file is not consistent with current entity state, so this PR regens it from a blank database and should now exactly match the entities.