### PR TITLE
Improved tasklist performance

### DIFF
--- a/src/interfaces/dimension-status.ts
+++ b/src/interfaces/dimension-status.ts
@@ -1,6 +1,7 @@
 import { TaskStatus } from '../enums/task-status';
 
 export interface DimensionStatus {
+    id: string;
     name: string;
     status: TaskStatus;
     type: string;

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -18,7 +18,7 @@ import { DimensionMetadata } from '../entities/dataset/dimension-metadata';
 import { Revision } from '../entities/dataset/revision';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 
-const defaultRelations: FindOptionsRelations<Dataset> = {
+const fullRelations: FindOptionsRelations<Dataset> = {
     createdBy: true,
     metadata: true,
     factTable: true,
@@ -52,7 +52,7 @@ const defaultRelations: FindOptionsRelations<Dataset> = {
 };
 
 export const DatasetRepository = dataSource.getRepository(Dataset).extend({
-    async getById(id: string, relations: FindOptionsRelations<Dataset> = defaultRelations): Promise<Dataset> {
+    async getById(id: string, relations: FindOptionsRelations<Dataset> = fullRelations): Promise<Dataset> {
         const findOptions: FindOneOptions<Dataset> = { where: { id }, relations };
 
         if (has(relations, 'revisions.factTables.factTableInfo')) {
@@ -70,7 +70,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
     async getPublishedById(id: string): Promise<Dataset> {
         const findOptions: FindOneOptions<Dataset> = {
             where: { id, live: Not(IsNull()) },
-            relations: defaultRelations,
+            relations: fullRelations,
             order: {
                 dimensions: { metadata: { language: 'ASC' } },
                 revisions: { dataTable: { dataTableDescriptions: { columnIndex: 'ASC' } } }

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -75,7 +75,7 @@ export const loadDataset = (relations?: FindOptionsRelations<Dataset>) => {
 
             logger.debug(`Dataset ${req.params.dataset_id} loaded { size: ${size}kb, time: ${time}ms }`);
         } catch (err) {
-            logger.error(`Failed to load dataset, error: ${err}`);
+            logger.error(err, `Failed to load dataset`);
             next(new NotFoundException('errors.no_dataset'));
             return;
         }
@@ -117,6 +117,10 @@ router.get('/active', listActiveDatasets);
 // GET /dataset/:dataset_id
 // Returns the dataset with the given ID with all available relations hydrated
 router.get('/:dataset_id', loadDataset(), getDatasetById);
+
+// GET /dataset/:dataset_id/limited
+// Returns the dataset with the given ID with limited relations hydrated
+router.get('/:dataset_id/limited', loadDataset({ metadata: true, revisions: true }), getDatasetById);
 
 // DELETE /dataset/:dataset_id
 // Deletes the dataset with the given ID
@@ -184,7 +188,15 @@ router.patch('/:dataset_id/sources', jsonParser, loadDataset(), updateSources);
 
 // GET /dataset/:dataset_id/tasklist
 // Returns a JSON object with info on what parts of the dataset have been created
-router.get('/:dataset_id/tasklist', loadDataset(), getDatasetTasklist);
+const relForTasklistState: FindOptionsRelations<Dataset> = {
+    metadata: true,
+    revisions: { dataTable: true },
+    dimensions: { metadata: true },
+    datasetProviders: true,
+    datasetTopics: true,
+    team: true
+};
+router.get('/:dataset_id/tasklist', loadDataset(relForTasklistState), getDatasetTasklist);
 
 // POST /dataset/:dataset_id/providers
 // Adds a new data provider for the dataset

--- a/src/route/error-handler.ts
+++ b/src/route/error-handler.ts
@@ -8,12 +8,12 @@ export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: R
 
     switch (err.status) {
         case 400:
-            logger.error(`400 error detected for ${req.originalUrl}: ${message}`);
+            logger.error(err, `400 error detected for ${req.originalUrl}: ${message}`);
             res.status(400);
             // TODO: flatten the validation errors to make them more friendly
             res.json({
                 error: t(message, { lng: req.language }),
-                reason: err.validationErrors ? err.validationErrors : undefined
+                reason: err.validationErrors
             });
             return;
 
@@ -23,13 +23,13 @@ export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: R
             break;
 
         case 404:
-            logger.error(`404 error detected for ${req.originalUrl}: ${message}`);
+            logger.error(err, `404 error detected for ${req.originalUrl}: ${message}`);
             res.status(404);
             break;
 
         case 500:
         default:
-            logger.error(`unknown error detected for ${req.originalUrl}: ${message}`);
+            logger.error(err, `unknown error detected for ${req.originalUrl}: ${message}`);
             res.status(500);
             break;
     }


### PR DESCRIPTION
Previously the tasklist was taking quite a while to load, and as it's the core of the publisher workflow, it results in a frustrating experience.

We do not need to load the full dataset with all relations just for the tasklist, so we have a new route with a minimal set of dataset relations loaded (currently metadata & revisions only). We could further improve this by only fetching the latest revision.

Before: ~380ms
![Screenshot 2025-02-08 at 12 17 31](https://github.com/user-attachments/assets/94ce7911-400a-4b54-864b-839d1fc1b9c2)

After: ~14ms
![Screenshot 2025-02-08 at 14 04 20](https://github.com/user-attachments/assets/e6edcf1a-624d-40b7-adcb-c20628c28bf2)

This PR is paired with the [frontend PR of the same name.](https://github.com/Marvell-Consulting/statswales-frontend/pull/119)