### PR TITLE
Update dimension error return values

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -402,6 +402,7 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
         next(new UnknownException('errors.no_fact_table'));
         return;
     }
+    logger.debug(`Processing request to update dataset sources...`);
     try {
         const validatedSourceAssignment = validateSourceAssignment(dataTable, sourceAssignment);
         await createDimensionsFromSourceAssignment(dataset, dataTable, validatedSourceAssignment);

--- a/src/controllers/dimension-controller.ts
+++ b/src/controllers/dimension-controller.ts
@@ -135,8 +135,8 @@ export const updateDimension = async (req: Request, res: Response, next: NextFun
     try {
         logger.debug(`User dimension type = ${JSON.stringify(dimensionPatchRequest)}`);
         switch (dimensionPatchRequest.dimension_type) {
-            case DimensionType.TimePeriod:
-            case DimensionType.TimePoint:
+            case DimensionType.DatePeriod:
+            case DimensionType.Date:
                 logger.debug('Matching a Dimension containing Dates');
                 preview = await validateDateTypeDimension(dimensionPatchRequest, dataset, dimension, factTable);
                 break;

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -307,8 +307,8 @@ async function attachUpdateDataTableToRevision(
                     logger.debug(`Validating reference data dimension: ${dimension.id}`);
                     await loadCorrectReferenceDataIntoReferenceDataTable(quack, dimension);
                     break;
-                case DimensionType.TimePeriod:
-                case DimensionType.TimePoint:
+                case DimensionType.DatePeriod:
+                case DimensionType.Date:
                     logger.debug(`Validating time dimension: ${dimension.id}`);
                     await createAndValidateDateDimension(quack, dimension.extractor, dimension.factTableColumn);
             }

--- a/src/enums/dimension-type.ts
+++ b/src/enums/dimension-type.ts
@@ -5,7 +5,9 @@ export enum DimensionType {
     Symbol = 'symbol',
     LookupTable = 'lookup_table',
     ReferenceData = 'reference_data',
+    DatePeriod = 'date_period',
+    Date = 'date',
     TimePeriod = 'time_period',
-    TimePoint = 'time_point',
+    Time = 'time',
     NoteCodes = 'note_codes'
 }

--- a/src/migrations/1741278090812-change_enum.ts
+++ b/src/migrations/1741278090812-change_enum.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChangeEnum1741278090812 implements MigrationInterface {
+    name = 'ChangeEnum1741278090812';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TYPE "public"."dimension_type_enum"
+            RENAME TO "dimension_type_enum_old"
+        `);
+        await queryRunner.query(`
+            CREATE TYPE "public"."dimension_type_enum" AS ENUM(
+                'raw',
+                'text',
+                'numeric',
+                'symbol',
+                'lookup_table',
+                'reference_data',
+                'date_period',
+                'date',
+                'time_period',
+                'time',
+                'note_codes'
+            )
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "dimension"
+            ALTER COLUMN "type" TYPE "public"."dimension_type_enum" USING "type"::"text"::"public"."dimension_type_enum"
+        `);
+        await queryRunner.query(`
+            DROP TYPE "public"."dimension_type_enum_old"
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TYPE IF EXISTS "public"."dimension_type_enum_old"
+        `);
+    }
+}

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -810,8 +810,8 @@ async function setupDimensions(
         let languageColumn = 'lang';
         try {
             switch (dimension.type) {
-                case DimensionType.TimePeriod:
-                case DimensionType.TimePoint:
+                case DimensionType.DatePeriod:
+                case DimensionType.Date:
                     if (dimension.extractor) {
                         await createAndValidateDateDimension(quack, dimension.extractor, dimension.factTableColumn);
                         SUPPORTED_LOCALES.map((locale) => {

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -143,7 +143,7 @@ async function createUpdateDimension(dataset: Dataset, columnDescriptor: SourceA
     await columnInfo.save();
     const dimension = new Dimension();
     dimension.type =
-        columnDescriptor.column_type === FactTableColumnType.Time ? DimensionType.TimePeriod : DimensionType.Raw;
+        columnDescriptor.column_type === FactTableColumnType.Time ? DimensionType.DatePeriod : DimensionType.Raw;
     dimension.dataset = dataset;
     dimension.factTableColumn = columnInfo.columnName;
     const savedDimension = await dimension.save();
@@ -689,8 +689,8 @@ export const getDimensionPreview = async (
     try {
         if (dimension.extractor) {
             switch (dimension.type) {
-                case DimensionType.TimePoint:
-                case DimensionType.TimePeriod:
+                case DimensionType.Date:
+                case DimensionType.DatePeriod:
                     logger.debug('Previewing a date type dimension');
                     viewDto = await getDatePreviewWithExtractor(
                         dataset,

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -90,7 +90,7 @@ export const validateSourceAssignment = (
     const dimensions: SourceAssignmentDTO[] = [];
     const dateDimensions: SourceAssignmentDTO[] = [];
     const ignore: SourceAssignmentDTO[] = [];
-
+    logger.debug(`Validating source assignment from: ${JSON.stringify(sourceAssignment, null, 2)}`);
     sourceAssignment.map((sourceInfo) => {
         if (
             !fileImport.dataTableDescriptions?.find(

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -168,12 +168,12 @@ export const validateLookupTable = async (
             );
             return viewErrorGenerator(400, dataset.id, 'patch', 'errors.dimensionValidation.invalid_lookup_table', {
                 totalNonMatching: rows[0].total_rows,
-                nonMatchingFactTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
+                nonMatchingDataTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
                 nonMatchedLookupValues: nonMatchedLookupValues.map((row) => Object.values(row)[0])
             });
         }
         if (nonMatchedRows.length > 0) {
-            const nonMatchingFactTableValues = await quack.all(
+            const nonMatchingDataTableValues = await quack.all(
                 `SELECT DISTINCT fact_table_column FROM (SELECT "${dimension.factTableColumn}" as fact_table_column
                 FROM ${factTableName})as fact_table
                 LEFT JOIN ${lookupTableName}
@@ -191,7 +191,7 @@ export const validateLookupTable = async (
             );
             return viewErrorGenerator(400, dataset.id, 'patch', 'errors.dimensionValidation.invalid_lookup_table', {
                 totalNonMatching: nonMatchedRows.length,
-                nonMatchingFactTableValues: nonMatchingFactTableValues.map((row) => Object.values(row)[0]),
+                nonMatchingDataTableValues: nonMatchingDataTableValues.map((row) => Object.values(row)[0]),
                 nonMatchedLookupValues: nonMatchingLookupValues.map((row) => Object.values(row)[0])
             });
         }
@@ -204,7 +204,7 @@ export const validateLookupTable = async (
         const nonMatchedValues = await quack.all(`SELECT DISTINCT ${dimension.factTableColumn} FROM ${factTableName};`);
         return viewErrorGenerator(400, dataset.id, 'patch', 'errors.dimensionValidation.invalid_lookup_table', {
             totalNonMatching: nonMatchedRows[0].total_rows,
-            nonMatchingFactTableValues: nonMatchedValues.map((row) => Object.values(row)[0])
+            nonMatchingDataTableValues: nonMatchedValues.map((row) => Object.values(row)[0])
         });
     }
 

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -178,7 +178,7 @@ async function rowMatcher(
             );
             return viewErrorGenerator(400, datasetId, 'patch', 'errors.dimensionValidation.matching_error', {
                 totalNonMatching: rows[0].total_rows,
-                nonMatchingFactTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
+                nonMatchingDataTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
                 nonMatchingLookupValues: nonMatchedLookupValues.map((row) => Object.values(row)[0])
             });
         }
@@ -201,7 +201,7 @@ async function rowMatcher(
             );
             return viewErrorGenerator(400, datasetId, 'patch', 'errors.dimensionValidation.matching_error', {
                 totalNonMatching: nonMatchedRows.length,
-                nonMatchingFactTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
+                nonMatchingDataTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
                 nonMatchingLookupValues: nonMatchingLookupValues.map((row) => Object.values(row)[0])
             });
         }
@@ -216,7 +216,7 @@ async function rowMatcher(
         );
         return viewErrorGenerator(400, datasetId, 'patch', 'errors.dimensionValidation.invalid_lookup_table', {
             totalNonMatching: nonMatchedRows[0].total_rows,
-            nonMatchingFactTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
+            nonMatchingDataTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0]),
             nonMatchingLookupValues: null
         });
     }

