### PR TITLE
Fix issue that calling confirm preview returns the wrong obj

### DIFF
--- a/src/controllers/csv-processor.ts
+++ b/src/controllers/csv-processor.ts
@@ -397,6 +397,16 @@ export const removeTempfileFromBlobStorage = async (importObj: FileImport) => {
     }
 };
 
+export const removeFileFromDatalake = async (importObj: FileImport) => {
+    const datalakeService = new DataLakeService();
+    try {
+        await datalakeService.deleteFile(importObj.filename);
+    } catch (err) {
+        logger.error(err);
+        throw new Error('Unable to successfully remove from from Datalake');
+    }
+};
+
 export const createSources = async (importObj: FileImport): Promise<ImportDTO> => {
     const revision: Revision = await importObj.revision;
     const dataset: Dataset = await revision.dataset;

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -514,7 +514,7 @@ router.patch(
         const importRecord = await validateImport(importID, res);
         if (!importRecord) return;
         if (importRecord.location === DataLocation.DATA_LAKE) {
-            const fileImportDto = await ImportDTO.fromImport(importRecord);
+            const fileImportDto = await ImportDTO.fromImportWithSources(importRecord);
             res.status(200);
             res.json(fileImportDto);
             return;

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -17,6 +17,7 @@ import {
     moveFileToDataLake,
     processCSVFromBlobStorage,
     processCSVFromDatalake,
+    removeFileFromDatalake,
     removeTempfileFromBlobStorage,
     uploadCSVBufferToBlobStorage
 } from '../controllers/csv-processor';
@@ -557,7 +558,14 @@ router.delete(
         const importRecord = await validateImport(importID, res);
         if (!importRecord) return;
         try {
-            await removeTempfileFromBlobStorage(importRecord);
+            if (importRecord.location === DataLocation.DATA_LAKE) {
+                logger.warn('User has requested to remove a fact table from the datalake.  This is unusual.');
+                await removeFileFromDatalake(importRecord);
+                const sources = await importRecord.sources;
+                sources.forEach((source) => source.remove());
+            } else {
+                await removeTempfileFromBlobStorage(importRecord);
+            }
         } catch (err) {
             logger.error(`An error occurred trying to remove the file with the following error: ${err}`);
             res.status(500);

--- a/test/helpers/jest-setup.ts
+++ b/test/helpers/jest-setup.ts
@@ -10,3 +10,5 @@ process.env.TEST_DB_PORT = '5433';
 process.env.TEST_DB_USERNAME = 'postgres';
 process.env.TEST_DB_PASSWORD = 'postgres';
 process.env.TEST_DB_DATABASE = 'statswales-backend-test';
+
+process.env.APP_ENV = 'ci';

--- a/test/publisher-journey.test.ts
+++ b/test/publisher-journey.test.ts
@@ -618,7 +618,7 @@ describe('API Endpoints', () => {
             expect(postRunFileImport.location).toBe(DataLocation.DATA_LAKE);
             const sources = await postRunFileImport.sources;
             expect(sources.length).toBe(4);
-            const dto = await ImportDTO.fromImport(postRunFileImport);
+            const dto = await ImportDTO.fromImportWithSources(postRunFileImport);
             expect(res.status).toBe(200);
             expect(res.body).toEqual(dto);
         });

--- a/test/publisher-journey.test.ts
+++ b/test/publisher-journey.test.ts
@@ -417,12 +417,42 @@ describe('API Endpoints', () => {
     });
 
     describe('Step 2b - Unhappy path of the user uploading the wrong file', () => {
-        test('Returns 200 when the user requests to delete the import', async () => {
+        test('Returns 200 when the user requests to delete the import stored in blobstorage', async () => {
             const testDatasetId = crypto.randomUUID().toLowerCase();
             const testRevisionId = crypto.randomUUID().toLowerCase();
             const testFileImportId = crypto.randomUUID().toLowerCase();
             await createSmallDataset(testDatasetId, testRevisionId, testFileImportId, user);
             BlobStorageService.prototype.deleteFile = jest.fn().mockReturnValue(true);
+            const res = await request(app)
+                .delete(
+                    `/en-GB/dataset/${testDatasetId}/revision/by-id/${testRevisionId}/import/by-id/${testFileImportId}`
+                )
+                .set(getAuthHeader(user));
+            expect(res.status).toBe(200);
+            const updatedRevision = await Revision.findOneBy({ id: testRevisionId });
+            if (!updatedRevision) {
+                throw new Error('Revision not found');
+            }
+            const imports = await updatedRevision.imports;
+            expect(imports).toBeInstanceOf(Array);
+            expect(imports.length).toBe(0);
+            const updatedDataset = await Dataset.findOneBy({ id: testDatasetId });
+            if (!updatedDataset) {
+                throw new Error('Dataset not found');
+            }
+            const dto = await DatasetDTO.fromDatasetWithRevisionsAndImports(updatedDataset);
+            expect(res.body).toEqual(dto);
+        });
+
+        test('Returns 200 when the user requests to delete the import stored in the datalake', async () => {
+            const testDatasetId = crypto.randomUUID().toLowerCase();
+            const testRevisionId = crypto.randomUUID().toLowerCase();
+            const testFileImportId = crypto.randomUUID().toLowerCase();
+            await createSmallDataset(testDatasetId, testRevisionId, testFileImportId, user);
+            const importRecord = await FileImport.findOneByOrFail({ id: testFileImportId });
+            importRecord.location = DataLocation.DATA_LAKE;
+            await importRecord.save();
+            DataLakeService.prototype.deleteFile = jest.fn().mockReturnValue(true);
             const res = await request(app)
                 .delete(
                     `/en-GB/dataset/${testDatasetId}/revision/by-id/${testRevisionId}/import/by-id/${testFileImportId}`


### PR DESCRIPTION
This fixes 2 bugs which were oddly related.  When we make subsequent requests to confirm an import we check if the import has any sources attached to it.  If it does we silently just return a DTO object with the current state of the import.  There was an error here where we failed to return the sources with the import.  This was tripping up the frontend which was assuming something had gone wrong as there were no sources now attached to the import.  So the fix was to update the return to include sources and update the test to reflect the change.

This opens the door to the other issue where if you try the unhappy path of removing the file at the preview page would result in errors as the file was already stored in the datalake.  This fixes that issue by adding a check for the files location and unwinding as appropriate.