### PR TITLE
fix blank children rows in topics

### DIFF
--- a/src/seeders/topics.ts
+++ b/src/seeders/topics.ts
@@ -41,14 +41,16 @@ export default class TopicSeeder extends Seeder {
                     logger.info(`Seeded root topic '${rootTopic.nameEN}'`);
                 }
 
-                const childTopic = Topic.create();
-                childTopic.id = topicId;
-                childTopic.path = `${rootTopic.path}.${topicId}`;
-                childTopic.nameEN = row.L2.trim();
-                childTopics.push(childTopic);
-                topicId++;
-                await em.save<Topic>(childTopic);
-                logger.info(`Seeded child topic '${childTopic.nameEN}'`);
+                if (row.L2) {
+                    const childTopic = Topic.create();
+                    childTopic.id = topicId;
+                    childTopic.path = `${rootTopic.path}.${topicId}`;
+                    childTopic.nameEN = row.L2.trim();
+                    childTopics.push(childTopic);
+                    topicId++;
+                    await em.save<Topic>(childTopic);
+                    logger.info(`Seeded child topic '${childTopic.nameEN}'`);
+                }
             }
         };
 


### PR DESCRIPTION
The seeder was inserting a blank child row if the parent topic had no children.