### PR TITLE
Fixes a bug in the update journey

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -325,6 +325,7 @@ export async function createAndValidateDateDimension(
     logger.debug(
         `Period coverage: ${toZonedTime(periodCoverage[0].startDate, 'UTC')} to ${toZonedTime(periodCoverage[0].endDate, 'UTC')}`
     );
+    await quack.exec(`CREATE TABLE IF NOT EXISTS metadata (key VARCHAR, value VARCHAR);`);
     const metaDataCoverage = await quack.all("SELECT * FROM metadata WHERE key = 'start_data' OR key = 'end_date';");
     if (metaDataCoverage.length > 0) {
         for (const metaData of metaDataCoverage) {


### PR DESCRIPTION
When doing the validation the metadata table in the cube doesn't exist when just doing validations.  Added the code to create an empty metadata table if it doesn't exist when the date dimension validates.