### PR TITLE
Casade dataset deletes to topics to prevent error

### DIFF
--- a/src/entities/dataset/dataset-topic.ts
+++ b/src/entities/dataset/dataset-topic.ts
@@ -11,7 +11,7 @@ export class DatasetTopic extends BaseEntity {
     @Column({ type: 'uuid', name: 'dataset_id' })
     datasetId: string;
 
-    @ManyToOne(() => Dataset, (dataset) => dataset.datasetTopics)
+    @ManyToOne(() => Dataset, (dataset) => dataset.datasetTopics, { onDelete: 'CASCADE', orphanedRowAction: 'delete' })
     @JoinColumn({ name: 'dataset_id', foreignKeyConstraintName: 'FK_dataset_topic_dataset_id' })
     dataset: Dataset;
 

--- a/src/migrations/1736866084732-topic-cascade.ts
+++ b/src/migrations/1736866084732-topic-cascade.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TopicCascade1736866084732 implements MigrationInterface {
+    name = 'TopicCascade1736866084732';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_dataset_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_dataset_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+    }
+}


### PR DESCRIPTION
If you try and manually delete datasets from the database that have topics, it will error on FK.