### PR TITLE
Fix issues with spaces in column headings

### DIFF
--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -400,9 +400,9 @@ export const getFactTableColumnPreview = async (
                 throw new Error('Unknown file type');
         }
         await quack.exec(createTableQuery);
-        const totals = await quack.all(`SELECT COUNT(DISTINCT ${columnName}) AS totalLines FROM ${tableName};`);
+        const totals = await quack.all(`SELECT COUNT(DISTINCT "${columnName}") AS totalLines FROM ${tableName};`);
         const totalLines = Number(totals[0].totalLines);
-        const previewQuery = `SELECT DISTINCT ${columnName} FROM ${tableName} LIMIT ${sampleSize}`;
+        const previewQuery = `SELECT DISTINCT "${columnName}" FROM ${tableName} LIMIT ${sampleSize}`;
         const preview = await quack.all(previewQuery);
         const tableHeaders = Object.keys(preview[0]);
         const dataArray = preview.map((row) => Object.values(row));

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -611,7 +611,7 @@ async function getPreviewWithoutExtractor(
     tableName: string
 ): Promise<ViewDTO> {
     const totals = await quack.all(
-        `SELECT COUNT(DISTINCT ${dimension.factTableColumn}) AS totalLines FROM ${tableName};`
+        `SELECT COUNT(DISTINCT "${dimension.factTableColumn}") AS totalLines FROM ${tableName};`
     );
     const totalLines = Number(totals[0].totalLines);
 


### PR DESCRIPTION
As suspected there was a pair of unquoted columns in some of the select statements.  This fixes these so people have the choice of spaace or not in their column names.