### PR TITLE
Tidying up schema

### DIFF
--- a/src/controllers/measure-controller.ts
+++ b/src/controllers/measure-controller.ts
@@ -62,8 +62,10 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
         next(new NotFoundException('errors.fact_table_invalid'));
         return;
     }
+
     let fileImport: DataTable;
     const utf8Buffer = convertBufferToUTF8(req.file.buffer);
+
     try {
         fileImport = await uploadCSV(utf8Buffer, req.file?.mimetype, req.file?.originalname, res.locals.datasetId);
     } catch (err) {
@@ -85,7 +87,7 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
         res.status(200);
         res.json(result);
     } catch (err) {
-        logger.error(`An error occurred trying to handle measure lookup table with error: ${err}`);
+        logger.error(err, `An error occurred trying to handle measure lookup table with error`);
         next(new UnknownException('errors.upload_error'));
     }
 };

--- a/src/dtos/lookup-table-dto.ts
+++ b/src/dtos/lookup-table-dto.ts
@@ -2,8 +2,6 @@ import { LookupTable } from '../entities/dataset/lookup-table';
 
 export class LookupTableDTO {
     id: string;
-    dimension_id?: string;
-    measure_id?: string;
     mime_type: string;
     filename: string;
     file_type: string;
@@ -13,8 +11,6 @@ export class LookupTableDTO {
     static fromLookupTable(lookupTable: LookupTable): LookupTableDTO {
         const dto = new LookupTableDTO();
         dto.id = lookupTable.id;
-        dto.dimension_id = lookupTable.dimension?.id || undefined;
-        dto.measure_id = lookupTable.measure?.id || undefined;
         dto.mime_type = lookupTable.mimeType;
         dto.filename = lookupTable.filename;
         dto.file_type = lookupTable.fileType;

--- a/src/entities/dataset/dataset-provider.ts
+++ b/src/entities/dataset/dataset-provider.ts
@@ -18,14 +18,20 @@ export class DatasetProvider extends BaseEntity {
     @Column({ type: 'varchar', length: 5 })
     language: string;
 
-    @ManyToOne(() => Dataset, (dataset) => dataset.datasetProviders)
+    @ManyToOne(() => Dataset, (dataset) => dataset.datasetProviders, {
+        onDelete: 'CASCADE',
+        orphanedRowAction: 'delete'
+    })
     @JoinColumn({ name: 'dataset_id', foreignKeyConstraintName: 'FK_dataset_provider_dataset_id' })
     dataset: Dataset;
 
     @Column({ type: 'uuid', name: 'provider_id' })
     providerId: string;
 
-    @ManyToOne(() => Provider, (provider) => provider.datasetProviders)
+    @ManyToOne(() => Provider, (provider) => provider.datasetProviders, {
+        onDelete: 'CASCADE',
+        orphanedRowAction: 'delete'
+    })
     @JoinColumn([
         {
             name: 'provider_id',
@@ -43,7 +49,10 @@ export class DatasetProvider extends BaseEntity {
     @Column({ type: 'uuid', name: 'provider_source_id', nullable: true })
     providerSourceId?: string;
 
-    @ManyToOne(() => ProviderSource, (providerSource) => providerSource.datasetProviders)
+    @ManyToOne(() => ProviderSource, (providerSource) => providerSource.datasetProviders, {
+        onDelete: 'CASCADE',
+        orphanedRowAction: 'delete'
+    })
     @JoinColumn([
         {
             name: 'provider_source_id',

--- a/src/entities/dataset/dataset-topic.ts
+++ b/src/entities/dataset/dataset-topic.ts
@@ -18,7 +18,7 @@ export class DatasetTopic extends BaseEntity {
     @Column({ type: 'int', name: 'topic_id' })
     topicId: number;
 
-    @ManyToOne(() => Topic, (topic) => topic.datasetTopics)
+    @ManyToOne(() => Topic, (topic) => topic.datasetTopics, { onDelete: 'CASCADE', orphanedRowAction: 'delete' })
     @JoinColumn({ name: 'topic_id', foreignKeyConstraintName: 'FK_dataset_topic_topic_id' })
     topic: Topic;
 }

--- a/src/entities/dataset/dimension.ts
+++ b/src/entities/dataset/dimension.ts
@@ -40,10 +40,7 @@ export class Dimension extends BaseEntity {
     isSliceDimension: boolean;
 
     @OneToOne(() => LookupTable, (lookupTable) => lookupTable.dimension, { cascade: true })
-    @JoinColumn({
-        name: 'lookup_table_id',
-        foreignKeyConstraintName: 'FK_dimension_lookup_table_id_lookup_table_dimension_id'
-    })
+    @JoinColumn({ name: 'lookup_table_id', foreignKeyConstraintName: 'FK_dimension_lookup_table_id' })
     lookupTable: LookupTable | null;
 
     @OneToMany(() => DimensionMetadata, (dimensionInfo) => dimensionInfo.dimension, { cascade: true })

--- a/src/entities/dataset/lookup-table.ts
+++ b/src/entities/dataset/lookup-table.ts
@@ -11,16 +11,10 @@ export class LookupTable extends BaseEntity implements FileImportInterface {
     @PrimaryGeneratedColumn('uuid', { primaryKeyConstraintName: 'PK_lookup_table_id' })
     id: string;
 
-    @OneToOne(() => Dimension, {
-        orphanedRowAction: 'delete'
-    })
-    @JoinColumn({ name: 'dimension_id' })
+    @OneToOne(() => Dimension, { orphanedRowAction: 'delete' })
     dimension: Dimension;
 
-    @OneToOne(() => Measure, {
-        orphanedRowAction: 'delete'
-    })
-    @JoinColumn({ name: 'measure_id' })
+    @OneToOne(() => Measure, { orphanedRowAction: 'delete' })
     measure: Measure;
 
     @Column({ name: 'mime_type', type: 'varchar', length: 255 })

--- a/src/entities/dataset/measure.ts
+++ b/src/entities/dataset/measure.ts
@@ -18,10 +18,7 @@ export class Measure extends BaseEntity {
     dataset: Dataset;
 
     @OneToOne(() => LookupTable, { cascade: true, onDelete: 'CASCADE' })
-    @JoinColumn({
-        name: 'lookup_table_id',
-        foreignKeyConstraintName: 'FK_measure_lookup_table_id_lookup_table_measure_id'
-    })
+    @JoinColumn({ name: 'lookup_table_id', foreignKeyConstraintName: 'FK_measure_lookup_table_id' })
     lookupTable: LookupTable | null;
 
     @Column({ name: 'fact_table_column', type: 'varchar' })

--- a/src/entities/reference-data/category-info.ts
+++ b/src/entities/reference-data/category-info.ts
@@ -17,6 +17,6 @@ export class CategoryInfo extends BaseEntity {
     notes: string;
 
     @ManyToOne(() => Category)
-    @JoinColumn({ name: 'category' })
+    @JoinColumn({ name: 'category', foreignKeyConstraintName: 'FK_category_info_category' })
     categoryEntity: Category;
 }

--- a/src/entities/reference-data/category-key-info.ts
+++ b/src/entities/reference-data/category-key-info.ts
@@ -17,6 +17,6 @@ export class CategoryKeyInfo extends BaseEntity {
     notes: string;
 
     @ManyToOne(() => CategoryKey)
-    @JoinColumn({ name: 'category_key' })
+    @JoinColumn({ name: 'category_key', foreignKeyConstraintName: 'FK_category_key_info_category_key' })
     categoryKeyEntity: CategoryKey;
 }

--- a/src/entities/reference-data/category-key.ts
+++ b/src/entities/reference-data/category-key.ts
@@ -11,6 +11,6 @@ export class CategoryKey extends BaseEntity {
     category: string;
 
     @ManyToOne(() => Category)
-    @JoinColumn({ name: 'category' })
+    @JoinColumn({ name: 'category', foreignKeyConstraintName: 'FK_category_key_category' })
     categoryEntity: Category;
 }

--- a/src/entities/reference-data/reference-data.ts
+++ b/src/entities/reference-data/reference-data.ts
@@ -23,6 +23,6 @@ export class ReferenceData extends BaseEntity {
     validityEnd: Date;
 
     @ManyToOne(() => CategoryKey)
-    @JoinColumn({ name: 'category_key' })
+    @JoinColumn({ name: 'category_key', foreignKeyConstraintName: 'FK_reference_data_category_key' })
     categoryKeyEntity: CategoryKey;
 }

--- a/src/migrations/1738930547117-resolve-outstanding.ts
+++ b/src/migrations/1738930547117-resolve-outstanding.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Not sure why, but these are showing as outstanding changes when I run migration:generate
+export class ResolveOutstanding1738930547117 implements MigrationInterface {
+    name = 'ResolveOutstanding1738930547117';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE SEQUENCE IF NOT EXISTS "event_log_id_seq" OWNED BY "event_log"."id"`);
+        await queryRunner.query(`ALTER TABLE "event_log" ALTER COLUMN "id" SET DEFAULT nextval('"event_log_id_seq"')`);
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_topic_id"`);
+        await queryRunner.query(`CREATE SEQUENCE IF NOT EXISTS "topic_id_seq" OWNED BY "topic"."id"`);
+        await queryRunner.query(`ALTER TABLE "topic" ALTER COLUMN "id" SET DEFAULT nextval('"topic_id_seq"')`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_topic_id" FOREIGN KEY ("topic_id") REFERENCES "topic"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_topic_id"`);
+        await queryRunner.query(`ALTER TABLE "topic" ALTER COLUMN "id" DROP DEFAULT`);
+        await queryRunner.query(`DROP SEQUENCE "topic_id_seq"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_topic_id" FOREIGN KEY ("topic_id") REFERENCES "topic"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(`ALTER TABLE "event_log" ALTER COLUMN "id" DROP DEFAULT`);
+        await queryRunner.query(`DROP SEQUENCE "event_log_id_seq"`);
+    }
+}

--- a/src/migrations/1738930610485-cascade.ts
+++ b/src/migrations/1738930610485-cascade.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Add on delete cascade to join tables
+export class Cascade1738930610485 implements MigrationInterface {
+    name = 'Cascade1738930610485';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_provider_source_id_language"`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_provider_id_language"`
+        );
+        await queryRunner.query(`ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_dataset_id"`);
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_topic_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_provider_id_language" FOREIGN KEY ("provider_id", "language") REFERENCES "provider"("id","language") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_provider_source_id_language" FOREIGN KEY ("provider_source_id", "language") REFERENCES "provider_source"("id","language") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_topic_id" FOREIGN KEY ("topic_id") REFERENCES "topic"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_topic" DROP CONSTRAINT "FK_dataset_topic_topic_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_provider_source_id_language"`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_provider_id_language"`
+        );
+        await queryRunner.query(`ALTER TABLE "dataset_provider" DROP CONSTRAINT "FK_dataset_provider_dataset_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "dataset_topic" ADD CONSTRAINT "FK_dataset_topic_topic_id" FOREIGN KEY ("topic_id") REFERENCES "topic"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_provider_id_language" FOREIGN KEY ("provider_id", "language") REFERENCES "provider"("id","language") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dataset_provider" ADD CONSTRAINT "FK_dataset_provider_provider_source_id_language" FOREIGN KEY ("provider_source_id", "language") REFERENCES "provider_source"("id","language") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+    }
+}

--- a/src/migrations/1738943651593-drop-multi-dir-fk.ts
+++ b/src/migrations/1738943651593-drop-multi-dir-fk.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropMultiDirFk1738943651593 implements MigrationInterface {
+    name = 'DropMultiDirFk1738943651593';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "measure" DROP CONSTRAINT "FK_measure_lookup_table_id_lookup_table_measure_id"`
+        );
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP CONSTRAINT "FK_47ad3331d1237986c7a106f6ede"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP CONSTRAINT "FK_d897df215d38c8de48699f0bb1e"`);
+        await queryRunner.query(
+            `ALTER TABLE "dimension" DROP CONSTRAINT "FK_dimension_lookup_table_id_lookup_table_dimension_id"`
+        );
+        await queryRunner.query(`ALTER TABLE "category_key" DROP CONSTRAINT "FK_087b36846d67092609821a62756"`);
+        await queryRunner.query(`ALTER TABLE "reference_data" DROP CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2"`);
+        await queryRunner.query(`ALTER TABLE "category_key_info" DROP CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47"`);
+        await queryRunner.query(`ALTER TABLE "category_info" DROP CONSTRAINT "FK_68028565126809c1e925e6f9334"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP CONSTRAINT "REL_d897df215d38c8de48699f0bb1"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP COLUMN "dimension_id"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP CONSTRAINT "REL_47ad3331d1237986c7a106f6ed"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" DROP COLUMN "measure_id"`);
+        await queryRunner.query(
+            `ALTER TABLE "measure" ADD CONSTRAINT "FK_measure_lookup_table_id" FOREIGN KEY ("lookup_table_id") REFERENCES "lookup_table"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_lookup_table_id" FOREIGN KEY ("lookup_table_id") REFERENCES "lookup_table"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_key" ADD CONSTRAINT "FK_category_key_category" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "reference_data" ADD CONSTRAINT "FK_reference_data_category_key" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_key_info" ADD CONSTRAINT "FK_category_key_info_category_key" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_info" ADD CONSTRAINT "FK_category_info_category" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category_info" DROP CONSTRAINT "FK_category_info_category"`);
+        await queryRunner.query(`ALTER TABLE "category_key_info" DROP CONSTRAINT "FK_category_key_info_category_key"`);
+        await queryRunner.query(`ALTER TABLE "reference_data" DROP CONSTRAINT "FK_reference_data_category_key"`);
+        await queryRunner.query(`ALTER TABLE "category_key" DROP CONSTRAINT "FK_category_key_category"`);
+        await queryRunner.query(`ALTER TABLE "dimension" DROP CONSTRAINT "FK_dimension_lookup_table_id"`);
+        await queryRunner.query(`ALTER TABLE "measure" DROP CONSTRAINT "FK_measure_lookup_table_id"`);
+        await queryRunner.query(`ALTER TABLE "lookup_table" ADD "measure_id" uuid`);
+        await queryRunner.query(
+            `ALTER TABLE "lookup_table" ADD CONSTRAINT "REL_47ad3331d1237986c7a106f6ed" UNIQUE ("measure_id")`
+        );
+        await queryRunner.query(`ALTER TABLE "lookup_table" ADD "dimension_id" uuid`);
+        await queryRunner.query(
+            `ALTER TABLE "lookup_table" ADD CONSTRAINT "REL_d897df215d38c8de48699f0bb1" UNIQUE ("dimension_id")`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_info" ADD CONSTRAINT "FK_68028565126809c1e925e6f9334" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_key_info" ADD CONSTRAINT "FK_ec0b41bafd5605fff51fc0c8e47" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "reference_data" ADD CONSTRAINT "FK_dd4ff535904e339641b0b0d52c2" FOREIGN KEY ("category_key") REFERENCES "category_key"("category_key") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "category_key" ADD CONSTRAINT "FK_087b36846d67092609821a62756" FOREIGN KEY ("category") REFERENCES "category"("category") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "dimension" ADD CONSTRAINT "FK_dimension_lookup_table_id_lookup_table_dimension_id" FOREIGN KEY ("lookup_table_id") REFERENCES "lookup_table"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "lookup_table" ADD CONSTRAINT "FK_d897df215d38c8de48699f0bb1e" FOREIGN KEY ("dimension_id") REFERENCES "dimension"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "lookup_table" ADD CONSTRAINT "FK_47ad3331d1237986c7a106f6ede" FOREIGN KEY ("measure_id") REFERENCES "measure"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "measure" ADD CONSTRAINT "FK_measure_lookup_table_id_lookup_table_measure_id" FOREIGN KEY ("lookup_table_id") REFERENCES "lookup_table"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+        );
+    }
+}

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks';
+
 import 'reflect-metadata';
 
 import express, { NextFunction, Request, Response, Router } from 'express';
@@ -61,10 +63,17 @@ export const loadDataset = (relations?: FindOptionsRelations<Dataset>) => {
         // TODO: include user in query to prevent unauthorized access
 
         try {
-            logger.debug(`Loading dataset ${req.params.dataset_id}...`);
+            const start = performance.now();
             const dataset = await DatasetRepository.getById(req.params.dataset_id, relations);
+            const end = performance.now();
+
             res.locals.datasetId = dataset.id;
             res.locals.dataset = dataset;
+
+            const size = Math.round(Buffer.byteLength(JSON.stringify(dataset)) / 1024);
+            const time = Math.round(end - start);
+
+            logger.debug(`Dataset ${req.params.dataset_id} loaded { size: ${size}kb, time: ${time}ms }`);
         } catch (err) {
             logger.error(`Failed to load dataset, error: ${err}`);
             next(new NotFoundException('errors.no_dataset'));

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,9 +9,18 @@ import { initPassport } from './middleware/passport-auth';
 
 const PORT = appConfig().backend.port;
 
-app.listen(PORT, async () => {
-    const dbManager = await initDb();
-    await initEntitySubscriber(dbManager.getDataSource());
-    await initPassport(dbManager.getDataSource());
-    logger.info(`Server is running on port ${PORT}`);
-});
+Promise.resolve()
+    .then(async () => {
+        const dbManager = await initDb();
+        await initEntitySubscriber(dbManager.getDataSource());
+        await initPassport(dbManager.getDataSource());
+    })
+    .then(() => {
+        app.listen(PORT, async () => {
+            logger.info(`Server is running on port ${PORT}`);
+        });
+    })
+    .catch((err) => {
+        logger.error(err);
+        process.exit(1);
+    });

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -125,9 +125,11 @@ async function setupMeasure(
     updateMeasure.joinColumn = confirmedJoinColumn;
     updateMeasure.lookupTable = lookupTable;
     updateMeasure.extractor = createExtractor(protoLookupTable, tableMatcher);
+
     logger.debug('Saving the lookup table');
     await lookupTable.save();
-    logger.debug('Saving the dimension');
+
+    logger.debug('Saving the measure');
     updateMeasure.lookupTable = lookupTable;
     await updateMeasure.save();
 }

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -16,8 +16,6 @@ export function convertFactTableToLookupTable(factTable: DataTable, dimension?: 
     lookupTable.filename = factTable.filename;
     lookupTable.mimeType = factTable.mimeType;
     lookupTable.hash = factTable.hash;
-    if (dimension) lookupTable.dimension = dimension;
-    if (measure) lookupTable.measure = measure;
     return lookupTable;
 }
 


### PR DESCRIPTION
Some tidying up -
 * there were some things in the entities that were not represented in the db after running the initial migration. Not sure why but after running the `resolve-outstanding` migration we now get "No changes in database schema were found" when running `npm run migration:generate` which is what we would expect
 * Some of the join tables (dataset_provider, dataset_topic) were missing on delete cascade
 * Some of the FKs around ref data were not named, makes it harder to identify what they're for
 * Both sides of the lookup_table <-> measure and lookup_table <-> dimension joins had an FK to the other side, we only need a single side to own the relationship, otherwise they can get out of sync and or cause other side-effects

There will be a part 2 coming with indexes but didn't want this to grow too large.
 