--- a/src/services/reference-data-handler.ts
+++ b/src/services/reference-data-handler.ts
@@ -54,14 +54,14 @@ async function validateUnknownReferenceDataItems(quack: Database, dataset: Datas
     `);
     if (nonMatchedRows.length > 0) {
         logger.error('The user has unknown items in their reference data column');
-        const nonMatchedValues = await quack.all(`
+        const nonMatchedFactTableValues = await quack.all(`
               SELECT DISTINCT fact_table."${dimension.factTableColumn}", reference_data.item_id FROM fact_table
               LEFT JOIN reference_data on reference_data.item_id=CAST(fact_table."${dimension.factTableColumn}" AS VARCHAR)
               WHERE reference_data.item_id IS NULL;
         `);
         return viewErrorGenerator(400, dataset.id, 'patch', 'errors.dimensionValidation.invalid_lookup_table', {
             totalNonMatching: nonMatchedRows.length,
-            nonMatchingValues: nonMatchedValues.map((row) => Object.values(row)[0])
+            nonMatchedFactTableValues: nonMatchedFactTableValues.map((row) => Object.values(row)[0])
         });
     }
     return undefined;

--- a/test/helpers/test-helper.ts
+++ b/test/helpers/test-helper.ts
@@ -108,7 +108,7 @@ export async function createSmallDataset(
 const sureStartShortDimensionDescriptor = [
     {
         columnName: 'YearCode',
-        dimensionType: DimensionType.TimePeriod,
+        dimensionType: DimensionType.DatePeriod,
         extractor: { type: 'financial', yearFormat: 'yyyyyy' },
         joinColumn: 'date_code'
     },


### PR DESCRIPTION
Lookup Table and Measure Lookup needed to return additional values to support the new mismatch screens.  The intention had been to also do this for reference data but this will need to be revisited when we do reference data.

TimePoint and TimePeriod have also been renamed to Date and DatePeriod to support adding Time and TimePeriod to the dimension type enums.  This was done to allow us to implement time and time period dimension types which we know will be required soon.