### PR TITLE
add management designation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,13 +89,14 @@ jobs:
             type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
+      # Only build amd64 for pull request build test - build both amd64 and arm64 for merge to main
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -89,7 +89,7 @@ export class Revision extends BaseEntity {
     @Column({ type: 'text', name: 'update_frequency', nullable: true })
     updateFrequency?: string; // in ISO 8601 duration format, e.g. P1Y = every year
 
-    @Column({ type: 'enum', enum: Object.values(Designation), nullable: true })
+    @Column({ type: 'text', nullable: true })
     designation?: Designation;
 
     @Column({ type: 'jsonb', name: 'related_links', nullable: true })

--- a/src/enums/designation.ts
+++ b/src/enums/designation.ts
@@ -2,5 +2,6 @@ export enum Designation {
   Official = 'official',
   Accredited = 'accredited',
   InDevelopment = 'in_development',
+  Management = 'management',
   None = 'none'
 }

--- a/src/migrations/1741787482585-designation.ts
+++ b/src/migrations/1741787482585-designation.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Designation1741787482585 implements MigrationInterface {
+    name = 'Designation1741787482585'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "designation" TYPE text`);
+        await queryRunner.query(`DROP TYPE "public"."revision_designation_enum"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`CREATE TYPE "public"."revision_designation_enum" AS ENUM('official', 'accredited', 'in_development', 'none')`);
+      await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "designation" TYPE revision_designation_enum USING "designation"::revision_designation_enum`);
+    }
+
+}

--- a/src/migrations/1741787482585-designation.ts
+++ b/src/migrations/1741787482585-designation.ts
@@ -1,16 +1,19 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Designation1741787482585 implements MigrationInterface {
-    name = 'Designation1741787482585'
+  name = 'Designation1741787482585';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "designation" TYPE text`);
-        await queryRunner.query(`DROP TYPE "public"."revision_designation_enum"`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "designation" TYPE text`);
+    await queryRunner.query(`DROP TYPE "public"."revision_designation_enum"`);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-      await queryRunner.query(`CREATE TYPE "public"."revision_designation_enum" AS ENUM('official', 'accredited', 'in_development', 'none')`);
-      await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "designation" TYPE revision_designation_enum USING "designation"::revision_designation_enum`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."revision_designation_enum" AS ENUM('official', 'accredited', 'in_development', 'none')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "revision" ALTER COLUMN "designation" TYPE revision_designation_enum USING "designation"::revision_designation_enum`
+    );
+  }
 }


### PR DESCRIPTION
This removes the enum on the db column so that we can manage the designation list purely in code without db migrations.