### PR TITLE
Fix bug where special characters in columns broke preview

### DIFF
--- a/src/controllers/dimension-processor.ts
+++ b/src/controllers/dimension-processor.ts
@@ -377,7 +377,7 @@ export const validateDateTypeDimension = async (
 
         // Now validate everything matches
         const nonMatchedRows = await quack.all(
-            `SELECT line_number, fact_table_date, date_dimension.date_code FROM (SELECT row_number() OVER () as line_number, ${dimension.factTableColumn} as fact_table_date FROM ${tableName}) as fact_table LEFT JOIN date_dimension ON fact_table.fact_table_date=date_dimension.date_code where date_code IS NULL;`
+            `SELECT line_number, fact_table_date, date_dimension.date_code FROM (SELECT row_number() OVER () as line_number, "${dimension.factTableColumn}" as fact_table_date FROM ${tableName}) as fact_table LEFT JOIN date_dimension ON fact_table.fact_table_date=date_dimension.date_code where date_code IS NULL;`
         );
         if (nonMatchedRows.length > 0) {
             if (nonMatchedRows.length === preview.length) {
@@ -410,7 +410,7 @@ export const validateDateTypeDimension = async (
                     `There were ${nonMatchedRows.length} row(s) which didn't match based on the information given to us by the user`
                 );
                 const nonMatchedRowSample = await quack.all(
-                    `SELECT DISTINCT fact_table_date, FROM (SELECT row_number() OVER () as line_number, ${dimension.factTableColumn} as fact_table_date FROM ${tableName}) as fact_table LEFT JOIN date_dimension ON fact_table.fact_table_date=date_dimension.date_code where date_code IS NULL;`
+                    `SELECT DISTINCT fact_table_date, FROM (SELECT row_number() OVER () as line_number, "${dimension.factTableColumn}" as fact_table_date FROM ${tableName}) as fact_table LEFT JOIN date_dimension ON fact_table.fact_table_date=date_dimension.date_code where date_code IS NULL;`
                 );
                 const nonMatchingValues = nonMatchedRowSample
                     .map((item) => item.fact_table_date)
@@ -498,7 +498,7 @@ async function getDatePreviewWithExtractor(
     quack: Database,
     tableName: string
 ): Promise<ViewDTO> {
-    const columnData = await quack.all(`SELECT DISTINCT ${dimension.factTableColumn} FROM ${tableName}`);
+    const columnData = await quack.all(`SELECT DISTINCT "${dimension.factTableColumn}" FROM ${tableName}`);
     const dateDimensionTable = dateDimensionReferenceTableCreator(dimension.extractor, columnData);
     await quack.exec(createDateDimensionTable);
     // Create the date_dimension table
@@ -546,7 +546,7 @@ async function getDatePreviewWithoutExtractor(
     tableName: string
 ): Promise<ViewDTO> {
     const preview = await quack.all(
-        `SELECT DISTINCT ${dimension.factTableColumn} FROM ${tableName} USING SAMPLE ${sampleSize};`
+        `SELECT DISTINCT "${dimension.factTableColumn}" FROM ${tableName} USING SAMPLE ${sampleSize};`
     );
     const tableHeaders = Object.keys(preview[0]);
     const dataArray = preview.map((row) => Object.values(row));

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -496,22 +496,30 @@ router.get(
             next(new NotFoundException('errors.fact_table_invalid'));
             return;
         }
-        let preview: ViewDTO | ViewErrDTO;
-        switch (dimension.type) {
-            case DimensionType.TimePoint:
-            case DimensionType.TimePeriod:
-                preview = await getDateDimensionColumnPreview(dataset, dimension, factTable);
-                break;
-            default:
-                preview = await getFactTableColumnPreview(dataset, factTable, dimension.factTableColumn);
-                break;
-        }
-        if ((preview as ViewErrDTO).errors) {
-            res.status(500);
+        try {
+            let preview: ViewDTO | ViewErrDTO;
+            switch (dimension.type) {
+                case DimensionType.TimePoint:
+                case DimensionType.TimePeriod:
+                    preview = await getDateDimensionColumnPreview(dataset, dimension, factTable);
+                    break;
+                default:
+                    preview = await getFactTableColumnPreview(dataset, factTable, dimension.factTableColumn);
+                    break;
+            }
+            if ((preview as ViewErrDTO).errors) {
+                res.status(500);
+                res.json(preview);
+            }
+            res.status(200);
             res.json(preview);
+        } catch (err) {
+            logger.error(
+                `Something went wrong trying to get a preview of the dimension with the following error: ${err}`
+            );
+            res.status(500);
+            res.json({ message: 'Something went wrong trying to generate a preview of the dimension' });
         }
-        res.status(200);
-        res.json(preview);
     }
 );
 


### PR DESCRIPTION
Bug where special characters such as `(`, `[`, ` `, `]`, `)` broke the SQL queries used to generate the previews.