### PR TITLE
SW-337: submit dataset for publication

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -6,6 +6,7 @@ import tmp from 'tmp';
 import { t } from 'i18next';
 import { isBefore, isValid } from 'date-fns';
 
+import { User } from '../entities/user/user';
 import { FactTableDTO } from '../dtos/fact-table-dto';
 import { UnknownException } from '../exceptions/unknown.exception';
 import { ViewErrDTO } from '../dtos/view-dto';
@@ -272,7 +273,7 @@ export const approveForPublication = async (req: Request, res: Response, next: N
             throw new BadRequestException('dataset not ready for publication, please check tasklist');
         }
 
-        await RevisionRepository.approvePublication(dataset.id);
+        await RevisionRepository.approvePublication(dataset.id, req.user as User);
         const updatedDataset = await DatasetRepository.getById(dataset.id);
         res.status(201);
         res.json(DatasetDTO.fromDataset(updatedDataset));

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -124,9 +124,9 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
             .addSelect(
                 `
                 CASE
-                    WHEN r.publish_at IS NULL THEN 'incomplete'
-                    WHEN r.publish_at > NOW() THEN 'scheduled'
-                    WHEN d.live IS NOT NULL AND r.publish_at <= NOW() THEN 'published'
+                    WHEN d.live IS NOT NULL AND r.approved_at IS NOT NULL AND r.publish_at <= NOW() THEN 'published'
+                    WHEN r.approved_at IS NOT NULL THEN 'scheduled'
+                    ELSE 'incomplete'
                 END
             `,
                 'publishing_status'
@@ -145,7 +145,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
                 'r.dataset_id = d.id'
             )
             .where('di.language LIKE :lang', { lang: `${lang}%` })
-            .groupBy('d.id, di.title, di.updatedAt, r.publish_at');
+            .groupBy('d.id, di.title, di.updatedAt, r.approved_at, r.publish_at');
 
         const offset = (page - 1) * limit;
 

--- a/src/repositories/revision.ts
+++ b/src/repositories/revision.ts
@@ -50,7 +50,7 @@ export const RevisionRepository = dataSource.getRepository(Revision).extend({
         return dataSource.getRepository(Revision).save(revision);
     },
 
-    async approvePublication(datasetId: string): Promise<Revision> {
+    async approvePublication(datasetId: string, approver: User): Promise<Revision> {
         const latestUnpublishedRevision = await dataSource.getRepository(Revision).findOneOrFail({
             where: {
                 dataset: { id: datasetId },
@@ -60,6 +60,7 @@ export const RevisionRepository = dataSource.getRepository(Revision).extend({
         });
 
         latestUnpublishedRevision.approvedAt = new Date();
+        latestUnpublishedRevision.approvedBy = approver;
         await latestUnpublishedRevision.save();
 
         return latestUnpublishedRevision;

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -58,6 +58,7 @@ import {
     getRevisionPreview,
     removeFactTableFromRevision,
     updateRevisionPublicationDate,
+    approveForPublication,
     updateSources
 } from '../controllers/revision';
 
@@ -351,3 +352,7 @@ router.patch(
     loadDataset(),
     updateRevisionPublicationDate
 );
+
+// POST /dataset/:dataset_id/approve
+// Approve the dataset's latest revision for publication
+router.post('/:dataset_id/approve', loadDataset(), approveForPublication);


### PR DESCRIPTION
For MVP, this sets the `revision.approvedAt` date so that we can test the "scheduled" and "published" statuses.

Post-MVP, we will have an approval stage and `approvedAt` will not be set until that journey is completed.

