### PR TITLE
Fixes an issue where the cube builder fails if select empty

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1087,6 +1087,9 @@ export const createBaseCube = async (datasetId: string, endRevisionId: string): 
     logger.info(`Creating default views...`);
     // Build the default views
     for (const locale of SUPPORTED_LOCALES) {
+        if (selectStatementsMap.get(locale)?.length === 0) {
+            selectStatementsMap.get(locale)?.push('*');
+        }
         const defaultViewSQL = `CREATE TABLE default_view_${locale.toLowerCase().split('-')[0]} AS SELECT\n${selectStatementsMap
             .get(locale)
             ?.join(


### PR DESCRIPTION
This fixes an issue when the cube builder fails because there are no dimensions or measures in a cube resulting in an empty select statement. This add a check to see if there is something in the select and if not adds `*` to the select to allow it just show the raw fact table.