### PR TITLE
SW-338: withdraw revision from publication

### DIFF
--- a/src/entities/dataset/revision.interface.ts
+++ b/src/entities/dataset/revision.interface.ts
@@ -12,7 +12,7 @@ export interface RevisionInterface {
     factTables: FactTable[];
     createdAt: Date;
     createdBy: User;
-    approvedAt: Date;
-    approvedBy: User;
+    approvedAt: Date | null;
+    approvedBy: User | null;
     publishAt: Date;
 }

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -45,11 +45,11 @@ export class Revision extends BaseEntity implements RevisionInterface {
     createdBy: User;
 
     @Column({ name: 'approved_at', type: 'timestamptz', nullable: true })
-    approvedAt: Date;
+    approvedAt: Date | null;
 
     @ManyToOne(() => User, { nullable: true })
     @JoinColumn({ name: 'approved_by', foreignKeyConstraintName: 'FK_revision_approved_by' })
-    approvedBy: User;
+    approvedBy: User | null;
 
     @Column({ name: 'publish_at', type: 'timestamptz', nullable: true })
     publishAt: Date;

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -59,7 +59,8 @@ import {
     removeFactTableFromRevision,
     updateRevisionPublicationDate,
     approveForPublication,
-    updateSources
+    updateSources,
+    withdrawFromPublication
 } from '../controllers/revision';
 
 const jsonParser = express.json();
@@ -356,3 +357,7 @@ router.patch(
 // POST /dataset/:dataset_id/approve
 // Approve the dataset's latest revision for publication
 router.post('/:dataset_id/approve', loadDataset(), approveForPublication);
+
+// POST /dataset/:dataset_id/withdraw
+// Withdraw the dataset's latest revision from scheduled publication
+router.post('/:dataset_id/withdraw', loadDataset(), withdrawFromPublication);


### PR DESCRIPTION
This adds a new route to allow a scheduled publication to be withdrawn.

For MVP, this just involves nullifying the `approvedAt` and `approvedBy` fields on the scheduled revision.