### PR TITLE
Add lookup table handling and cube creation

### DIFF
--- a/src/controllers/csv-processor.ts
+++ b/src/controllers/csv-processor.ts
@@ -362,6 +362,7 @@ export const getFactTableColumnPreview = async (
     factTable: FactTable,
     columnName: string
 ): Promise<ViewDTO | ViewErrDTO> => {
+    logger.debug(`Getting fact table column preview for ${columnName}`);
     const tableName = 'preview_table';
     const quack = await Database.create(':memory:');
     const tempFile = tmp.fileSync({ postfix: `.${factTable.fileType}` });

--- a/src/controllers/csv-processor.ts
+++ b/src/controllers/csv-processor.ts
@@ -18,6 +18,7 @@ import { Error } from '../dtos/error';
 import { Locale } from '../enums/locale';
 import { FileType } from '../enums/file-type';
 import { FactTableInfo } from '../entities/dataset/fact-table-info';
+import { FactTableAction } from '../enums/fact-table-action';
 
 export const MAX_PAGE_SIZE = 500;
 export const MIN_PAGE_SIZE = 5;
@@ -129,7 +130,7 @@ export async function extractTableInformation(fileBuffer: Buffer, fileType: File
     try {
         await quack.exec(createTableQuery);
         tableHeaders = await quack.all(
-            `SELECT (row_number() OVER ())-1 as index, column_name FROM (DESCRIBE ${tableName});`
+            `SELECT (row_number() OVER ())-1 as index, column_name, column_type FROM (DESCRIBE ${tableName});`
         );
     } catch (error) {
         logger.error(`Something went wrong trying to read the users file with the following error: ${error}`);
@@ -149,6 +150,7 @@ export async function extractTableInformation(fileBuffer: Buffer, fileType: File
         info.columnName = header.column_name;
         info.columnIndex = header.index;
         info.columnType = FactTableColumnType.Unknown;
+        info.columnDatatype = header.column_type;
         return info;
     });
 }
@@ -230,6 +232,7 @@ export const uploadCSV = async (
     }
     factTable.factTableInfo = factTableDescriptions;
     factTable.filename = `${factTable.id}.${extension}`;
+    factTable.action = FactTableAction.ReplaceAll;
     const hash = createHash('sha256');
     hash.update(fileBuffer);
     try {

--- a/src/controllers/cube-handler.ts
+++ b/src/controllers/cube-handler.ts
@@ -1,0 +1,514 @@
+import fs from 'node:fs';
+
+import tmp, { FileResult } from 'tmp';
+import { Database } from 'duckdb-async';
+import { t } from 'i18next';
+
+import { Dataset } from '../entities/dataset/dataset';
+import { FactTableAction } from '../enums/fact-table-action';
+import { DataLakeService } from '../services/datalake';
+import { FactTableColumnType } from '../enums/fact-table-column-type';
+import { FactTableInfo } from '../entities/dataset/fact-table-info';
+import { FileImport } from '../entities/dataset/file-import';
+import { SUPPORTED_LOCALES } from '../middleware/translation';
+import { DimensionType } from '../enums/dimension-type';
+import { Dimension } from '../entities/dataset/dimension';
+import { FileType } from '../enums/file-type';
+import { logger } from '../utils/logger';
+import { Locale } from '../enums/locale';
+import { Revision } from '../entities/dataset/revision';
+import { FactTable } from '../entities/dataset/fact-table';
+import { DuckdbOutputType } from '../enums/duckdb-outputs';
+
+import { dateDimensionReferenceTableCreator } from './time-matching';
+// eslint-disable-next-line import/no-cycle
+import { LookupTableExtractor } from './lookup-table-handler';
+
+export const FACT_TABLE_NAME = 'fact_table';
+
+export const makeCubeSafeString = (str: string): string => {
+    return str
+        .toLowerCase()
+        .replace(/[ ]/g, '_')
+        .replace(/[^a-zA-Z_]/g, '');
+};
+
+export const getFileImportAndSaveToDisk = async (dataset: Dataset, importFile: FileImport): Promise<FileResult> => {
+    const dataLakeService = new DataLakeService();
+    const importTmpFile = tmp.fileSync({ postfix: `.${importFile.fileType}` });
+    const buffer = await dataLakeService.getFileBuffer(importFile.filename, dataset.id);
+    fs.writeFileSync(importTmpFile.name, buffer);
+    return importTmpFile;
+};
+
+// This function creates a table in a duckdb database based on a file and loads the files contents directly into the table
+export const loadFileIntoDatabase = async (
+    quack: Database,
+    fileImport: FileImport,
+    tempFile: FileResult,
+    tableName: string
+) => {
+    let createTableQuery: string;
+    switch (fileImport.fileType) {
+        case FileType.Csv:
+        case FileType.GzipCsv:
+            createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM read_csv('${tempFile.name}', auto_type_candidates = ['BOOLEAN', 'BIGINT', 'DOUBLE', 'VARCHAR']);`;
+            break;
+        case FileType.Parquet:
+            createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM '${tempFile.name}';`;
+            break;
+        case FileType.Json:
+        case FileType.GzipJson:
+            createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM read_json_auto('${tempFile.name}');`;
+            break;
+        case FileType.Excel:
+            await quack.exec('INSTALL spatial;');
+            await quack.exec('LOAD spatial;');
+            createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM st_read('${tempFile.name}');`;
+            break;
+        default:
+            throw new Error('Unknown file type');
+    }
+    await quack.exec(createTableQuery);
+};
+
+// This function differs from loadFileIntoDatabase in that it only loads a file into an existing table
+export const loadFileDataIntoTable = async (
+    quack: Database,
+    fileImport: FileImport,
+    tempFile: FileResult,
+    tableName: string
+) => {
+    let insertQuery: string;
+    switch (fileImport.fileType) {
+        case FileType.Csv:
+        case FileType.GzipCsv:
+            insertQuery = `INSERT INTO ${tableName} SELECT * FROM read_csv('${tempFile.name}', auto_type_candidates = ['BOOLEAN', 'BIGINT', 'DOUBLE', 'VARCHAR']);`;
+            break;
+        case FileType.Parquet:
+            insertQuery = `INSERT INTO ${tableName} SELECT * FROM ${tempFile.name};`;
+            break;
+        case FileType.Json:
+        case FileType.GzipJson:
+            insertQuery = `INSERT INTO ${tableName} SELECT * FROM read_json_auto('${tempFile.name}');`;
+            break;
+        case FileType.Excel:
+            insertQuery = `INSERT INTO ${tableName} SELECT * FROM st_read('${tempFile.name}');`;
+            break;
+        default:
+            throw new Error('Unknown file type');
+    }
+    await quack.exec(insertQuery);
+};
+
+// This is a short version of validate date dimension code found in the dimension processor.
+// This concise version doesn't return any information on why the creation failed.  Just that it failed
+async function createAndValidateDateDimension(quack: Database, extractor: object | null, factTableColumn: string) {
+    if (!extractor) {
+        throw new Error('Extractor not supplied');
+    }
+    const columnData = await quack.all(`SELECT "${factTableColumn}" FROM ${FACT_TABLE_NAME};`);
+    const dateDimensionTable = dateDimensionReferenceTableCreator(extractor, columnData);
+    await quack.exec(
+        `CREATE TABLE ${makeCubeSafeString(factTableColumn)}_lookup (date_code VARCHAR, description VARCHAR, start_date datetime, end_date datetime, date_type varchar);`
+    );
+    // Create the date_dimension table
+    const stmt = await quack.prepare(`INSERT INTO ${makeCubeSafeString(factTableColumn)}_lookup VALUES (?,?,?,?,?);`);
+    dateDimensionTable.map(async (row) => {
+        await stmt.run(row.dateCode, row.description, row.start, row.end, row.type);
+    });
+    await stmt.finalize();
+    const nonMatchedRows = await quack.all(
+        `SELECT line_number, fact_table_date, ${makeCubeSafeString(factTableColumn)}_lookup.date_code FROM (SELECT row_number() OVER () as line_number, "${factTableColumn}" as fact_table_date FROM ${FACT_TABLE_NAME}) as fact_table LEFT JOIN ${makeCubeSafeString(factTableColumn)}_lookup ON CAST(fact_table.fact_table_date AS VARCHAR)=CAST(${makeCubeSafeString(factTableColumn)}_lookup.date_code AS VARCHAR) where date_code IS NULL;`
+    );
+    if (nonMatchedRows.length > 0) {
+        throw new Error(`Failed to validate date dimension`);
+    }
+    return `${makeCubeSafeString(factTableColumn)}_lookup`;
+}
+
+// This is a short version of the validate lookup table code found in the dimension process.
+// This concise version doesn't return any information on why the creation failed.  Just that it failed
+async function createAndValidateLookupTableDimension(quack: Database, dataset: Dataset, dimension: Dimension) {
+    if (!dimension.lookupTable) return;
+    if (!dimension.extractor) return;
+    const extractor = dimension.extractor as LookupTableExtractor;
+    const lookupTableFile = await getFileImportAndSaveToDisk(dataset, dimension.lookupTable);
+    if (dimension.lookupTable.isStatsWales2Format) {
+        await loadFileIntoDatabase(
+            quack,
+            dimension.lookupTable,
+            lookupTableFile,
+            `${makeCubeSafeString(dimension.factTableColumn)}_lookup_sw2`
+        );
+        let sortOrderCol = '';
+        if (extractor.sortColumn) {
+            sortOrderCol = `${extractor.sortColumn}, `;
+        }
+        const viewParts: string[] = SUPPORTED_LOCALES.map((locale) => {
+            const descriptionCol = extractor.descriptionColumns.find((col) => col.lang === locale.split('-')[0]);
+            const descriptionColStr = descriptionCol ? `${descriptionCol.name} as description, ` : '';
+            const notesCol = extractor.notesColumns.find((col) => col.lang === locale.split('-')[0]);
+            const notesColStr = notesCol ? `${notesCol.name} as notes, ` : '';
+            return (
+                `SELECT "${dimension.joinColumn}", ${sortOrderCol} '${locale.toLowerCase()}' as language,\n` +
+                `${descriptionColStr} ${notesColStr} from ${makeCubeSafeString(dimension.factTableColumn)}_lookup_sw2`
+            );
+        });
+        await quack.exec(`CREATE VIEW ${dimension.factTableColumn}_lookup AS ${viewParts.join('\nUNION\n')};`);
+    } else {
+        await loadFileIntoDatabase(
+            quack,
+            dimension.lookupTable,
+            lookupTableFile,
+            `${makeCubeSafeString(dimension.factTableColumn)}_lookup`
+        );
+    }
+    const nonMatchedRows = await quack.all(
+        `SELECT line_number, fact_table_column, ${makeCubeSafeString(dimension.factTableColumn)}_lookup.${dimension.joinColumn} as lookup_table_column FROM (SELECT row_number() OVER () as line_number, "${dimension.factTableColumn}" as fact_table_column FROM ${FACT_TABLE_NAME}) as fact_table LEFT JOIN ${makeCubeSafeString(dimension.factTableColumn)}_lookup ON CAST(fact_table.fact_table_column AS VARCHAR)=CAST(${makeCubeSafeString(dimension.factTableColumn)}_lookup.${dimension.joinColumn} AS VARCHAR) where lookup_table_column IS NULL;`
+    );
+    if (nonMatchedRows.length > 0) {
+        throw new Error('Failed to validate lookup table dimension');
+    }
+}
+
+function setupFactTableUpdateJoins(factTableInfos: FactTableInfo[]): string {
+    return factTableInfos.map((info) => `update_table."${info.columnName}"="${info.columnName}"`).join(' AND ');
+}
+
+// Builds a fresh cube based on all revisions and returns the file pointer
+// to the duckdb file on disk.  This is based on the recipe in our cube miro
+// board and our candidate cube format repo.  It is limited to building a
+// simple default view based on the available locales.
+export const createBaseCube = async (dataset: Dataset, endRevision: Revision): Promise<string> => {
+    const firstRevision = dataset.revisions.find((rev) => rev.revisionIndex === 1);
+    if (!firstRevision) {
+        throw new Error(`Unable to find first revision for dataset ${dataset.id}`);
+    }
+    const firstFactTable = firstRevision.factTables[0];
+    const quack = await Database.create(':memory:');
+    const compositeKey: string[] = [];
+    const factIdentifiers: FactTableInfo[] = [];
+    let notesCodeColumn: FactTableInfo | undefined;
+    let dataValuesColumn: FactTableInfo | undefined;
+    let measureColumn: FactTableInfo | undefined;
+    const factTableDef = firstFactTable.factTableInfo.map((field) => {
+        switch (field.columnType) {
+            case FactTableColumnType.Dimension:
+            case FactTableColumnType.Time:
+                compositeKey.push(`"${field.columnName}"`);
+                factIdentifiers.push(field);
+                break;
+            case FactTableColumnType.Measure:
+                compositeKey.push(`"${field.columnName}"`);
+                factIdentifiers.push(field);
+                measureColumn = field;
+                break;
+            case FactTableColumnType.NoteCodes:
+                notesCodeColumn = field;
+                break;
+            case FactTableColumnType.DataValues:
+                dataValuesColumn = field;
+                break;
+        }
+        return `"${field.columnName}" ${field.columnDatatype}`;
+    });
+
+    if (!notesCodeColumn) {
+        throw Error(`No column representing notes codes was found`);
+    }
+    if (!dataValuesColumn) {
+        throw Error(`No column representing data was found`);
+    }
+    logger.info('Creating fact table in cube');
+    try {
+        await quack.exec(
+            `CREATE TABLE ${FACT_TABLE_NAME} (${factTableDef.join(', ')}, PRIMARY KEY (${compositeKey.join(', ')}));`
+        );
+    } catch (err) {
+        logger.error(`Failed to create fact table in cube: ${err}`);
+        await quack.close();
+        throw new Error(`Failed to create fact table in cube: ${err}`);
+    }
+
+    // Find all the fact tables for the given revision
+    let allFactTables: FactTable[] = [];
+    if (endRevision.revisionIndex > 0) {
+        // If we have a revision index we start here
+        const validRevisions = dataset.revisions.filter(
+            (rev) => rev.revisionIndex <= endRevision.revisionIndex && rev.revisionIndex > 0
+        );
+        allFactTables = validRevisions.flatMap((revision) => revision.factTables);
+    } else {
+        // If we don't have a revision index we need to find the previous revision to this one that does
+        allFactTables = allFactTables.concat(endRevision.factTables);
+        const validRevisions = dataset.revisions.filter(
+            (rev) => rev.createdAt < endRevision.createdAt && rev.revisionIndex > 0
+        );
+        allFactTables = validRevisions.flatMap((revision) => revision.factTables);
+    }
+
+    // Process all the fact tables
+    logger.debug('Loading all fact tables in to database');
+    try {
+        for (const factTable of allFactTables.sort((ftA, ftB) => ftA.uploadedAt.getTime() - ftB.uploadedAt.getTime())) {
+            logger.info(`Loading fact table data for fact table ${factTable.id}`);
+            const factTableFile = await getFileImportAndSaveToDisk(dataset, factTable);
+            const updateQuery =
+                `UPDATE ${FACT_TABLE_NAME} SET "${dataValuesColumn.columnName}"=update_table."${dataValuesColumn.columnName}", ` +
+                `"${notesCodeColumn.columnName}"=(CASE ${FACT_TABLE_NAME}."${notesCodeColumn.columnName}" = NULL THEN 'r' ELSE concat(${FACT_TABLE_NAME}."${notesCodeColumn.columnName}"', ',r') END) ` +
+                `FROM update_table WHERE ${setupFactTableUpdateJoins(factIdentifiers)} ` +
+                `AND update_table."${notesCodeColumn.columnName}" LIKE '%r';`;
+            switch (factTable.action) {
+                case FactTableAction.ReplaceAll:
+                    await quack.exec(`DELETE FROM ${FACT_TABLE_NAME};`);
+                    await loadFileDataIntoTable(quack, factTable, factTableFile, FACT_TABLE_NAME);
+                    break;
+                case FactTableAction.Add:
+                    await loadFileDataIntoTable(quack, factTable, factTableFile, FACT_TABLE_NAME);
+                    break;
+                case FactTableAction.Revise:
+                    await loadFileDataIntoTable(quack, factTable, factTableFile, 'update_table');
+                    await quack.exec(updateQuery);
+                    await quack.exec(`DROP TABLE update_table;`);
+                    break;
+                case FactTableAction.AddRevise:
+                    await loadFileDataIntoTable(quack, factTable, factTableFile, 'update_table');
+                    await quack.exec(updateQuery);
+                    await quack.exec(`DELETE FROM update_table WHERE ${notesCodeColumn.columnName} LIKE '%r';`);
+                    await quack.exec(`INSERT INTO ${FACT_TABLE_NAME} (SELECT * FROM update_table);`);
+                    await quack.exec(`DROP TABLE update_table;`);
+                    break;
+            }
+            factTableFile.removeCallback();
+        }
+    } catch (error) {
+        logger.error(`Something went wrong trying to create the core fact table with error: ${error}`);
+        await quack.close();
+        throw error;
+    }
+
+    const selectStatementsMap = new Map<Locale, string[]>();
+    SUPPORTED_LOCALES.map((locale) => selectStatementsMap.set(locale, []));
+    const joinStatements: string[] = [];
+    const orderByStatements: string[] = [];
+
+    logger.info('Setting up measure table if present...');
+    // Process the column that represents the measure
+    if (measureColumn && dataset.measure && dataset.measure.joinColumn) {
+        // If we parsed the lookup table or the user
+        // has used a user journey to define measures
+        // use this first
+        if (dataset.measure.measureInfo.length > 0) {
+            try {
+                await quack.exec(
+                    `CREATE TABLE measure (measure_id ${measureColumn.columnType}, sort_order INT, language VARCHAR(5), description VARCHAR, notes VARCHAR, data_type VARCHAR, display_type VARCHAR);`
+                );
+                const insertStmt = await quack.prepare(`INSERT INTO measure (?,?,?,?,?,?);`);
+                dataset.measure.measureInfo.map(async (measure) => {
+                    await insertStmt.run(
+                        measure.id,
+                        measure.sortOrder,
+                        measure.language,
+                        measure.description,
+                        measure.notes,
+                        measure.displayType
+                    );
+                });
+                await insertStmt.finalize();
+            } catch (error) {
+                logger.error(`Unable to create or load measure table in to the cube with error: ${error}`);
+                await quack.close();
+                throw error;
+            }
+        } else if (dataset.measure && dataset.measure.lookupTable) {
+            const measureFile = await getFileImportAndSaveToDisk(dataset, dataset.measure.lookupTable);
+            if (dataset.measure.lookupTable.isStatsWales2Format) {
+                try {
+                    await quack.exec(`INSERT INTO measure_sw2 SELECT * FROM '${measureFile.name}`);
+                    const viewComponents: string[] = [];
+                    for (const locale of SUPPORTED_LOCALES) {
+                        viewComponents.push(
+                            `SELECT MeasureCode as measure_id, sort_order, '${locale.toLowerCase()}' AS language, "Description_${locale.split('-')[0]}" AS description, "Format" AS format, data_type AS data_type FROM measure_sw2\n`
+                        );
+                    }
+                    const buildMeasureViewQuery = `CREATE VIEW measure AS SELECT * FROM ${measureFile.name}\n${viewComponents.join('\nUNION\n')};`;
+                    await quack.exec(buildMeasureViewQuery);
+                } catch (error) {
+                    logger.error(`Unable to create or load measure table in to the cube with error: ${error}`);
+                    await quack.close();
+                    throw error;
+                }
+            }
+            measureFile.removeCallback();
+        } else {
+            logger.error(`Measure is defined in the dataset but it has no lookup nor definitions`);
+            await quack.close();
+            throw new Error('No measure definitions found');
+        }
+        SUPPORTED_LOCALES.map((locale) => {
+            selectStatementsMap
+                .get(locale)
+                ?.push(
+                    `measure_id as ${dataset.measure.measureInfo.find((info) => info.language === locale.toLowerCase())?.description || dataset.measure.factTableColumn}`
+                );
+            // UPDATE THIS TO SUPPORT SPECIFIC DISPLAY TYPES
+            if (dataValuesColumn)
+                selectStatementsMap
+                    .get(locale)
+                    ?.push(
+                        `${FACT_TABLE_NAME}."${dataValuesColumn?.columnName}" as "${t('column_headers.data_values', { lng: locale })}"`
+                    );
+        });
+        joinStatements.push(
+            `LEFT JOIN measure on measure.measure_id=${FACT_TABLE_NAME}.${dataset.measure.factTableColumn} AND measure.language='#LANG#'`
+        );
+        orderByStatements.push(`measure.measure_id`);
+    } else {
+        SUPPORTED_LOCALES.map((locale) => {
+            if (dataValuesColumn)
+                selectStatementsMap
+                    .get(locale)
+                    ?.push(
+                        `${FACT_TABLE_NAME}."${dataValuesColumn?.columnName}" as "${t('column_headers.data_values', { lng: locale })}"`
+                    );
+        });
+    }
+
+    for (const dimension of dataset.dimensions) {
+        logger.info(`Setting up dimension ${dimension.id} for fact table column ${dimension.factTableColumn}`);
+        const dimTable = `${makeCubeSafeString(dimension.factTableColumn)}_lookup`;
+        try {
+            switch (dimension.type) {
+                case DimensionType.TimePeriod:
+                case DimensionType.TimePoint:
+                    await createAndValidateDateDimension(quack, dimension.extractor, dimension.factTableColumn);
+                    SUPPORTED_LOCALES.map((locale) => {
+                        const columnName =
+                            dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                            dimension.factTableColumn;
+                        selectStatementsMap.get(locale)?.push(`${dimTable}.description as "${columnName}"`);
+                        selectStatementsMap
+                            .get(locale)
+                            ?.push(`${dimTable}.start_date as "${t('column_headers.start_date', { lng: locale })}"`);
+                        selectStatementsMap
+                            .get(locale)
+                            ?.push(`${dimTable}.end_date as "${t('column_headers.end_date', { lng: locale })}"`);
+                    });
+                    joinStatements.push(
+                        `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}"`
+                    );
+                    orderByStatements.push(`${dimTable}.end_date`);
+                    break;
+                case DimensionType.LookupTable:
+                    await createAndValidateLookupTableDimension(quack, dataset, dimension);
+                    SUPPORTED_LOCALES.map((locale) => {
+                        const columnName =
+                            dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                            dimension.factTableColumn;
+                        selectStatementsMap.get(locale)?.push(`${dimTable}.description as "${columnName}"`);
+                    });
+                    joinStatements.push(
+                        `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}" AND ${dimTable}.language='#LANG#'`
+                    );
+                    orderByStatements.push(`${dimTable}.sort_order`);
+                    break;
+                case DimensionType.ReferenceData:
+                    logger.error(`Reference data dimensions not implemented`);
+                    SUPPORTED_LOCALES.map((locale) => {
+                        const columnName =
+                            dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                            dimension.factTableColumn;
+                        selectStatementsMap.get(locale)?.push(`${dimension.factTableColumn} as "${columnName}"`);
+                    });
+                    break;
+                case DimensionType.Raw:
+                case DimensionType.Numeric:
+                case DimensionType.Text:
+                case DimensionType.Symbol:
+                    SUPPORTED_LOCALES.map((locale) => {
+                        const columnName =
+                            dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                            dimension.factTableColumn;
+                        selectStatementsMap.get(locale)?.push(`${dimension.factTableColumn} as "${columnName}"`);
+                    });
+                    break;
+            }
+        } catch (err) {
+            logger.error(`Something went wrong trying to load dimension ${dimension.id} in to the cube`);
+            await quack.close();
+            throw new Error(
+                `Could not load dimensions ${dimension.id} in to the cube with the following error: ${err}`
+            );
+        }
+    }
+
+    SUPPORTED_LOCALES.map((locale) => {
+        if (notesCodeColumn)
+            selectStatementsMap
+                .get(locale)
+                ?.push(
+                    `${FACT_TABLE_NAME}."${notesCodeColumn?.columnName}" as "${t('column_headers.note_codes', { lng: locale })}"`
+                );
+    });
+
+    logger.info(`Creating default views...`);
+    // Build the default views
+    for (const locale of SUPPORTED_LOCALES) {
+        const defaultViewSQL = `CREATE VIEW default_view_${locale.toLowerCase().split('-')[0]} AS SELECT\n${selectStatementsMap
+            .get(locale)
+            ?.join(
+                ',\n'
+            )} FROM ${FACT_TABLE_NAME}\n${joinStatements.join('\n').replace('#LANG#', locale.toLowerCase())}\n ${orderByStatements.length > 0 ? `ORDER BY ${orderByStatements.join(', ')}` : ''};`;
+        await quack.exec(defaultViewSQL);
+    }
+    logger.debug(`Writing memory database to disk`);
+    const tmpFile = tmp.tmpNameSync({ postfix: '.db' });
+    logger.debug(`Writing memory database to disk at ${tmpFile}`);
+    await quack.exec(`ATTACH '${tmpFile}' as outDB;`);
+    await quack.exec(`COPY FROM DATABASE memory TO outDB;`);
+    await quack.exec('DETACH outDB;');
+    await quack.close();
+    // Pass the file handle to the calling method
+    // If used for preview you just want the file
+    // If it's the end of the publishing step you'll
+    // want to upload the file to the data lake.
+    return tmpFile;
+};
+
+export const getCubeDataTable = async (cubeFile: string, lang: string) => {
+    const quack = await Database.create(cubeFile);
+    const defaultView = await quack.all(`SELECT * FROM default_view_${lang};`);
+    await quack.close();
+    return defaultView;
+};
+
+export const outputCube = async (cubeFile: string, lang: string, mode: DuckdbOutputType) => {
+    const quack = await Database.create(cubeFile);
+    const outputFile: FileResult = tmp.fileSync({ postfix: `.${mode}` });
+    switch (mode) {
+        case DuckdbOutputType.Csv:
+            await quack.exec(`COPY default_view_${lang} TO '${outputFile.name}' (HEADER, DELIMITER ',');`);
+            break;
+        case DuckdbOutputType.Parquet:
+            await quack.exec(`COPY default_view_${lang} TO '${outputFile.name}' (FORMAT PARQUET);`);
+            break;
+        case DuckdbOutputType.Excel:
+            await quack.exec(`INSTALL spatial;`);
+            await quack.exec('LOAD spatial;');
+            await quack.exec(`COPY default_view_${lang} TO '${outputFile.name}' WITH (FORMAT GDAL, DRIVER 'xlsx');`);
+            break;
+        case DuckdbOutputType.Json:
+            await quack.exec(`COPY default_view_${lang} TO '${outputFile.name}' (FORMAT JSON);`);
+            break;
+        case DuckdbOutputType.DuckDb:
+            return cubeFile;
+        default:
+            throw new Error(`Format ${mode} not supported`);
+    }
+    return outputFile.name;
+};
+
+export const cleanUpCube = async (tmpFile: string) => {
+    fs.unlinkSync(tmpFile);
+};

--- a/src/controllers/cube-handler.ts
+++ b/src/controllers/cube-handler.ts
@@ -19,10 +19,17 @@ import { Locale } from '../enums/locale';
 import { Revision } from '../entities/dataset/revision';
 import { FactTable } from '../entities/dataset/fact-table';
 import { DuckdbOutputType } from '../enums/duckdb-outputs';
+// eslint-disable-next-line import/no-cycle
+import { DatasetRepository } from '../repositories/dataset';
+import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { DatasetDTO } from '../dtos/dataset-dto';
+import { FactTableDTO } from '../dtos/fact-table-dto';
+import { Error } from '../dtos/error';
 
-import { dateDimensionReferenceTableCreator } from './time-matching';
 // eslint-disable-next-line import/no-cycle
 import { LookupTableExtractor } from './lookup-table-handler';
+import { dateDimensionReferenceTableCreator } from './time-matching';
+import { MAX_PAGE_SIZE, MIN_PAGE_SIZE } from './csv-processor';
 
 export const FACT_TABLE_NAME = 'fact_table';
 
@@ -382,23 +389,34 @@ export const createBaseCube = async (dataset: Dataset, endRevision: Revision): P
             switch (dimension.type) {
                 case DimensionType.TimePeriod:
                 case DimensionType.TimePoint:
-                    await createAndValidateDateDimension(quack, dimension.extractor, dimension.factTableColumn);
-                    SUPPORTED_LOCALES.map((locale) => {
-                        const columnName =
-                            dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
-                            dimension.factTableColumn;
-                        selectStatementsMap.get(locale)?.push(`${dimTable}.description as "${columnName}"`);
-                        selectStatementsMap
-                            .get(locale)
-                            ?.push(`${dimTable}.start_date as "${t('column_headers.start_date', { lng: locale })}"`);
-                        selectStatementsMap
-                            .get(locale)
-                            ?.push(`${dimTable}.end_date as "${t('column_headers.end_date', { lng: locale })}"`);
-                    });
-                    joinStatements.push(
-                        `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}"`
-                    );
-                    orderByStatements.push(`${dimTable}.end_date`);
+                    if (dimension.extractor) {
+                        await createAndValidateDateDimension(quack, dimension.extractor, dimension.factTableColumn);
+                        SUPPORTED_LOCALES.map((locale) => {
+                            const columnName =
+                                dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                                dimension.factTableColumn;
+                            selectStatementsMap.get(locale)?.push(`${dimTable}.description as "${columnName}"`);
+                            selectStatementsMap
+                                .get(locale)
+                                ?.push(
+                                    `${dimTable}.start_date as "${t('column_headers.start_date', { lng: locale })}"`
+                                );
+                            selectStatementsMap
+                                .get(locale)
+                                ?.push(`${dimTable}.end_date as "${t('column_headers.end_date', { lng: locale })}"`);
+                        });
+                        joinStatements.push(
+                            `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}"`
+                        );
+                        orderByStatements.push(`${dimTable}.end_date`);
+                    } else {
+                        SUPPORTED_LOCALES.map((locale) => {
+                            const columnName =
+                                dimension.dimensionInfo.find((info) => info.language === locale)?.name ||
+                                dimension.factTableColumn;
+                            selectStatementsMap.get(locale)?.push(`${dimension.factTableColumn} as "${columnName}"`);
+                        });
+                    }
                     break;
                 case DimensionType.LookupTable:
                     await createAndValidateLookupTableDimension(quack, dataset, dimension);
@@ -481,6 +499,130 @@ export const getCubeDataTable = async (cubeFile: string, lang: string) => {
     const defaultView = await quack.all(`SELECT * FROM default_view_${lang};`);
     await quack.close();
     return defaultView;
+};
+
+function validatePageSize(page_size: number): boolean {
+    return !(page_size > MAX_PAGE_SIZE || page_size < MIN_PAGE_SIZE);
+}
+
+function validatePageNumber(page_number: number): boolean {
+    return page_number >= 1;
+}
+
+function validatMaxPageNumber(page_number: number, max_page_number: number): boolean {
+    return page_number <= max_page_number;
+}
+
+function validateParams(page_number: number, max_page_number: number, page_size: number): Error[] {
+    const errors: Error[] = [];
+    if (!validatePageSize(page_size)) {
+        errors.push({
+            field: 'page_size',
+            message: [
+                {
+                    lang: Locale.English,
+                    message: t('errors.page_size', {
+                        lng: Locale.English,
+                        max_page_size: MAX_PAGE_SIZE,
+                        min_page_size: MIN_PAGE_SIZE
+                    })
+                },
+                {
+                    lang: Locale.Welsh,
+                    message: t('errors.page_size', {
+                        lng: Locale.Welsh,
+                        max_page_size: MAX_PAGE_SIZE,
+                        min_page_size: MIN_PAGE_SIZE
+                    })
+                }
+            ],
+            tag: {
+                name: 'errors.page_size',
+                params: { max_page_size: MAX_PAGE_SIZE, min_page_size: MIN_PAGE_SIZE }
+            }
+        });
+    }
+    if (!validatMaxPageNumber(page_number, max_page_number)) {
+        errors.push({
+            field: 'page_number',
+            message: [
+                {
+                    lang: Locale.English,
+                    message: t('errors.page_number_to_high', { lng: Locale.English, page_number: max_page_number })
+                },
+                {
+                    lang: Locale.Welsh,
+                    message: t('errors.page_number_to_high', { lng: Locale.Welsh, page_number: max_page_number })
+                }
+            ],
+            tag: {
+                name: 'errors.page_number_to_high',
+                params: { page_number: max_page_number }
+            }
+        });
+    }
+    if (!validatePageNumber(page_number)) {
+        errors.push({
+            field: 'page_number',
+            message: [
+                { lang: Locale.English, message: t('errors.page_number_to_low', { lng: Locale.English }) },
+                { lang: Locale.Welsh, message: t('errors.page_number_to_low', { lng: Locale.Welsh }) }
+            ],
+            tag: { name: 'errors.page_number_to_low', params: {} }
+        });
+    }
+    return errors;
+}
+
+export const getCubePreview = async (
+    cubeFile: string,
+    lang: string,
+    dataset: Dataset,
+    page: number,
+    size: number
+): Promise<ViewDTO | ViewErrDTO> => {
+    const quack = await Database.create(cubeFile);
+    const defaultView = await quack.all(`SELECT * FROM default_view_${lang};`);
+    const totalsQuery = `SELECT count(*) as totalLines, ceil(count(*)/${size}) as totalPages from default_view_${lang};`;
+    const totals = await quack.all(totalsQuery);
+    const totalPages = Number(totals[0].totalPages);
+    const totalLines = Number(totals[0].totalLines);
+    const errors = validateParams(page, totalPages, size);
+    if (errors.length > 0) {
+        return {
+            status: 400,
+            errors,
+            dataset_id: dataset.id
+        };
+    }
+    const previewQuery = `SELECT * FROM default_view_${lang} LIMIT ${size} OFFSET ${(page - 1) * size}`;
+    const preview = await quack.all(previewQuery);
+    const startLine = Number(preview[0].int_line_number);
+    const lastLine = Number(preview[preview.length - 1].int_line_number);
+    const tableHeaders = Object.keys(preview[0]);
+    const dataArray = preview.map((row) => Object.values(row));
+    const currentDataset = await DatasetRepository.getById(dataset.id);
+    const headers: CSVHeader[] = [];
+    for (let i = 0; i < tableHeaders.length; i++) {
+        headers.push({
+            index: i - 1,
+            name: tableHeaders[i],
+            source_type: FactTableColumnType.Unknown
+        });
+    }
+    return {
+        dataset: DatasetDTO.fromDataset(currentDataset),
+        current_page: page,
+        page_info: {
+            total_records: totalLines,
+            start_record: startLine,
+            end_record: lastLine
+        },
+        page_size: size,
+        total_pages: totalPages,
+        headers,
+        data: dataArray
+    };
 };
 
 export const outputCube = async (cubeFile: string, lang: string, mode: DuckdbOutputType) => {

--- a/src/controllers/dimension-processor.ts
+++ b/src/controllers/dimension-processor.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import { Database } from 'duckdb-async';
 import tmp from 'tmp';
 import { t } from 'i18next';
-import { View } from 'typeorm';
 
 import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
 import { Dataset } from '../entities/dataset/dataset';
@@ -26,7 +25,9 @@ import { DatasetRepository } from '../repositories/dataset';
 import { DatasetDTO } from '../dtos/dataset-dto';
 import { FactTableDTO } from '../dtos/fact-table-dto';
 
-import { DateExtractor, DateReferenceDataItem, dateDimensionReferenceTableCreator } from './time-matching';
+import { dateDimensionReferenceTableCreator, DateExtractor, DateReferenceDataItem } from './time-matching';
+import { getFileImportAndSaveToDisk, loadFileIntoDatabase } from './cube-handler';
+import { LookupTableExtractor } from './lookup-table-handler';
 
 const createDateDimensionTable = `CREATE TABLE date_dimension (date_code VARCHAR, description VARCHAR, start_date datetime, end_date datetime, date_type varchar);`;
 const sampleSize = 5;
@@ -510,9 +511,7 @@ async function getDatePreviewWithExtractor(
         await stmt.run(row.dateCode, row.description, row.start, row.end, row.type);
     });
     await stmt.finalize();
-    const dimensionTable = await quack.all(
-        `SELECT * FROM date_dimension USING SAMPLE ${sampleSize} ORDER BY end_date;`
-    );
+    const dimensionTable = await quack.all(`SELECT * FROM date_dimension ORDER BY end_date ASC LIMIT ${sampleSize};`);
     const tableHeaders = Object.keys(dimensionTable[0]);
     const dataArray = dimensionTable.map((row) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
@@ -541,7 +540,7 @@ async function getDatePreviewWithExtractor(
     };
 }
 
-async function getDatePreviewWithoutExtractor(
+async function getPreviewWithoutExtractor(
     dataset: Dataset,
     dimension: Dimension,
     factTable: FactTable,
@@ -579,7 +578,54 @@ async function getDatePreviewWithoutExtractor(
     };
 }
 
-export const getDateDimensionColumnPreview = async (dataset: Dataset, dimension: Dimension, factTable: FactTable) => {
+async function getLookupPreviewWithExtractor(
+    dataset: Dataset,
+    dimension: Dimension,
+    factTable: FactTable,
+    quack: Database,
+    tableName: string
+) {
+    if (!dimension.lookupTable) {
+        throw new Error(`Lookup table does does not exist on dimension ${dimension.id}`);
+    }
+    logger.debug(`Generating lookup table preview for dimension ${dimension.id}`);
+    const lookupTmpFile = await getFileImportAndSaveToDisk(dataset, dimension.lookupTable);
+    const lookupTableName = `lookup_table`;
+    await loadFileIntoDatabase(quack, dimension.lookupTable, lookupTmpFile, lookupTableName);
+    const sortColumn = (dimension.extractor as LookupTableExtractor).sortColumn || dimension.joinColumn;
+    const query = `SELECT * FROM ${lookupTableName} ORDER BY ${sortColumn} LIMIT ${sampleSize};`;
+    logger.debug(`Querying the cube to get the preview using query ${query}`);
+    const dimensionTable = await quack.all(query);
+    const tableHeaders = Object.keys(dimensionTable[0]);
+    const dataArray = dimensionTable.map((row) => Object.values(row));
+    const currentDataset = await DatasetRepository.getById(dataset.id);
+    const currentImport = await FactTable.findOneByOrFail({ id: factTable.id });
+    const headers: CSVHeader[] = [];
+    for (let i = 0; i < tableHeaders.length; i++) {
+        headers.push({
+            index: i,
+            name: tableHeaders[i],
+            source_type: FactTableColumnType.Unknown
+        });
+    }
+    return {
+        dataset: DatasetDTO.fromDataset(currentDataset),
+        fact_table: FactTableDTO.fromFactTable(currentImport),
+        current_page: 1,
+        page_info: {
+            total_records: dimensionTable.length,
+            start_record: 1,
+            end_record: dimensionTable.length < sampleSize ? dimensionTable.length : sampleSize
+        },
+        page_size: dimensionTable.length < sampleSize ? dimensionTable.length : sampleSize,
+        total_pages: 1,
+        headers,
+        data: dataArray
+    };
+}
+
+export const getDimensionPreview = async (dataset: Dataset, dimension: Dimension, factTable: FactTable) => {
+    logger.debug(`Getting dimension preview for ${dimension.id}`);
     const tableName = 'fact_table';
     const quack = await Database.create(':memory:');
     const tempFile = tmp.fileSync({ postfix: `.${factTable.fileType}` });
@@ -601,26 +647,36 @@ export const getDateDimensionColumnPreview = async (dataset: Dataset, dimension:
     let viewDto: ViewDTO;
     try {
         if (dimension.extractor) {
-            logger.debug('Using extractor');
-            viewDto = await getDatePreviewWithExtractor(
-                dataset,
-                dimension.extractor,
-                dimension.factTableColumn,
-                factTable,
-                quack,
-                tableName
-            );
+            switch (dimension.type) {
+                case DimensionType.TimePoint:
+                case DimensionType.TimePeriod:
+                    logger.debug('Previewing a date type dimension');
+                    viewDto = await getDatePreviewWithExtractor(
+                        dataset,
+                        dimension.extractor,
+                        dimension.factTableColumn,
+                        factTable,
+                        quack,
+                        tableName
+                    );
+                    break;
+                case DimensionType.LookupTable:
+                    logger.debug('Previewing a lookup table');
+                    viewDto = await getLookupPreviewWithExtractor(dataset, dimension, factTable, quack, tableName);
+                    break;
+                default:
+                    logger.debug(`Previewing a dimension of an unknown type.  Type supplied is ${dimension.type}`);
+                    viewDto = await getPreviewWithoutExtractor(dataset, dimension, factTable, quack, tableName);
+            }
         } else {
             logger.debug('Straight column preview');
-            viewDto = await getDatePreviewWithoutExtractor(dataset, dimension, factTable, quack, tableName);
+            viewDto = await getPreviewWithoutExtractor(dataset, dimension, factTable, quack, tableName);
         }
         await quack.close();
         tempFile.removeCallback();
         return viewDto;
     } catch (error) {
-        logger.error(
-            `Something went wrong trying to create the date reference table with the following error: ${error}`
-        );
+        logger.error(`Something went wrong trying to create dimension preview with the following error: ${error}`);
         await quack.close();
         tempFile.removeCallback();
         throw error;

--- a/src/controllers/lookup-table-handler.ts
+++ b/src/controllers/lookup-table-handler.ts
@@ -1,0 +1,285 @@
+import fs from 'fs';
+
+import { Database } from 'duckdb-async';
+import tmp from 'tmp';
+import { t } from 'i18next';
+
+import { LookupTable } from '../entities/dataset/lookup-table';
+import { FactTable } from '../entities/dataset/fact-table';
+import { Dimension } from '../entities/dataset/dimension';
+import { logger } from '../utils/logger';
+import { Dataset } from '../entities/dataset/dataset';
+import { Locale } from '../enums/locale';
+import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { DimensionType } from '../enums/dimension-type';
+import { DatasetRepository } from '../repositories/dataset';
+import { FactTableColumnType } from '../enums/fact-table-column-type';
+import { DatasetDTO } from '../dtos/dataset-dto';
+import { FactTableDTO } from '../dtos/fact-table-dto';
+import { DataLakeService } from '../services/datalake';
+
+// eslint-disable-next-line import/no-cycle
+import { getFileImportAndSaveToDisk, loadFileIntoDatabase } from './cube-handler';
+
+interface ColumnDescriptor {
+    lang: string;
+    name: string;
+}
+export interface LookupTableExtractor {
+    sortColumn: string | undefined;
+    descriptionColumns: ColumnDescriptor[];
+    notesColumns: ColumnDescriptor[];
+}
+
+function convertFactTableToLookupTable(factTable: FactTable, dimension: Dimension) {
+    const lookupTable = new LookupTable();
+    lookupTable.id = factTable.id;
+    lookupTable.fileType = factTable.fileType;
+    lookupTable.filename = factTable.filename;
+    lookupTable.mimeType = factTable.mimeType;
+    lookupTable.hash = factTable.hash;
+    lookupTable.delimiter = factTable.delimiter;
+    lookupTable.linebreak = factTable.linebreak;
+    lookupTable.quote = factTable.quote;
+    lookupTable.dimension = dimension;
+    return lookupTable;
+}
+
+export const validateLookupTable = async (
+    protoLookupTable: FactTable,
+    factTable: FactTable,
+    dataset: Dataset,
+    dimension: Dimension,
+    buffer: Buffer,
+    joinColumn?: string
+): Promise<ViewDTO | ViewErrDTO> => {
+    const lookupTable = convertFactTableToLookupTable(protoLookupTable, dimension);
+    const factTableName = 'fact_table';
+    const lookupTableName = 'preview_lookup';
+    const quack = await Database.create(':memory:');
+    const lookupTableTmpFile = tmp.fileSync({ postfix: `.${lookupTable.fileType}` });
+    try {
+        fs.writeFileSync(lookupTableTmpFile.name, buffer);
+        const factTableTmpFile = await getFileImportAndSaveToDisk(dataset, factTable);
+        await loadFileIntoDatabase(quack, factTable, factTableTmpFile, factTableName);
+        await loadFileIntoDatabase(quack, lookupTable, lookupTableTmpFile, lookupTableName);
+        lookupTableTmpFile.removeCallback();
+        factTableTmpFile.removeCallback();
+    } catch (err) {
+        logger.error(`Something went wrong trying to load data in to DuckDB with the following error: ${err}`);
+        throw err;
+    }
+
+    let confirmedJoinColumn: string;
+    if (joinColumn) {
+        confirmedJoinColumn = joinColumn;
+    } else {
+        const possibleJoinColumns = protoLookupTable.factTableInfo.filter((info) => {
+            if (info.columnName.toLowerCase().startsWith('description')) return false;
+            if (info.columnName.toLowerCase().startsWith('sort')) return false;
+            if (info.columnName.toLowerCase().startsWith('note')) return false;
+            return true;
+        });
+        if (possibleJoinColumns.length > 1) {
+            throw new Error('There are to many possible join columns.  Ask user for more information');
+        }
+        if (possibleJoinColumns.length === 0) {
+            throw new Error('Could not find a column to join against the fact table.');
+        }
+        confirmedJoinColumn = possibleJoinColumns[0].columnName;
+    }
+
+    try {
+        const nonMatchedRows = await quack.all(
+            `SELECT line_number, fact_table_column, ${lookupTableName}.${confirmedJoinColumn} as lookup_table_column FROM (SELECT row_number() OVER () as line_number, "${dimension.factTableColumn}" as fact_table_column FROM ${factTableName}) as fact_table LEFT JOIN ${lookupTableName} ON CAST(fact_table.fact_table_column AS VARCHAR)=CAST(${lookupTableName}."${confirmedJoinColumn}" AS VARCHAR) where lookup_table_column IS NULL;`
+        );
+        const rows = await quack.all(`SELECT COUNT(*) as total_rows FROM ${factTableName}`);
+        if (nonMatchedRows.length === rows[0].total_rows) {
+            logger.error(`The user supplied an incorrect lookup table and none of the rows matched`);
+            const nonMatchedValues = await quack.all(
+                `SELECT DISTINCT ${dimension.factTableColumn} FROM ${factTableName};`
+            );
+            return {
+                status: 400,
+                dataset_id: dataset.id,
+                errors: [
+                    {
+                        field: 'patch',
+                        tag: { name: 'errors.dimensionValidation.invalid_lookup_table', params: {} },
+                        message: [
+                            {
+                                lang: Locale.English,
+                                message: t('errors.dimensionValidation.invalid_lookup_table', {
+                                    lng: Locale.English
+                                })
+                            }
+                        ]
+                    }
+                ],
+                extension: {
+                    totalNonMatching: rows[0].total_rows,
+                    nonMatchingValues: nonMatchedValues.map((row) => Object.values(row)[0])
+                }
+            };
+        }
+        if (nonMatchedRows.length > 0) {
+            const nonMatchedValues = await quack.all(
+                `SELECT DISTINCT fact_table_column FROM (SELECT "${dimension.factTableColumn}" as fact_table_column FROM ${factTableName}) as fact_table LEFT JOIN ${lookupTableName} ON CAST(fact_table.fact_table_column AS VARCHAR)=CAST(${lookupTableName}."${confirmedJoinColumn}" AS VARCHAR) where lookup_table_column IS NULL;`
+            );
+            logger.error(
+                `The user supplied an incorrect or incomplete lookup table and ${nonMatchedRows.length} rows didn't match`
+            );
+            return {
+                status: 400,
+                dataset_id: dataset.id,
+                errors: [
+                    {
+                        field: 'patch',
+                        tag: { name: 'errors.dimensionValidation.invalid_lookup_table', params: {} },
+                        message: [
+                            {
+                                lang: Locale.English,
+                                message: t('errors.dimensionValidation.invalid_lookup_table', {
+                                    lng: Locale.English
+                                })
+                            }
+                        ]
+                    }
+                ],
+                extension: {
+                    totalNonMatching: nonMatchedRows.length,
+                    nonMatchingValues: nonMatchedValues.map((row) => Object.values(row)[0])
+                }
+            };
+        }
+    } catch (error) {
+        logger.error(
+            `Something went wrong, most likely an incorrect join column name, while trying to validate the lookup table with error: ${error}`
+        );
+        const nonMatchedRows = await quack.all(`SELECT COUNT(*) AS total_rows FROM ${factTableName};`);
+        const nonMatchedValues = await quack.all(`SELECT DISTINCT ${dimension.factTableColumn} FROM ${factTableName};`);
+        return {
+            status: 400,
+            dataset_id: dataset.id,
+            errors: [
+                {
+                    field: 'patch',
+                    tag: { name: 'errors.dimensionValidation.invalid_join_column', params: {} },
+                    message: [
+                        {
+                            lang: Locale.English,
+                            message: t('errors.dimensionValidation.invalid_join_column', {
+                                lng: Locale.English
+                            })
+                        }
+                    ]
+                }
+            ],
+            extension: {
+                totalNonMatching: nonMatchedRows[0].total_rows,
+                nonMatchingValues: nonMatchedValues.map((row) => Object.values(row)[0])
+            }
+        };
+    }
+
+    // Clean up previously uploaded dimensions
+    if (dimension.lookupTable) {
+        logger.info(`Cleaning up previous lookup table`);
+        try {
+            const dataLakeServuce = new DataLakeService();
+            await dataLakeServuce.deleteFile(dimension.lookupTable.filename, dataset.id);
+        } catch (err) {
+            logger.error(`Something went wrong trying to remove previously uploaded lookup table with error: ${err}`);
+        }
+
+        try {
+            const lookupTableId = dimension.lookupTable.id;
+            dimension.lookupTable = null;
+            dimension.extractor = null;
+            dimension.type = DimensionType.Raw;
+            dimension.joinColumn = null;
+            await dimension.save();
+            const oldLookupTable = await LookupTable.findOneBy({ id: lookupTableId });
+            await oldLookupTable?.remove();
+        } catch (err) {
+            logger.error(
+                `Something has gone wrong trying to unlike the previous lookup table from the dimension with the following error: ${err}`
+            );
+            throw err;
+        }
+    }
+
+    lookupTable.isStatsWales2Format = !protoLookupTable.factTableInfo.find((info) =>
+        info.columnName.toLowerCase().startsWith('lang')
+    );
+    const updateDimension = await Dimension.findOneByOrFail({ id: dimension.id });
+    updateDimension.type = DimensionType.LookupTable;
+    updateDimension.joinColumn = confirmedJoinColumn;
+    updateDimension.lookupTable = lookupTable;
+    const extractor: LookupTableExtractor = {
+        sortColumn: protoLookupTable.factTableInfo.find((info) => info.columnName.toLowerCase().startsWith('sort'))
+            ?.columnName,
+        descriptionColumns: protoLookupTable.factTableInfo
+            .filter((info) => info.columnName.toLowerCase().startsWith('description'))
+            .map((info) => {
+                return {
+                    name: info.columnName,
+                    lang: info.columnName.split('_')[1]
+                };
+            }),
+        notesColumns: protoLookupTable.factTableInfo
+            .filter((info) => info.columnName.toLowerCase().startsWith('note'))
+            .map((info) => {
+                return {
+                    name: info.columnName,
+                    lang: info.columnName.split('_')[1]
+                };
+            })
+    };
+    updateDimension.extractor = extractor;
+    logger.debug('Saving the lookup table');
+    await lookupTable.save();
+    logger.debug('Saving the dimension');
+    updateDimension.lookupTable = lookupTable;
+    updateDimension.type = DimensionType.LookupTable;
+    await updateDimension.save();
+    try {
+        const dimensionTable = await quack.all(`SELECT * FROM ${lookupTableName};`);
+        await quack.close();
+        const tableHeaders = Object.keys(dimensionTable[0]);
+        const dataArray = dimensionTable.map((row) => Object.values(row));
+        const currentDataset = await DatasetRepository.getById(dataset.id);
+        const currentImport = await FactTable.findOneByOrFail({ id: factTable.id });
+        const headers: CSVHeader[] = [];
+        for (let i = 0; i < tableHeaders.length; i++) {
+            let sourceType: FactTableColumnType;
+            if (tableHeaders[i] === 'int_line_number') sourceType = FactTableColumnType.LineNumber;
+            else
+                sourceType =
+                    factTable.factTableInfo.find((info) => info.columnName === tableHeaders[i])?.columnType ??
+                    FactTableColumnType.Unknown;
+            headers.push({
+                index: i - 1,
+                name: tableHeaders[i],
+                source_type: sourceType
+            });
+        }
+        return {
+            dataset: DatasetDTO.fromDataset(currentDataset),
+            fact_table: FactTableDTO.fromFactTable(currentImport),
+            current_page: 1,
+            page_info: {
+                total_records: 1,
+                start_record: 1,
+                end_record: 10
+            },
+            page_size: 10,
+            total_pages: 1,
+            headers,
+            data: dataArray
+        };
+    } catch (error) {
+        logger.error(`Something went wrong trying to generate the preview of the lookup table with error: ${error}`);
+        throw error;
+    }
+};

--- a/src/dtos/dimension-dto.ts
+++ b/src/dtos/dimension-dto.ts
@@ -20,11 +20,11 @@ export class DimensionDTO {
         const dimDto = new DimensionDTO();
         dimDto.id = dimension.id;
         dimDto.type = dimension.type;
-        dimDto.extractor = dimension.extractor;
+        dimDto.extractor = dimension.extractor || undefined;
         dimDto.lookupTable = dimension?.lookupTable
             ? LookupTableDTO.fromLookupTable(dimension?.lookupTable)
             : undefined;
-        dimDto.joinColumn = dimension.joinColumn;
+        dimDto.joinColumn = dimension.joinColumn || undefined;
         dimDto.factTableColumn = dimension.factTableColumn;
         dimDto.isSliceDimension = dimension.isSliceDimension;
 

--- a/src/dtos/view-dto.ts
+++ b/src/dtos/view-dto.ts
@@ -29,7 +29,7 @@ export interface ViewErrDTO {
 
 export interface ViewDTO {
     dataset: DatasetDTO;
-    fact_table: FactTableDTO;
+    fact_table?: FactTableDTO;
     current_page: number;
     page_info: PageInfo;
     page_size: number;

--- a/src/entities/dataset/dimension.ts
+++ b/src/entities/dataset/dimension.ts
@@ -28,10 +28,10 @@ export class Dimension extends BaseEntity {
     type: DimensionType;
 
     @Column({ type: 'jsonb', nullable: true })
-    extractor: object;
+    extractor: object | null;
 
     @Column({ name: 'join_column', type: 'varchar', nullable: true })
-    joinColumn: string; // <-- Tells you have to join the dimension to the fact_table
+    joinColumn: string | null; // <-- Tells you have to join the dimension to the fact_table
 
     @Column({ name: 'fact_table_column', type: 'varchar', nullable: false })
     factTableColumn: string; // <-- Tells you which column in the fact table you're joining to
@@ -44,7 +44,7 @@ export class Dimension extends BaseEntity {
         name: 'lookup_table_id',
         foreignKeyConstraintName: 'FK_dimension_lookup_table_id_lookup_table_dimension_id'
     })
-    lookupTable: LookupTable;
+    lookupTable: LookupTable | null;
 
     @OneToMany(() => DimensionInfo, (dimensionInfo) => dimensionInfo.dimension, { cascade: true })
     dimensionInfo: DimensionInfo[];

--- a/src/entities/dataset/fact-table-info.ts
+++ b/src/entities/dataset/fact-table-info.ts
@@ -26,6 +26,9 @@ export class FactTableInfo extends BaseEntity {
     @Column({ name: 'column_type', type: 'enum', enum: Object.values(FactTableColumnType), nullable: false })
     columnType: FactTableColumnType;
 
+    @Column({ name: 'column_datatype', type: 'varchar', nullable: false })
+    columnDatatype: string;
+
     @ManyToOne(() => FactTable, (factTable) => factTable.factTableInfo, {
         onDelete: 'CASCADE',
         orphanedRowAction: 'delete'

--- a/src/entities/dataset/fact-table.ts
+++ b/src/entities/dataset/fact-table.ts
@@ -10,12 +10,14 @@ import {
 } from 'typeorm';
 
 import { FileType } from '../../enums/file-type';
+import { FactTableAction } from '../../enums/fact-table-action';
 
 import { Revision } from './revision';
 import { FactTableInfo } from './fact-table-info';
+import { FileImport } from './file-import';
 
 @Entity({ name: 'fact_table', orderBy: { uploadedAt: 'ASC' } })
-export class FactTable extends BaseEntity {
+export class FactTable extends BaseEntity implements FileImport {
     @PrimaryGeneratedColumn('uuid', { primaryKeyConstraintName: 'PK_fact_table_id' })
     id: string;
 
@@ -52,6 +54,9 @@ export class FactTable extends BaseEntity {
 
     @Column({ name: 'linebreak', type: 'varchar', nullable: true })
     linebreak: string;
+
+    @Column({ type: 'enum', enum: Object.values(FactTableAction), nullable: false })
+    action: FactTableAction;
 
     @OneToMany(() => FactTableInfo, (factTableInfo) => factTableInfo.factTable, { cascade: true })
     factTableInfo: FactTableInfo[];

--- a/src/entities/dataset/file-import.ts
+++ b/src/entities/dataset/file-import.ts
@@ -1,0 +1,13 @@
+import { FileType } from '../../enums/file-type';
+
+export interface FileImport {
+    id: string;
+    mimeType: string;
+    fileType: FileType;
+    filename: string;
+    hash: string;
+    uploadedAt: Date;
+    delimiter: string;
+    quote: string;
+    linebreak: string;
+}

--- a/src/entities/dataset/lookup-table.ts
+++ b/src/entities/dataset/lookup-table.ts
@@ -4,9 +4,10 @@ import { FileType } from '../../enums/file-type';
 
 import { Dimension } from './dimension';
 import { Measure } from './measure';
+import { FileImport } from './file-import';
 
 @Entity({ name: 'lookup_table', orderBy: { uploadedAt: 'ASC' } })
-export class LookupTable extends BaseEntity {
+export class LookupTable extends BaseEntity implements FileImport {
     @PrimaryGeneratedColumn('uuid', { primaryKeyConstraintName: 'PK_lookup_table_id' })
     id: string;
 
@@ -14,12 +15,14 @@ export class LookupTable extends BaseEntity {
         onDelete: 'CASCADE',
         orphanedRowAction: 'delete'
     })
+    @JoinColumn({ name: 'dimension_id' })
     dimension: Dimension;
 
     @OneToOne(() => Measure, {
         onDelete: 'CASCADE',
         orphanedRowAction: 'delete'
     })
+    @JoinColumn({ name: 'measure_id' })
     measure: Measure;
 
     @Column({ name: 'mime_type', type: 'varchar', length: 255 })
@@ -45,4 +48,7 @@ export class LookupTable extends BaseEntity {
 
     @Column({ name: 'linebreak', type: 'varchar' })
     linebreak: string;
+
+    @Column({ name: 'is_statswales2_format', type: 'boolean' })
+    isStatsWales2Format: boolean;
 }

--- a/src/entities/dataset/measure-info.ts
+++ b/src/entities/dataset/measure-info.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryColumn, Column, BaseEntity, ManyToOne, JoinColumn } from 'typeorm';
 
 import { DisplayType } from '../../enums/display-type';
+import { DataType } from '../../enums/data-types';
 
 import { Measure } from './measure';
 
@@ -12,6 +13,9 @@ export class MeasureInfo extends BaseEntity {
         primaryKeyConstraintName: 'PK_measure_info_measure_id_language'
     })
     id: string;
+
+    @Column({ name: 'sort_order', type: 'int', nullable: true })
+    sortOrder: number;
 
     @PrimaryColumn({
         name: 'language',
@@ -37,6 +41,7 @@ export class MeasureInfo extends BaseEntity {
     @JoinColumn({ name: 'measure_id', foreignKeyConstraintName: 'FK_measure_info_measure_id' })
     measure: Measure;
 
+    @Column({ name: 'data_type', type: 'enum', enum: Object.values(DataType), nullable: false })
     @Column({ name: 'display_type', type: 'enum', enum: Object.values(DisplayType), nullable: false })
     displayType: DisplayType;
 }

--- a/src/enums/data-types.ts
+++ b/src/enums/data-types.ts
@@ -1,0 +1,7 @@
+export enum DataType {
+    Numerical,
+    Percentage,
+    Rank,
+    Decile,
+    Quintile
+}

--- a/src/enums/data-value-format.ts
+++ b/src/enums/data-value-format.ts
@@ -1,0 +1,12 @@
+export enum DataValueFormat {
+    Decimal = 'Decimal',
+    Float = 'Float ',
+    Integer = 'Integer',
+    Long = 'Long',
+    Percentage = 'Percentage',
+    String = 'String',
+    Boolean = 'Boolean',
+    Date = 'Date',
+    DateTime = 'DateTime',
+    Time = 'Time'
+}

--- a/src/enums/duckdb-outputs.ts
+++ b/src/enums/duckdb-outputs.ts
@@ -1,0 +1,9 @@
+export enum DuckdbOutputType {
+    Csv = 'csv',
+    DuckDb = 'duckdb',
+    Json = 'json',
+    Excel = 'xlsx',
+    Odf = 'odf',
+    Sqlite = 'sqlite',
+    Parquet = 'parquet'
+}

--- a/src/enums/fact-table-action.ts
+++ b/src/enums/fact-table-action.ts
@@ -1,0 +1,6 @@
+export enum FactTableAction {
+    Add = 'add',
+    ReplaceAll = 'replace_all',
+    Revise = 'revise',
+    AddRevise = 'add_revise'
+}

--- a/src/migrations/1734375703542-initial-schema.ts
+++ b/src/migrations/1734375703542-initial-schema.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class InitialSchema1733849625476 implements MigrationInterface {
-    name = 'InitialSchema1733849625476';
+export class InitialSchema1734375703542 implements MigrationInterface {
+    name = 'InitialSchema1734375703542';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
@@ -28,6 +28,48 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             CREATE UNIQUE INDEX "UX_user_provider_provider_user_id" ON "user" ("provider", "provider_user_id")
         `);
         await queryRunner.query(`
+            CREATE TABLE "organisation_info" (
+                "organisation_id" uuid NOT NULL,
+                "language" character varying(5) NOT NULL,
+                "name" text NOT NULL,
+                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_organisation_info_organisation_id_language" PRIMARY KEY ("organisation_id", "language")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "organisation" (
+                "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_organisation_id" PRIMARY KEY ("id")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "category" (
+                "category" text NOT NULL,
+                CONSTRAINT "PK_dab3b9cd30b5940f3a808316991" PRIMARY KEY ("category")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "category_key" (
+                "category_key" text NOT NULL,
+                "category" text NOT NULL,
+                CONSTRAINT "PK_b305284188b72bbeb54babee1c8" PRIMARY KEY ("category_key")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "reference_data" (
+                "item_id" text NOT NULL,
+                "version_no" integer NOT NULL,
+                "category_key" text NOT NULL,
+                "sort_order" integer,
+                "validity_start" date NOT NULL,
+                "validity_end" date,
+                CONSTRAINT "PK_1c127907e0b334cd1cc15afc1bb" PRIMARY KEY ("item_id", "version_no", "category_key")
+            )
+        `);
+        await queryRunner.query(`
             CREATE TYPE "public"."fact_table_info_column_type_enum" AS ENUM(
                 'data_values',
                 'note_codes',
@@ -45,6 +87,7 @@ export class InitialSchema1733849625476 implements MigrationInterface {
                 "column_name" character varying NOT NULL,
                 "column_index" integer NOT NULL,
                 "column_type" "public"."fact_table_info_column_type_enum" NOT NULL,
+                "column_datatype" character varying NOT NULL,
                 CONSTRAINT "PK_fact_table_info_id_language" PRIMARY KEY ("fact_table_id", "column_name")
             )
         `);
@@ -60,6 +103,9 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             )
         `);
         await queryRunner.query(`
+            CREATE TYPE "public"."fact_table_action_enum" AS ENUM('add', 'replace_all', 'revise', 'add_revise')
+        `);
+        await queryRunner.query(`
             CREATE TABLE "fact_table" (
                 "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
                 "mime_type" character varying(255) NOT NULL,
@@ -71,6 +117,7 @@ export class InitialSchema1733849625476 implements MigrationInterface {
                 "delimiter" character,
                 "quote" character,
                 "linebreak" character varying,
+                "action" "public"."fact_table_action_enum" NOT NULL,
                 "revision_id" uuid,
                 CONSTRAINT "PK_fact_table_id" PRIMARY KEY ("id")
             )
@@ -146,6 +193,7 @@ export class InitialSchema1733849625476 implements MigrationInterface {
         await queryRunner.query(`
             CREATE TABLE "measure_info" (
                 "measure_id" uuid NOT NULL,
+                "sort_order" integer,
                 "language" character varying(5) NOT NULL,
                 "description" character varying NOT NULL,
                 "reference" character varying NOT NULL,
@@ -188,6 +236,11 @@ export class InitialSchema1733849625476 implements MigrationInterface {
                 "delimiter" character NOT NULL,
                 "quote" character NOT NULL,
                 "linebreak" character varying NOT NULL,
+                "is_statswales2_format" boolean NOT NULL,
+                "dimension_id" uuid,
+                "measure_id" uuid,
+                CONSTRAINT "REL_d897df215d38c8de48699f0bb1" UNIQUE ("dimension_id"),
+                CONSTRAINT "REL_47ad3331d1237986c7a106f6ed" UNIQUE ("measure_id"),
                 CONSTRAINT "PK_lookup_table_id" PRIMARY KEY ("id")
             )
         `);
@@ -277,21 +330,13 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             )
         `);
         await queryRunner.query(`
-            CREATE TABLE "organisation_info" (
-                "organisation_id" uuid NOT NULL,
-                "language" character varying(5) NOT NULL,
-                "name" text NOT NULL,
-                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                CONSTRAINT "PK_organisation_info_organisation_id_language" PRIMARY KEY ("organisation_id", "language")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "organisation" (
+            CREATE TABLE "team" (
                 "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "prefix" text NOT NULL,
                 "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
                 "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                CONSTRAINT "PK_organisation_id" PRIMARY KEY ("id")
+                "organisation_id" uuid,
+                CONSTRAINT "PK_team_id" PRIMARY KEY ("id")
             )
         `);
         await queryRunner.query(`
@@ -303,60 +348,6 @@ export class InitialSchema1733849625476 implements MigrationInterface {
                 "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
                 "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
                 CONSTRAINT "PK_team_info_team_id_language" PRIMARY KEY ("team_id", "language")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "team" (
-                "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
-                "prefix" text NOT NULL,
-                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                "organisation_id" uuid,
-                CONSTRAINT "PK_team_id" PRIMARY KEY ("id")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "category" (
-                "category" text NOT NULL,
-                CONSTRAINT "PK_dab3b9cd30b5940f3a808316991" PRIMARY KEY ("category")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "category_key" (
-                "category_key" text NOT NULL,
-                "category" text NOT NULL,
-                CONSTRAINT "PK_b305284188b72bbeb54babee1c8" PRIMARY KEY ("category_key")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "reference_data" (
-                "item_id" text NOT NULL,
-                "version_no" integer NOT NULL,
-                "category_key" text NOT NULL,
-                "sort_order" integer,
-                "validity_start" date NOT NULL,
-                "validity_end" date,
-                CONSTRAINT "PK_1c127907e0b334cd1cc15afc1bb" PRIMARY KEY ("item_id", "version_no", "category_key")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "category_key_info" (
-                "category_key" text NOT NULL,
-                "lang" text NOT NULL,
-                "description" text NOT NULL,
-                "notes" text,
-                CONSTRAINT "PK_845dcc2857b4a2d31252e03f8d5" PRIMARY KEY ("category_key", "lang")
-            )
-        `);
-        await queryRunner.query(`
-            CREATE TABLE "reference_data_info" (
-                "item_id" text NOT NULL,
-                "version_no" integer NOT NULL,
-                "category_key" text NOT NULL,
-                "lang" text NOT NULL,
-                "description" text NOT NULL,
-                "notes" text,
-                CONSTRAINT "PK_bc5f1f5cf97870b0d373f7edae7" PRIMARY KEY ("item_id", "version_no", "category_key", "lang")
             )
         `);
         await queryRunner.query(`
@@ -378,6 +369,15 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             )
         `);
         await queryRunner.query(`
+            CREATE TABLE "category_key_info" (
+                "category_key" text NOT NULL,
+                "lang" text NOT NULL,
+                "description" text NOT NULL,
+                "notes" text,
+                CONSTRAINT "PK_845dcc2857b4a2d31252e03f8d5" PRIMARY KEY ("category_key", "lang")
+            )
+        `);
+        await queryRunner.query(`
             CREATE TABLE "category_info" (
                 "category" text NOT NULL,
                 "lang" text NOT NULL,
@@ -385,6 +385,29 @@ export class InitialSchema1733849625476 implements MigrationInterface {
                 "notes" text,
                 CONSTRAINT "PK_b352b1990fc76e4cb4c7c9e0c9d" PRIMARY KEY ("category", "lang")
             )
+        `);
+        await queryRunner.query(`
+            CREATE TABLE "reference_data_info" (
+                "item_id" text NOT NULL,
+                "version_no" integer NOT NULL,
+                "category_key" text NOT NULL,
+                "lang" text NOT NULL,
+                "description" text NOT NULL,
+                "notes" text,
+                CONSTRAINT "PK_bc5f1f5cf97870b0d373f7edae7" PRIMARY KEY ("item_id", "version_no", "category_key", "lang")
+            )
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "organisation_info"
+            ADD CONSTRAINT "FK_organisation_info_organisation_id" FOREIGN KEY ("organisation_id") REFERENCES "organisation"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "category_key"
+            ADD CONSTRAINT "FK_087b36846d67092609821a62756" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "reference_data"
+            ADD CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
             ALTER TABLE "fact_table_info"
@@ -431,6 +454,14 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             ADD CONSTRAINT "FK_measure_lookup_table_id_lookup_table_measure_id" FOREIGN KEY ("lookup_table_id") REFERENCES "lookup_table"("id") ON DELETE CASCADE ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
+            ALTER TABLE "lookup_table"
+            ADD CONSTRAINT "FK_d897df215d38c8de48699f0bb1e" FOREIGN KEY ("dimension_id") REFERENCES "dimension"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "lookup_table"
+            ADD CONSTRAINT "FK_47ad3331d1237986c7a106f6ede" FOREIGN KEY ("measure_id") REFERENCES "measure"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
             ALTER TABLE "dimension"
             ADD CONSTRAINT "FK_dimension_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION
         `);
@@ -471,32 +502,12 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             ADD CONSTRAINT "FK_dataset_team_id" FOREIGN KEY ("team_id") REFERENCES "team"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
-            ALTER TABLE "organisation_info"
-            ADD CONSTRAINT "FK_organisation_info_organisation_id" FOREIGN KEY ("organisation_id") REFERENCES "organisation"("id") ON DELETE CASCADE ON UPDATE NO ACTION
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "team_info"
-            ADD CONSTRAINT "FK_team_info_team_id" FOREIGN KEY ("team_id") REFERENCES "team"("id") ON DELETE CASCADE ON UPDATE NO ACTION
-        `);
-        await queryRunner.query(`
             ALTER TABLE "team"
             ADD CONSTRAINT "FK_team_organisation_id" FOREIGN KEY ("organisation_id") REFERENCES "organisation"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
-            ALTER TABLE "category_key"
-            ADD CONSTRAINT "FK_087b36846d67092609821a62756" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "reference_data"
-            ADD CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "category_key_info"
-            ADD CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "reference_data_info"
-            ADD CONSTRAINT "FK_f671fde9c769286ba971485ba09" FOREIGN KEY ("item_id", "version_no", "category_key") REFERENCES "reference_data"("item_id", "version_no", "category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
+            ALTER TABLE "team_info"
+            ADD CONSTRAINT "FK_team_info_team_id" FOREIGN KEY ("team_id") REFERENCES "team"("id") ON DELETE CASCADE ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
             ALTER TABLE "hierarchy"
@@ -507,14 +518,28 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             ADD CONSTRAINT "FK_6ca6a866371cdd67a638df8a74c" FOREIGN KEY ("parent_id", "parent_version", "parent_category") REFERENCES "reference_data"("item_id", "version_no", "category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
         await queryRunner.query(`
+            ALTER TABLE "category_key_info"
+            ADD CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
             ALTER TABLE "category_info"
             ADD CONSTRAINT "FK_68028565126809c1e925e6f9334" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "reference_data_info"
+            ADD CONSTRAINT "FK_f671fde9c769286ba971485ba09" FOREIGN KEY ("item_id", "version_no", "category_key") REFERENCES "reference_data"("item_id", "version_no", "category_key") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
+            ALTER TABLE "reference_data_info" DROP CONSTRAINT "FK_f671fde9c769286ba971485ba09"
+        `);
+        await queryRunner.query(`
             ALTER TABLE "category_info" DROP CONSTRAINT "FK_68028565126809c1e925e6f9334"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "category_key_info" DROP CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47"
         `);
         await queryRunner.query(`
             ALTER TABLE "hierarchy" DROP CONSTRAINT "FK_6ca6a866371cdd67a638df8a74c"
@@ -523,25 +548,10 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             ALTER TABLE "hierarchy" DROP CONSTRAINT "FK_aaba494e02eaa91111d549e5763"
         `);
         await queryRunner.query(`
-            ALTER TABLE "reference_data_info" DROP CONSTRAINT "FK_f671fde9c769286ba971485ba09"
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "category_key_info" DROP CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47"
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "reference_data" DROP CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2"
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "category_key" DROP CONSTRAINT "FK_087b36846d67092609821a62756"
-        `);
-        await queryRunner.query(`
-            ALTER TABLE "team" DROP CONSTRAINT "FK_team_organisation_id"
-        `);
-        await queryRunner.query(`
             ALTER TABLE "team_info" DROP CONSTRAINT "FK_team_info_team_id"
         `);
         await queryRunner.query(`
-            ALTER TABLE "organisation_info" DROP CONSTRAINT "FK_organisation_info_organisation_id"
+            ALTER TABLE "team" DROP CONSTRAINT "FK_team_organisation_id"
         `);
         await queryRunner.query(`
             ALTER TABLE "dataset" DROP CONSTRAINT "FK_dataset_team_id"
@@ -572,6 +582,12 @@ export class InitialSchema1733849625476 implements MigrationInterface {
         `);
         await queryRunner.query(`
             ALTER TABLE "dimension" DROP CONSTRAINT "FK_dimension_dataset_id"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "lookup_table" DROP CONSTRAINT "FK_47ad3331d1237986c7a106f6ede"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "lookup_table" DROP CONSTRAINT "FK_d897df215d38c8de48699f0bb1e"
         `);
         await queryRunner.query(`
             ALTER TABLE "measure" DROP CONSTRAINT "FK_measure_lookup_table_id_lookup_table_measure_id"
@@ -607,37 +623,31 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             ALTER TABLE "fact_table_info" DROP CONSTRAINT "FK_fact_table_info_fact_table_id"
         `);
         await queryRunner.query(`
-            DROP TABLE "category_info"
+            ALTER TABLE "reference_data" DROP CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2"
         `);
         await queryRunner.query(`
-            DROP TABLE "hierarchy"
+            ALTER TABLE "category_key" DROP CONSTRAINT "FK_087b36846d67092609821a62756"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "organisation_info" DROP CONSTRAINT "FK_organisation_info_organisation_id"
         `);
         await queryRunner.query(`
             DROP TABLE "reference_data_info"
         `);
         await queryRunner.query(`
+            DROP TABLE "category_info"
+        `);
+        await queryRunner.query(`
             DROP TABLE "category_key_info"
         `);
         await queryRunner.query(`
-            DROP TABLE "reference_data"
-        `);
-        await queryRunner.query(`
-            DROP TABLE "category_key"
-        `);
-        await queryRunner.query(`
-            DROP TABLE "category"
-        `);
-        await queryRunner.query(`
-            DROP TABLE "team"
+            DROP TABLE "hierarchy"
         `);
         await queryRunner.query(`
             DROP TABLE "team_info"
         `);
         await queryRunner.query(`
-            DROP TABLE "organisation"
-        `);
-        await queryRunner.query(`
-            DROP TABLE "organisation_info"
+            DROP TABLE "team"
         `);
         await queryRunner.query(`
             DROP TABLE "dataset"
@@ -694,6 +704,9 @@ export class InitialSchema1733849625476 implements MigrationInterface {
             DROP TABLE "fact_table"
         `);
         await queryRunner.query(`
+            DROP TYPE "public"."fact_table_action_enum"
+        `);
+        await queryRunner.query(`
             DROP TYPE "public"."fact_table_filetype_enum"
         `);
         await queryRunner.query(`
@@ -701,6 +714,21 @@ export class InitialSchema1733849625476 implements MigrationInterface {
         `);
         await queryRunner.query(`
             DROP TYPE "public"."fact_table_info_column_type_enum"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "reference_data"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "category_key"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "category"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "organisation"
+        `);
+        await queryRunner.query(`
+            DROP TABLE "organisation_info"
         `);
         await queryRunner.query(`
             DROP INDEX "public"."UX_user_provider_provider_user_id"

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -18,7 +18,8 @@ const defaultRelations: FindOptionsRelations<Dataset> = {
     createdBy: true,
     datasetInfo: true,
     dimensions: {
-        dimensionInfo: true
+        dimensionInfo: true,
+        lookupTable: true
     },
     measure: {
         lookupTable: true,

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -107,5 +107,11 @@
         "upload": "upload",
         "list": "list",
         "data": "data"
+    },
+    "column_headers": {
+        "data_values": "Data Values",
+        "note_codes": "Note Codes",
+        "start_date": "Start Date",
+        "end_date": "End Date"
     }
 }

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -1,14 +1,14 @@
 import 'reflect-metadata';
-
 import { Readable } from 'node:stream';
+import fs from 'fs';
 
-// import util from 'node:util';
 import express, { NextFunction, Request, Response, Router } from 'express';
 import multer from 'multer';
 import { FieldValidationError } from 'express-validator';
 import { FindOptionsRelations } from 'typeorm';
 import { t } from 'i18next';
 import { isBefore, isValid } from 'date-fns';
+import tmp from 'tmp';
 
 import { logger } from '../utils/logger';
 import { ViewDTO, ViewErrDTO } from '../dtos/view-dto';
@@ -56,6 +56,10 @@ import { LookupTable } from '../entities/dataset/lookup-table';
 import { DimensionInfoDTO } from '../dtos/dimension-info-dto';
 import { DimensionInfo } from '../entities/dataset/dimension-info';
 import { TeamSelectionDTO } from '../dtos/team-selection-dto';
+import { validateLookupTable } from '../controllers/lookup-table-handler';
+import { FactTableAction } from '../enums/fact-table-action';
+import { createBaseCube, outputCube } from '../controllers/cube-handler';
+import { DuckdbOutputType } from '../enums/duckdb-outputs';
 
 const jsonParser = express.json();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -205,6 +209,7 @@ router.post(
                 req.file?.originalname,
                 res.locals.datasetId
             );
+            fileImport.action = FactTableAction.Add;
         } catch (err) {
             logger.error(`An error occurred trying to upload the file: ${err}`);
             next(new UnknownException('errors.upload_error'));
@@ -250,6 +255,238 @@ router.get('/:dataset_id/view', loadDataset(), async (req: Request, res: Respons
         res.status(500);
     }
     res.json(processedCSV);
+});
+
+// GET /dataset/:dataset_id/cube
+// Returns the latest revision of the dataset as a DuckDB File
+router.get('/:dataset_id/cube', loadDataset(), async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
+    const lang = req.language.split('-')[0];
+    const latestRevision = getLatestRevision(dataset);
+    if (!latestRevision) {
+        next(new UnknownException('errors.no_revision'));
+        return;
+    }
+    let cubeFile: string;
+    if (latestRevision.onlineCubeFilename) {
+        const dataLakeService = new DataLakeService();
+        const fileBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
+        cubeFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+        fs.writeFileSync(cubeFile, fileBuffer);
+    } else {
+        try {
+            cubeFile = await createBaseCube(dataset, latestRevision);
+        } catch (err) {
+            logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
+            next(new UnknownException('errors.cube_create_error'));
+            return;
+        }
+    }
+    const fileBuffer = Buffer.from(fs.readFileSync(cubeFile));
+    logger.info(`Sending original cube file (size: ${fileBuffer.length}) from: ${cubeFile}`);
+    res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/octet-stream',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-disposition': `attachment;filename=${dataset.id}.duckdb`,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Length': fileBuffer.length
+    });
+    res.end(fileBuffer);
+});
+
+// GET /dataset/:dataset_id/cube/json
+// Returns a JSON file representation of the default view of the cube
+router.get('/:dataset_id/cube/json', loadDataset(), async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
+    const lang = req.language.split('-')[0];
+    const latestRevision = getLatestRevision(dataset);
+    if (!latestRevision) {
+        next(new UnknownException('errors.no_revision'));
+        return;
+    }
+    let cubeFile: string;
+    if (latestRevision.onlineCubeFilename) {
+        const dataLakeService = new DataLakeService();
+        const fileBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
+        cubeFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+        fs.writeFileSync(cubeFile, fileBuffer);
+    } else {
+        try {
+            logger.info('Creating fresh cube file.');
+            cubeFile = await createBaseCube(dataset, latestRevision);
+        } catch (err) {
+            logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
+            next(new UnknownException('errors.cube_create_error'));
+            return;
+        }
+    }
+    const downloadFile = await outputCube(cubeFile, lang, DuckdbOutputType.Json);
+    fs.unlinkSync(cubeFile);
+    const downloadStream = fs.createReadStream(downloadFile);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    res.writeHead(200, { 'Content-Type': '\tapplication/json' });
+    downloadStream.pipe(res);
+
+    // Handle errors in the file stream
+    downloadStream.on('error', (err) => {
+        logger.error('File stream error:', err);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        fs.unlinkSync(downloadFile);
+        res.end('Server Error');
+    });
+
+    // Optionally listen for the end of the stream
+    downloadStream.on('end', () => {
+        fs.unlinkSync(downloadFile);
+        logger.debug('File stream ended');
+    });
+});
+
+// GET /dataset/:dataset_id/cube/csv
+// Returns a CSV file representation of the default view of the cube
+router.get('/:dataset_id/cube/csv', loadDataset(), async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
+    const lang = req.language.split('-')[0];
+    const latestRevision = getLatestRevision(dataset);
+    if (!latestRevision) {
+        next(new UnknownException('errors.no_revision'));
+        return;
+    }
+    let cubeFile: string;
+    if (latestRevision.onlineCubeFilename) {
+        const dataLakeService = new DataLakeService();
+        const fileBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
+        cubeFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+        fs.writeFileSync(cubeFile, fileBuffer);
+    } else {
+        try {
+            cubeFile = await createBaseCube(dataset, latestRevision);
+        } catch (err) {
+            logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
+            next(new UnknownException('errors.cube_create_error'));
+            return;
+        }
+    }
+    const downloadFile = await outputCube(cubeFile, lang, DuckdbOutputType.Csv);
+    fs.unlinkSync(cubeFile);
+    const downloadStream = fs.createReadStream(downloadFile);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    res.writeHead(200, { 'Content-Type': '\ttext/csv' });
+    downloadStream.pipe(res);
+
+    // Handle errors in the file stream
+    downloadStream.on('error', (err) => {
+        logger.error('File stream error:', err);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        fs.unlinkSync(downloadFile);
+        res.end('Server Error');
+    });
+
+    // Optionally listen for the end of the stream
+    downloadStream.on('end', () => {
+        fs.unlinkSync(downloadFile);
+        logger.debug('File stream ended');
+    });
+});
+
+// GET /dataset/:dataset_id/cube/parquet
+// Returns a CSV file representation of the default view of the cube
+router.get('/:dataset_id/cube/parquet', loadDataset(), async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
+    const lang = req.language.split('-')[0];
+    const latestRevision = getLatestRevision(dataset);
+    if (!latestRevision) {
+        next(new UnknownException('errors.no_revision'));
+        return;
+    }
+    let cubeFile: string;
+    if (latestRevision.onlineCubeFilename) {
+        const dataLakeService = new DataLakeService();
+        const fileBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
+        cubeFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+        fs.writeFileSync(cubeFile, fileBuffer);
+    } else {
+        try {
+            cubeFile = await createBaseCube(dataset, latestRevision);
+        } catch (err) {
+            logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
+            next(new UnknownException('errors.cube_create_error'));
+            return;
+        }
+    }
+    const downloadFile = await outputCube(cubeFile, lang, DuckdbOutputType.Parquet);
+    fs.unlinkSync(cubeFile);
+    const downloadStream = fs.createReadStream(downloadFile);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    res.writeHead(200, { 'Content-Type': '\tapplication/vnd.apache.parquet' });
+    downloadStream.pipe(res);
+
+    // Handle errors in the file stream
+    downloadStream.on('error', (err) => {
+        logger.error('File stream error:', err);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        fs.unlinkSync(downloadFile);
+        res.end('Server Error');
+    });
+
+    // Optionally listen for the end of the stream
+    downloadStream.on('end', () => {
+        fs.unlinkSync(downloadFile);
+        logger.debug('File stream ended');
+    });
+});
+
+// GET /dataset/:dataset_id/cube/excel
+// Returns a CSV file representation of the default view of the cube
+router.get('/:dataset_id/cube/excel', loadDataset(), async (req: Request, res: Response, next: NextFunction) => {
+    const dataset = res.locals.dataset;
+    const lang = req.language.split('-')[0];
+    const latestRevision = getLatestRevision(dataset);
+    if (!latestRevision) {
+        next(new UnknownException('errors.no_revision'));
+        return;
+    }
+    let cubeFile: string;
+    if (latestRevision.onlineCubeFilename) {
+        const dataLakeService = new DataLakeService();
+        const fileBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
+        cubeFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+        fs.writeFileSync(cubeFile, fileBuffer);
+    } else {
+        try {
+            cubeFile = await createBaseCube(dataset, latestRevision);
+        } catch (err) {
+            logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
+            next(new UnknownException('errors.cube_create_error'));
+            return;
+        }
+    }
+    const downloadFile = await outputCube(cubeFile, lang, DuckdbOutputType.Excel);
+    logger.info(`Cube file located at: ${cubeFile}`);
+    // fs.unlinkSync(cubeFile);
+    const downloadStream = fs.createReadStream(downloadFile);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    res.writeHead(200, { 'Content-Type': '\tapplication/vnd.ms-excel' });
+    downloadStream.pipe(res);
+
+    // Handle errors in the file stream
+    downloadStream.on('error', (err) => {
+        logger.error('File stream error:', err);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        fs.unlinkSync(downloadFile);
+        res.end('Server Error');
+    });
+
+    // Optionally listen for the end of the stream
+    downloadStream.on('end', () => {
+        fs.unlinkSync(downloadFile);
+        logger.debug('File stream ended');
+    });
 });
 
 // PATCH /dataset/:dataset_id/info
@@ -519,6 +756,75 @@ router.get(
             );
             res.status(500);
             res.json({ message: 'Something went wrong trying to generate a preview of the dimension' });
+        }
+    }
+);
+
+// POST /:dataset_id/dimension/by-id/:dimension_id/lookup
+// Attaches a lookup table to do a dimension and validates
+// the lookup table.
+router.post(
+    '/:dataset_id/dimension/by-id/:dimension_id/lookup',
+    upload.single('csv'),
+    loadDataset(),
+    async (req: Request, res: Response, next: NextFunction) => {
+        if (!req.file) {
+            next(new BadRequestException('errors.upload.no_csv'));
+            return;
+        }
+        const dataset = res.locals.dataset;
+        if (!dataset) {
+            next(new NotFoundException('errors.dataset_id_invalid'));
+            return;
+        }
+        const dimension: Dimension = dataset.dimensions.find((dim: Dimension) => dim.id === req.params.dimension_id);
+        if (!dimension) {
+            next(new NotFoundException('errors.dimension_id_invalid'));
+            return;
+        }
+        const factTable = getLatestRevision(dataset)?.factTables[0];
+        if (!factTable) {
+            next(new NotFoundException('errors.fact_table_invalid'));
+            return;
+        }
+        let fileImport: FactTable;
+        try {
+            fileImport = await uploadCSV(
+                req.file.buffer,
+                req.file?.mimetype,
+                req.file?.originalname,
+                res.locals.datasetId
+            );
+        } catch (err) {
+            logger.error(`An error occurred trying to upload the file: ${err}`);
+            next(new UnknownException('errors.upload_error'));
+            return;
+        }
+
+        if (req.body.joinColumn) {
+            dimension.joinColumn = req.body.joinColumn;
+        }
+
+        try {
+            const result = await validateLookupTable(
+                fileImport,
+                factTable,
+                dataset,
+                dimension,
+                req.file.buffer,
+                req.body.join_column
+            );
+            if ((result as ViewErrDTO).status) {
+                const error = result as ViewErrDTO;
+                res.status(error.status);
+                res.json(result);
+                return;
+            }
+            res.status(200);
+            res.json(result);
+        } catch (err) {
+            logger.error(`An error occurred trying to handle the lookup table: ${err}`);
+            next(new UnknownException('errors.upload_error'));
         }
     }
 );

--- a/test/helpers/test-helper.ts
+++ b/test/helpers/test-helper.ts
@@ -5,15 +5,14 @@ import { createHash } from 'crypto';
 import { Dataset } from '../../src/entities/dataset/dataset';
 import { DatasetInfo } from '../../src/entities/dataset/dataset-info';
 import { Revision } from '../../src/entities/dataset/revision';
-import { FactTableColumnType } from '../../src/enums/fact-table-column-type';
 import { DimensionType } from '../../src/enums/dimension-type';
 import { Dimension } from '../../src/entities/dataset/dimension';
 import { DimensionInfo } from '../../src/entities/dataset/dimension-info';
 import { User } from '../../src/entities/user/user';
 import { FactTable } from '../../src/entities/dataset/fact-table';
 import { FileType } from '../../src/enums/file-type';
-import { FactTableInfo } from '../../src/entities/dataset/fact-table-info';
 import { extractTableInformation } from '../../src/controllers/csv-processor';
+import { FactTableAction } from '../../src/enums/fact-table-action';
 
 export async function createSmallDataset(
     datasetId: string,
@@ -57,6 +56,7 @@ export async function createSmallDataset(
     factTable.originalFilename = path.basename(testFile);
     const testFileBuffer = fs.readFileSync(testFile);
     factTable.hash = createHash('sha256').update(testFileBuffer).digest('hex');
+    factTable.action = FactTableAction.Add;
     factTable.fileType = fileType;
     switch (fileType) {
         case FileType.Csv:


### PR DESCRIPTION
This sizable PR add lookup table handling and cube creation to the backend.  Cube creation is in its intfancy but this allows you to download the cube and the cubes default view in JSON, CSV, Excel and Parquet file formats.