### PR TITLE
Clean up source implementation to remove everything and recreate

### DIFF
--- a/src/db/entity-subscriber.ts
+++ b/src/db/entity-subscriber.ts
@@ -78,6 +78,10 @@ export class EntitySubscriber implements EntitySubscriberInterface {
     }
 
     async afterRemove(event: RemoveEvent<any>): Promise<void> {
+        if (!event.entity) {
+            logger.warn('afterRemove event has no entity to log.');
+            return;
+        }
         await this.logEvent('delete', event);
     }
 }

--- a/test/publisher-journey.test.ts
+++ b/test/publisher-journey.test.ts
@@ -545,7 +545,7 @@ describe('API Endpoints', () => {
                 throw new Error('Dataset not found');
             }
             const dimensions = updatedDataset.dimensions;
-            expect(dimensions.length).toBe(4);
+            expect(dimensions.length).toBe(3);
         });
 
         test('Create dimensions from user supplied JSON returns 400 if the body is empty', async () => {


### PR DESCRIPTION
This addresses ticket SW-382 by changing the behaviour to remove all fact table columns, dimensions and measures and effectivly start the create process from scratch if the user changes either the sources or based fact table.