### PR TITLE
Fix date dimension join bug

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -667,7 +667,7 @@ async function setupMeasures(
                 ?.push(`measure.description as "${t('column_headers.measure', { lng: locale })}"`);
         });
         joinStatements.push(
-            `LEFT JOIN measure on measure.measure_id=${FACT_TABLE_NAME}.${dataset.measure.factTableColumn} AND measure.language='#LANG#'`
+            `LEFT JOIN measure on CAST (measure.measure_id AS VARCHAR)=CAST(${FACT_TABLE_NAME}.${dataset.measure.factTableColumn} AS VARCHAR) AND measure.language='#LANG#'`
         );
         orderByStatements.push(`measure.measure_id`);
     } else {
@@ -722,7 +722,7 @@ async function setupDimensions(
                                 );
                         });
                         joinStatements.push(
-                            `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}"`
+                            `LEFT JOIN ${dimTable} on CAST(${dimTable}."${dimension.joinColumn}" AS VARCHAR)=CAST(${FACT_TABLE_NAME}."${dimension.factTableColumn}" AS VARCHAR)`
                         );
                         orderByStatements.push(`${dimTable}.end_date`);
                     } else {
@@ -743,7 +743,7 @@ async function setupDimensions(
                         selectStatementsMap.get(locale)?.push(`${dimTable}.description as "${columnName}"`);
                     });
                     joinStatements.push(
-                        `LEFT JOIN ${dimTable} on ${dimTable}."${dimension.joinColumn}"=${FACT_TABLE_NAME}."${dimension.factTableColumn}" AND ${dimTable}.language='#LANG#'`
+                        `LEFT JOIN ${dimTable} on CAST(${dimTable}."${dimension.joinColumn}" AS VARCHAR)=CAST(${FACT_TABLE_NAME}."${dimension.factTableColumn}" AS VARCHAR) AND ${dimTable}.language='#LANG#'`
                     );
                     if ((dimension.extractor as LookupTableExtractor).sortColumn) {
                         orderByStatements.push(

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -529,7 +529,11 @@ async function getDatePreviewWithExtractor(
         await stmt.run(row.dateCode, row.description, row.start, row.end, row.type);
     });
     await stmt.finalize();
-    const dimensionTable = await quack.all(`SELECT * FROM date_dimension ORDER BY end_date ASC LIMIT ${sampleSize};`);
+    const dimensionTable = await quack.all(
+        `SELECT date_dimension.* FROM date_dimension
+        RIGHT JOIN "${tableName}" ON CAST("${tableName}"."${factTableColumn}" AS VARCHAR)=CAST(date_dimension.date_code AS VARCHAR)
+        ORDER BY end_date ASC LIMIT ${sampleSize};`
+    );
     const tableHeaders = Object.keys(dimensionTable[0]);
     const dataArray = dimensionTable.map((row) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);


### PR DESCRIPTION
This fixes a small issue in the dimension preview where values not present in the fact table are displayed to the end user.  The occurs because we generate yearly values along side any quarter or month representations.  So when a user advises they have quarterly data we generate the values for year to.  If they don't have a yearly totals we still show them that yearly values are present in the lookup.  This small fix stops that from happening by only showing them values which match their fact table(s).