### PR TITLE
Use type text instead of ltree for hierarchy path

### DIFF
--- a/src/entities/dataset/topic.ts
+++ b/src/entities/dataset/topic.ts
@@ -11,10 +11,7 @@ export class Topic extends BaseEntity {
     // For root topics, the path is just the id, e.g. if id = 1, then the path is '1'
     // For child topics, the path contains the parent topic ids, e.g. for a topic with
     // grandparent id 1, parent id of 12 and an id of 57, then the path is '1.12.57'
-    // This uses the ltree type in PostgreSQL, but we could just use text if we don't need the extra features
-    // See https://www.postgresql.org/docs/current/ltree.html
-    // and https://patshaughnessy.net/2017/12/13/saving-a-tree-in-postgres-using-ltree
-    @Column({ name: 'path', type: 'ltree', nullable: false })
+    @Column({ name: 'path', type: 'text', nullable: false })
     path: string;
 
     @Column({ name: 'name_en', type: 'text', nullable: true })

--- a/src/migrations/1732809740745-topics.ts
+++ b/src/migrations/1732809740745-topics.ts
@@ -1,11 +1,11 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class Topics1732808273510 implements MigrationInterface {
-    name = 'Topics1732808273510';
+export class Topics1732809740745 implements MigrationInterface {
+    name = 'Topics1732809740745';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `CREATE TABLE "topic" ("id" SERIAL NOT NULL, "path" ltree NOT NULL, "name_en" text, "name_cy" text, CONSTRAINT "PK_topic_id" PRIMARY KEY ("id"))`
+            `CREATE TABLE "topic" ("id" SERIAL NOT NULL, "path" text NOT NULL, "name_en" text, "name_cy" text, CONSTRAINT "PK_topic_id" PRIMARY KEY ("id"))`
         );
         await queryRunner.query(
             `CREATE TABLE "dataset_topic" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "dataset_id" uuid NOT NULL, "topic_id" integer NOT NULL, CONSTRAINT "PK_dataset_topic_id" PRIMARY KEY ("id"))`


### PR DESCRIPTION
The `ltree` type is available out of the box in the default Postgres docker image, but not in Azure. We could enable it through the extensions option in the settings, but we can do without it for this particular use-case.

