### PR TITLE
GET Dataset response now skips join table for Topics

### DIFF
--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -10,9 +10,9 @@ import { DimensionDTO } from './dimension-dto';
 import { RevisionDTO } from './revision-dto';
 import { DatasetInfoDTO } from './dataset-info-dto';
 import { DatasetProviderDTO } from './dataset-provider-dto';
-import { DatasetTopicDTO } from './dataset-topic-dto';
 import { MeasureDTO } from './measure-dto';
 import { TeamDTO } from './team-dto';
+import { TopicDTO } from './topic-dto';
 
 export class DatasetDTO {
     id: string;
@@ -25,7 +25,7 @@ export class DatasetDTO {
     measure?: MeasureDTO;
     datasetInfo: DatasetInfoDTO[];
     providers: DatasetProviderDTO[];
-    topics: DatasetTopicDTO[];
+    topics: TopicDTO[];
     team?: TeamDTO[];
     start_date?: Date | null;
     end_date?: Date | null;
@@ -46,9 +46,7 @@ export class DatasetDTO {
             DatasetProviderDTO.fromDatasetProvider(datasetProvider)
         );
 
-        dto.topics = dataset.datasetTopics?.map((datasetTopic: DatasetTopic) =>
-            DatasetTopicDTO.fromDatasetTopic(datasetTopic)
-        );
+        dto.topics = dataset.datasetTopics?.map((datasetTopic: DatasetTopic) => TopicDTO.fromTopic(datasetTopic.topic));
 
         if (dataset.team) {
             dto.team = SUPPORTED_LOCALES.map((locale) => {

--- a/src/dtos/dataset-topic-dto.ts
+++ b/src/dtos/dataset-topic-dto.ts
@@ -1,15 +1,20 @@
 import { DatasetTopic } from '../entities/dataset/dataset-topic';
 
+import { TopicDTO } from './topic-dto';
+
 export class DatasetTopicDTO {
     id: string;
     dataset_id: string;
     topic_id: number;
+    topic: TopicDTO;
 
     static fromDatasetTopic(datasetTopic: DatasetTopic): DatasetTopicDTO {
         const dto = new DatasetTopicDTO();
         dto.id = datasetTopic.id;
         dto.dataset_id = datasetTopic.datasetId;
         dto.topic_id = datasetTopic.topicId;
+        dto.topic = TopicDTO.fromTopic(datasetTopic.topic);
+
         return dto;
     }
 }

--- a/src/dtos/topic-dto.ts
+++ b/src/dtos/topic-dto.ts
@@ -5,12 +5,20 @@ export class TopicDTO {
     id: number;
     path: string;
     name: string;
+    name_en: string;
+    name_cy: string;
 
-    static fromTopic(topic: Topic, lang: Locale): TopicDTO {
+    static fromTopic(topic: Topic, lang?: Locale): TopicDTO {
         const dto = new TopicDTO();
         dto.id = topic.id;
         dto.path = topic.path;
-        dto.name = lang.includes('en') ? topic.nameEN : topic.nameCY;
+        dto.name_en = topic.nameEN;
+        dto.name_cy = topic.nameCY;
+
+        if (lang) {
+            dto.name = lang.includes('en') ? topic.nameEN : topic.nameCY;
+        }
+
         return dto;
     }
 }


### PR DESCRIPTION
The DTO for `dataset.topics` was previously:

```js
topics: [
    {
      id: 'e2b29741-4197-4a1a-b44d-31dda2fff904',
      dataset_id: '75be5766-e05c-4a11-9243-90c374ac1668',
      topic_id: 9
    },
    {
      id: 'd49fd23b-ff6e-40cd-a624-6d96507770da',
      dataset_id: '75be5766-e05c-4a11-9243-90c374ac1668',
      topic_id: 8
    }
  ],

```

and is now:

```js
topics: [
    { id: 9, path: '8.9', name_en: 'Crime and justice', name_cy: null },
    {
      id: 8,
      path: '8',
      name_en: 'Crime, fire and rescue',
      name_cy: null
    }
  ],
```