### PR TITLE
Event log improvements

### DIFF
--- a/src/entities/event-log.ts
+++ b/src/entities/event-log.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'event_log' })
 export class EventLog extends BaseEntity {
@@ -11,12 +11,14 @@ export class EventLog extends BaseEntity {
     @Column({ name: 'entity', type: 'text', nullable: false })
     entity: string; // the entity that was affected, e.g. user, dataset, dimension, etc
 
+    @Index('IDX_event_log_entity_id')
     @Column({ name: 'entity_id', type: 'text', nullable: false })
     entityId: string; // the id of the entity that was affected
 
     @Column({ name: 'data', type: 'jsonb', nullable: true })
     data?: Record<string, any>; // the new values of the record that was changed
 
+    @Index('IDX_event_log_user_id')
     @Column({ name: 'user_id', type: 'uuid', nullable: true })
     userId?: string; // the user that triggered the event
 

--- a/src/migrations/1737566648484-event-log-index.ts
+++ b/src/migrations/1737566648484-event-log-index.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EventLogIndex1737566648484 implements MigrationInterface {
+    name = 'EventLogIndex1737566648484';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE INDEX "IDX_event_log_entity_id" ON "event_log" ("entity_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_event_log_user_id" ON "event_log" ("user_id") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_event_log_user_id"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_event_log_entity_id"`);
+    }
+}

--- a/src/services/entity-subscriber.ts
+++ b/src/services/entity-subscriber.ts
@@ -21,7 +21,7 @@ type WriteEvent = InsertEvent<any> | UpdateEvent<any> | RemoveEvent<any>;
 const ignoreTables: string[] = ['event_log'];
 
 // ignore some common props from the logged value that can be easily retrieved elsewhere
-const ignoreProps: string[] = ['id', 'createdAt', 'updatedAt', 'createdBy'];
+const ignoreProps: string[] = ['id', 'createdAt', 'updatedAt', 'createdBy', 'factTables'];
 
 @EventSubscriber()
 export class EntitySubscriber implements EntitySubscriberInterface {


### PR DESCRIPTION
Added an index on entity_id and another on user_id, should help with querying perf once we have a load of rows in there (might want others as well, but will see what usage is like first).

Removed `factTables` nested prop from `revision` event logs.