### PR TITLE
Improve dataset provider & topic performance

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -39,6 +39,7 @@ import { FactTable } from '../entities/dataset/fact-table';
 import { Dataset } from '../entities/dataset/dataset';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { FactTableColumnDto } from '../dtos/fact-table-column-dto';
+import { TopicDTO } from '../dtos/topic-dto';
 
 import { getCubePreview } from './cube-controller';
 
@@ -266,6 +267,16 @@ export const updateDatasetProviders = async (req: Request, res: Response, next: 
             return;
         }
         next(new UnknownException('errors.provider_update_error'));
+    }
+};
+
+export const getDatasetTopics = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dataset = await DatasetRepository.getById(res.locals.datasetId, { datasetTopics: { topic: true } });
+        const topics = dataset.datasetTopics.map((datasetTopic) => TopicDTO.fromTopic(datasetTopic.topic));
+        res.json(topics);
+    } catch (err) {
+        next(err);
     }
 };
 

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -218,6 +218,17 @@ export const getDatasetTasklist = async (req: Request, res: Response, next: Next
     }
 };
 
+export const getDatasetProviders = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const relations = { datasetProviders: { provider: true, providerSource: true } };
+        const dataset: Dataset = await DatasetRepository.getById(res.locals.datasetId, relations);
+        const providers = dataset.datasetProviders.map((provider) => DatasetProviderDTO.fromDatasetProvider(provider));
+        res.json(providers);
+    } catch (err) {
+        next(err);
+    }
+};
+
 export const addProvidersToDataset = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const datasetId = res.locals.datasetId;

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -220,7 +220,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
 
         logger.debug(`Added new provider for dataset ${datasetId}`);
 
-        return this.getById(datasetId);
+        return this.getById(datasetId, { datasetProviders: { provider: true, providerSource: true } });
     },
 
     async updateDatasetProviders(datasetId: string, dataProviders: DatasetProviderDTO[]): Promise<Dataset> {
@@ -253,7 +253,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
             `Removed ${toRemove.length} providers and updated ${toUpdate.length} providers for dataset ${datasetId}`
         );
 
-        return this.getById(datasetId);
+        return this.getById(datasetId, { datasetProviders: { provider: true, providerSource: true } });
     },
 
     async updateDatasetTopics(datasetId: string, topics: string[]): Promise<Dataset> {

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -268,7 +268,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
 
         await dataSource.getRepository(DatasetTopic).save(datasetTopics);
 
-        return this.getById(datasetId);
+        return this.getById(datasetId, {});
     },
 
     async updateDatasetTeam(datasetId: string, teamId: string): Promise<Dataset> {

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -26,6 +26,7 @@ import {
     cubePreview,
     deleteDatasetById,
     getDatasetById,
+    getDatasetProviders,
     getDatasetTasklist,
     getFactTableDefinition,
     listActiveDatasets,
@@ -194,13 +195,17 @@ const relForTasklistState: FindOptionsRelations<Dataset> = {
 };
 router.get('/:dataset_id/tasklist', loadDataset(relForTasklistState), getDatasetTasklist);
 
+// GET /dataset/:dataset_id/providers
+// Returns the data providers for the dataset
+router.get('/:dataset_id/providers', jsonParser, loadDataset({}), getDatasetProviders);
+
 // POST /dataset/:dataset_id/providers
 // Adds a new data provider for the dataset
-router.post('/:dataset_id/providers', jsonParser, loadDataset(), addProvidersToDataset);
+router.post('/:dataset_id/providers', jsonParser, loadDataset({}), addProvidersToDataset);
 
 // PATCH /dataset/:dataset_id/providers
 // Updates the data providers for the dataset
-router.patch('/:dataset_id/providers', jsonParser, loadDataset(), updateDatasetProviders);
+router.patch('/:dataset_id/providers', jsonParser, loadDataset({}), updateDatasetProviders);
 
 // PATCH /dataset/:dataset_id/topics
 // Updates the topics for the dataset

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -28,6 +28,7 @@ import {
     getDatasetById,
     getDatasetProviders,
     getDatasetTasklist,
+    getDatasetTopics,
     getFactTableDefinition,
     listActiveDatasets,
     listAllDatasets,
@@ -207,9 +208,13 @@ router.post('/:dataset_id/providers', jsonParser, loadDataset({}), addProvidersT
 // Updates the data providers for the dataset
 router.patch('/:dataset_id/providers', jsonParser, loadDataset({}), updateDatasetProviders);
 
+// GET /dataset/:dataset_id/topics
+// Returns the topics for the dataset
+router.get('/:dataset_id/topics', jsonParser, loadDataset({}), getDatasetTopics);
+
 // PATCH /dataset/:dataset_id/topics
 // Updates the topics for the dataset
-router.patch('/:dataset_id/topics', jsonParser, loadDataset(), updateDatasetTopics);
+router.patch('/:dataset_id/topics', jsonParser, loadDataset({}), updateDatasetTopics);
 
 // PATCH /dataset/:dataset_id/team
 // Updates the team for the dataset


### PR DESCRIPTION
Adds new routes for fetching the dataset providers /topics so that we don't have to include those relations in the "limited" dataset used by unrelated requests.

https://github.com/Marvell-Consulting/statswales-frontend/pull/121