### PR TITLE
Fix clearing dimension, measures and fact tables

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -30,6 +30,7 @@ import { convertBufferToUTF8 } from '../utils/file-utils';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item-dto';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 import {
+    cleanupDimensionMeasureAndFactTable,
     createDimensionsFromSourceAssignment,
     ValidatedSourceAssignment,
     validateSourceAssignment
@@ -128,9 +129,8 @@ export const createFirstRevision = async (req: Request, res: Response, next: Nex
         return;
     }
 
-    if (dataset.factTable && dataset.factTable.length > 0) {
-        await FactTableColumn.getRepository().remove(dataset.factTable);
-    }
+    logger.debug('Cleaning up any existing dimension, measure and fact table definitions');
+    await cleanupDimensionMeasureAndFactTable(dataset);
 
     logger.debug('Updating dataset records');
     try {

--- a/src/route/dataset.ts
+++ b/src/route/dataset.ts
@@ -148,7 +148,17 @@ router.post('/', jsonParser, createDataset);
 // POST /dataset/:dataset_id/data
 // Upload a CSV file to a dataset
 // Returns a DTO object that includes the revisions and import records
-router.post('/:dataset_id/data', upload.single('csv'), loadDataset(), createFirstRevision);
+router.post(
+    '/:dataset_id/data',
+    upload.single('csv'),
+    loadDataset({
+        factTable: true,
+        measure: { measureTable: true },
+        dimensions: true,
+        revisions: { dataTable: { dataTableDescriptions: true } }
+    }),
+    createFirstRevision
+);
 
 // GET /dataset/:dataset_id/view
 // Returns a view of the data file attached to the import

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -274,7 +274,7 @@ export const getCSVPreview = async (
         switch (importObj.fileType) {
             case FileType.Csv:
             case FileType.GzipCsv:
-                createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM read_csv('${tempFile}', auto_type_candidates = ['BOOLEAN', 'BIGINT', 'DOUBLE', 'VARCHAR']);`;
+                createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM read_csv('${tempFile}', auto_type_candidates = ['BIGINT', 'DOUBLE', 'VARCHAR']);`;
                 break;
             case FileType.Parquet:
                 createTableQuery = `CREATE TABLE ${tableName} AS SELECT * FROM '${tempFile}';`;


### PR DESCRIPTION
This PR fixes issues where fact table, measure and dimension entries aren't cleanly removed when the user uploads a replacement data table. As an added bonus we no longer try to detect boolean values when reading CSV files.