### PR TITLE
Fixes long queries makes the cube builder a little more independant

### DIFF
--- a/src/controllers/cube-controller.ts
+++ b/src/controllers/cube-controller.ts
@@ -130,7 +130,7 @@ export const downloadCubeFile = async (req: Request, res: Response, next: NextFu
         cubeBuffer = await dataLakeService.getFileBuffer(latestRevision.onlineCubeFilename, dataset.id);
     } else {
         try {
-            const cubeFile = await createBaseCube(dataset, latestRevision);
+            const cubeFile = await createBaseCube(dataset.id, latestRevision.id);
             cubeBuffer = Buffer.from(fs.readFileSync(cubeFile));
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
@@ -167,7 +167,7 @@ export const downloadCubeAsJSON = async (req: Request, res: Response, next: Next
     } else {
         try {
             logger.info('Creating fresh cube file.');
-            cubeFile = await createBaseCube(dataset, latestRevision);
+            cubeFile = await createBaseCube(dataset.id, latestRevision.id);
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
             next(new UnknownException('errors.cube_create_error'));
@@ -213,7 +213,7 @@ export const downloadCubeAsCSV = async (req: Request, res: Response, next: NextF
         fs.writeFileSync(cubeFile, fileBuffer);
     } else {
         try {
-            cubeFile = await createBaseCube(dataset, latestRevision);
+            cubeFile = await createBaseCube(dataset.id, latestRevision.id);
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
             next(new UnknownException('errors.cube_create_error'));
@@ -259,7 +259,7 @@ export const downloadCubeAsParquet = async (req: Request, res: Response, next: N
         fs.writeFileSync(cubeFile, fileBuffer);
     } else {
         try {
-            cubeFile = await createBaseCube(dataset, latestRevision);
+            cubeFile = await createBaseCube(dataset.id, latestRevision.id);
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
             next(new UnknownException('errors.cube_create_error'));
@@ -305,7 +305,7 @@ export const downloadCubeAsExcel = async (req: Request, res: Response, next: Nex
         fs.writeFileSync(cubeFile, fileBuffer);
     } else {
         try {
-            cubeFile = await createBaseCube(dataset, latestRevision);
+            cubeFile = await createBaseCube(dataset.id, latestRevision.id);
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
             next(new UnknownException('errors.cube_create_error'));

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -174,7 +174,7 @@ export const cubePreview = async (req: Request, res: Response, next: NextFunctio
         fs.writeFileSync(cubeFile, fileBuffer);
     } else {
         try {
-            cubeFile = await createBaseCube(dataset, latestRevision);
+            cubeFile = await createBaseCube(dataset.id, latestRevision.id);
         } catch (err) {
             logger.error(`Something went wrong trying to create the cube with the error: ${err}`);
             next(new UnknownException('errors.cube_create_error'));

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -24,6 +24,7 @@ const fullRelations: FindOptionsRelations<Dataset> = {
         metadata: true,
         lookupTable: true
     },
+    factTable: true,
     measure: true,
     revisions: {
         dataTable: {

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -19,19 +19,13 @@ import { Revision } from '../entities/dataset/revision';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 
 const fullRelations: FindOptionsRelations<Dataset> = {
-    createdBy: true,
     metadata: true,
-    factTable: true,
     dimensions: {
         metadata: true,
         lookupTable: true
     },
-    measure: {
-        lookupTable: true,
-        measureTable: true
-    },
+    measure: true,
     revisions: {
-        createdBy: true,
         dataTable: {
             dataTableDescriptions: true
         }
@@ -54,6 +48,9 @@ const fullRelations: FindOptionsRelations<Dataset> = {
 export const DatasetRepository = dataSource.getRepository(Dataset).extend({
     async getById(id: string, relations: FindOptionsRelations<Dataset> = fullRelations): Promise<Dataset> {
         const findOptions: FindOneOptions<Dataset> = { where: { id }, relations };
+        logger.debug(
+            `Getting Dataset by ID "${id}" with the following relations: ${JSON.stringify(relations, null, 2)}`
+        );
 
         if (has(relations, 'revisions.factTables.factTableInfo')) {
             // sort sources by column index if they're requested

--- a/src/repositories/revision.ts
+++ b/src/repositories/revision.ts
@@ -18,6 +18,9 @@ const defaultRelations: FindOptionsRelations<Revision> = {
 export const RevisionRepository = dataSource.getRepository(Revision).extend({
     async getById(id: string, relations: FindOptionsRelations<Revision> = defaultRelations): Promise<Revision> {
         const findOptions: FindOneOptions<Revision> = { where: { id }, relations };
+        logger.debug(
+            `Getting Revision by ID "${id}" with the following relations: ${JSON.stringify(relations, null, 2)}`
+        );
 
         if (has(relations, 'revisions.factTables.factTableInfo')) {
             // sort sources by column index if they're requested

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -112,7 +112,11 @@ router.use(
     '/:dataset_id/measure',
     rateLimiter,
     passport.authenticate('jwt', { session: false }),
-    loadDataset(),
+    loadDataset({
+        factTable: true,
+        measure: { measureTable: true, metadata: true },
+        revisions: { dataTable: true }
+    }),
     measureRouter
 );
 
@@ -174,9 +178,9 @@ router.get('/:dataset_id/cube/excel', loadDataset(), downloadCubeAsExcel);
 // Updates the dataset info with the provided data
 router.patch('/:dataset_id/info', jsonParser, loadDataset({}), updateDatasetInfo);
 
-router.get('/:dataset_id/sources', loadDataset(), getFactTableDefinition);
+router.get('/:dataset_id/sources', loadDataset({ factTable: true }), getFactTableDefinition);
 
-router.get('/:dataset_id/fact-table', loadDataset(), getFactTableDefinition);
+router.get('/:dataset_id/fact-table', loadDataset({ factTable: true }), getFactTableDefinition);
 
 // PATCH /dataset/:dataset_id/sources
 // Creates the dimensions and measures from the first import based on user input via JSON
@@ -190,7 +194,20 @@ router.get('/:dataset_id/fact-table', loadDataset(), getFactTableDefinition);
 // Notes: There can only be one object with a type of "dataValue" and one object with a type of "noteCodes"
 // and one object with a value of "measure"
 // Returns a JSON object with the current state of the dataset including the dimensions created.
-router.patch('/:dataset_id/sources', jsonParser, loadDataset(), updateSources);
+router.patch(
+    '/:dataset_id/sources',
+    jsonParser,
+    loadDataset({
+        dimensions: true,
+        revisions: {
+            dataTable: {
+                dataTableDescriptions: true
+            }
+        },
+        factTable: true
+    }),
+    updateSources
+);
 
 // GET /dataset/:dataset_id/tasklist
 // Returns a JSON object with info on what parts of the dataset have been created

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1042,7 +1042,7 @@ export const createBaseCube = async (datasetId: string, endRevisionId: string): 
     logger.info(`Creating default views...`);
     // Build the default views
     for (const locale of SUPPORTED_LOCALES) {
-        const defaultViewSQL = `CREATE VIEW default_view_${locale.toLowerCase().split('-')[0]} AS SELECT\n${selectStatementsMap
+        const defaultViewSQL = `CREATE TABLE default_view_${locale.toLowerCase().split('-')[0]} AS SELECT\n${selectStatementsMap
             .get(locale)
             ?.join(
                 ',\n'

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'path';
+import { performance } from 'node:perf_hooks';
 
 import { Database, DuckDbError } from 'duckdb-async';
 import tmp from 'tmp';
 import { t } from 'i18next';
+import { FindOptionsRelations } from 'typeorm';
 
 import { FileType } from '../enums/file-type';
 import { FileImportInterface } from '../entities/dataset/file-import.interface';
@@ -25,6 +27,8 @@ import { FactTableColumn } from '../entities/dataset/fact-table-column';
 import { CubeValidationException, CubeValidationType } from '../exceptions/cube-error-exception';
 import { DataTableDescription } from '../entities/dataset/data-table-description';
 import { MeasureRow } from '../entities/dataset/measure-row';
+import { DatasetRepository } from '../repositories/dataset';
+import { RevisionRepository } from '../repositories/revision';
 
 import { dateDimensionReferenceTableCreator } from './time-matching';
 import { duckdb } from './duckdb';
@@ -749,7 +753,20 @@ async function setupDimensions(
     orderByStatements: string[]
 ) {
     logger.info('Setting up dimension tables...');
-    for (const dimension of dataset.dimensions) {
+    const factTable = dataset.factTable;
+    if (!factTable)
+        throw new Error(
+            `No fact table found in dataset ${dataset.id} for revision ${endRevision.id}.  Cannot create dimension tables`
+        );
+    const orderedDimension = dataset.dimensions.map((dim) => {
+        const col = factTable.find((col) => col.columnName === dim.factTableColumn);
+        return {
+            dimension: dim,
+            index: col ? factTable.indexOf(col) : -1
+        };
+    });
+    for (const dim of orderedDimension.sort((dimA, dimB) => dimA.index - dimB.index)) {
+        const dimension = dim.dimension;
         logger.info(`Setting up dimension ${dimension.id} for fact table column ${dimension.factTableColumn}`);
         const dimTable = `${makeCubeSafeString(dimension.factTableColumn)}_lookup`;
         let languageColumn = 'lang';
@@ -877,13 +894,13 @@ async function createBaseFactTable(quack: Database, dataset: Dataset) {
     if (!firstRevision) {
         throw new Error(`Unable to find first revision for dataset ${dataset.id}`);
     }
-    const factTable = dataset.factTable;
+    if (!dataset.factTable) {
+        throw new Error(`Unable to find fact table for dataset ${dataset.id}`);
+    }
+    const factTable = dataset.factTable.sort((colA, colB) => colA.columnIndex - colB.columnIndex);
     const compositeKey: string[] = [];
     const factIdentifiers: FactTableColumn[] = [];
     const factTableDef: string[] = [];
-    if (!factTable) {
-        throw new Error(`Unable to find fact table for dataset ${dataset.id}`);
-    }
 
     const factTableCreationDef = factTable
         .sort((col1, col2) => col1.columnIndex - col2.columnIndex)
@@ -946,11 +963,38 @@ export const updateFactTableValidator = async (
 // DO NOT put validation against columns which should be present here.
 // Function should be able to generate a cube just from a fact table or collection
 // of fact tables.
-export const createBaseCube = async (dataset: Dataset, endRevision: Revision): Promise<string> => {
+export const createBaseCube = async (datasetId: string, endRevisionId: string): Promise<string> => {
+    const functionStart = performance.now();
     const selectStatementsMap = new Map<Locale, string[]>();
     SUPPORTED_LOCALES.map((locale) => selectStatementsMap.set(locale, []));
     const joinStatements: string[] = [];
     const orderByStatements: string[] = [];
+
+    const datasetRelations: FindOptionsRelations<Dataset> = {
+        dimensions: {
+            metadata: true,
+            lookupTable: true
+        },
+        factTable: true,
+        measure: {
+            measureTable: true
+        },
+        revisions: {
+            dataTable: {
+                dataTableDescriptions: true
+            }
+        }
+    };
+
+    const endRevisionRelations: FindOptionsRelations<Revision> = {
+        dataTable: {
+            dataTableDescriptions: true
+        }
+    };
+
+    logger.debug(`Loading dataset with id: ${datasetId} using relations: ${JSON.stringify(datasetRelations)}`);
+    const dataset = await DatasetRepository.getById(datasetId, datasetRelations);
+    const endRevision = await RevisionRepository.getById(endRevisionId, endRevisionRelations);
 
     const firstRevision = dataset.revisions.find((rev) => rev.revisionIndex === 1);
     if (!firstRevision) {
@@ -958,6 +1002,7 @@ export const createBaseCube = async (dataset: Dataset, endRevision: Revision): P
     }
 
     logger.debug('Creating an in-memory database to hold the cube using DuckDB 🐤');
+    const buildStart = performance.now();
     const quack = await duckdb();
 
     const { measureColumn, notesCodeColumn, dataValuesColumn, factTableDef, factIdentifiers } =
@@ -1021,6 +1066,10 @@ export const createBaseCube = async (dataset: Dataset, endRevision: Revision): P
     // If used for preview you just want the file
     // If it's the end of the publishing step you'll
     // want to upload the file to the data lake.
+    const end = performance.now();
+    const functionTime = Math.round(end - functionStart);
+    const buildTime = Math.round(end - buildStart);
+    logger.warn(`Cube function took ${functionTime}ms to complete and it took ${buildTime}ms to build the cube.`);
     return tmpFile;
 };
 

--- a/test/view-dataset-contents.test.ts
+++ b/test/view-dataset-contents.test.ts
@@ -76,17 +76,17 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
         ]);
         expect(res.body.data[0]).toEqual([
             1,
-            137527,
+            4.030567686,
             '2021-22',
             '01/04/2021',
             '31/03/2022',
             'Wales',
             'Health Visitor',
-            'Total'
+            'Average'
         ]);
         expect(res.body.data[23]).toEqual([
             24,
-            1.563664596,
+            1007,
             '2022-23',
             '01/04/2022',
             '31/03/2023',

--- a/test/view-dataset-contents.test.ts
+++ b/test/view-dataset-contents.test.ts
@@ -67,31 +67,31 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
         expect(res.body.headers).toEqual([
             { index: -1, name: 'int_line_number', source_type: 'line_number' },
             { index: 0, name: 'Data Values', source_type: 'unknown' },
-            { index: 1, name: 'RowRef', source_type: 'unknown' },
-            { index: 2, name: 'AreaCode', source_type: 'unknown' },
-            { index: 3, name: 'YearCode', source_type: 'unknown' },
-            { index: 4, name: 'Start Date', source_type: 'unknown' },
-            { index: 5, name: 'End Date', source_type: 'unknown' },
+            { index: 1, name: 'YearCode', source_type: 'unknown' },
+            { index: 2, name: 'Start Date', source_type: 'unknown' },
+            { index: 3, name: 'End Date', source_type: 'unknown' },
+            { index: 4, name: 'AreaCode', source_type: 'unknown' },
+            { index: 5, name: 'RowRef', source_type: 'unknown' },
             { index: 6, name: 'Notes', source_type: 'unknown' }
         ]);
         expect(res.body.data[0]).toEqual([
             1,
             137527,
-            'Health Visitor',
-            'Wales',
             '2021-22',
             '01/04/2021',
             '31/03/2022',
+            'Wales',
+            'Health Visitor',
             'Total'
         ]);
         expect(res.body.data[23]).toEqual([
             24,
             1.563664596,
-            'Other Staff',
-            'Isle of Anglesey',
             '2022-23',
             '01/04/2022',
             '31/03/2023',
+            'Isle of Anglesey',
+            'Other Staff',
             null
         ]);
     });


### PR DESCRIPTION
The cube builder now only takes in IDs and is responsible for loading its own dataset and associated relations.  Reduced the scope of the default relations on the dataset.  This has cute queries from 15000ms down to 800ms.

Confirmed cube builder and validation methods take around 500ms to
complete locally.   Looking to confirm in service to support our
rational for using DuckDB.