### PR TITLE
Roll out languague matcher case statement to lookups

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -36,7 +36,7 @@ import { dateDimensionReferenceTableCreator } from './time-matching';
 import { duckdb } from './duckdb';
 import { NumberExtractor, NumberType } from '../extractors/number-extractor';
 import { CubeValidationType } from '../enums/cube-validation-type';
-import {languageMatcherCaseStatement} from "../utils/lookup-table-utils";
+import { languageMatcherCaseStatement } from '../utils/lookup-table-utils';
 
 export const FACT_TABLE_NAME = 'fact_table';
 

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -36,6 +36,7 @@ import { dateDimensionReferenceTableCreator } from './time-matching';
 import { duckdb } from './duckdb';
 import { NumberExtractor, NumberType } from '../extractors/number-extractor';
 import { CubeValidationType } from '../enums/cube-validation-type';
+import {languageMatcherCaseStatement} from "../utils/lookup-table-utils";
 
 export const FACT_TABLE_NAME = 'fact_table';
 
@@ -421,11 +422,12 @@ export async function createLookupTableDimension(quack: Database, dataset: Datas
     logger.debug(`Built insert query: ${builtInsertQuery}`);
     await quack.exec(builtInsertQuery);
   } else {
+    const languageMatcher = languageMatcherCaseStatement(extractor.languageColumn);
     const notesStr = extractor.notesColumns ? `"${extractor.notesColumns[0].name}"` : 'NULL';
     const dataExtractorParts = `
       SELECT
         "${dimension.joinColumn}" as ${factTableColumn.columnName},
-        "${extractor.languageColumn}" as language,
+        ${languageMatcher} as language,
         "${extractor.descriptionColumns[0].name}" as description,
         ${notesStr} as notes,
         ${extractor.sortColumn ? `"${extractor.sortColumn}"` : 'NULL'} as sort_order,

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -808,7 +808,7 @@ async function getLookupPreviewWithExtractor(
   const lookupTableName = `lookup_table`;
   await loadFileIntoDatabase(quack, dimension.lookupTable, lookupTmpFile, lookupTableName);
   await createLookupTableInCube(quack, factTableColumn, dimension, lookupTableName);
-  const query = `SELECT * EXCLUDE(language) FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup where language = '${language.toLowerCase()}' ORDER BY sort_order LIMIT ${sampleSize};`;
+  const query = `SELECT * EXCLUDE(language) FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup where language = '${language.toLowerCase()}' ORDER BY sort_order, "${dimension.factTableColumn}";`;
   logger.debug(`Querying the cube to get the preview using query ${query}`);
   const dimensionTable = await quack.all(query);
   const tableHeaders = Object.keys(dimensionTable[0]);

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -760,7 +760,6 @@ async function getPreviewWithoutExtractor(
     `SELECT COUNT(DISTINCT "${dimension.factTableColumn}") AS totalLines FROM ${tableName};`
   );
   const totalLines = Number(totals[0].totalLines);
-
   const preview = await quack.all(
     `SELECT DISTINCT "${dimension.factTableColumn}" FROM ${tableName} ORDER BY "${dimension.factTableColumn}" ASC LIMIT ${sampleSize};`
   );
@@ -808,7 +807,10 @@ async function getLookupPreviewWithExtractor(
   const lookupTableName = `lookup_table`;
   await loadFileIntoDatabase(quack, dimension.lookupTable, lookupTmpFile, lookupTableName);
   await createLookupTableInCube(quack, factTableColumn, dimension, lookupTableName);
-  const query = `SELECT * EXCLUDE(language) FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup where language = '${language.toLowerCase()}' ORDER BY sort_order, "${dimension.factTableColumn}";`;
+  const lookupTableSize = await quack.all(
+    `SELECT * FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup WHERE language = '${language.toLowerCase()}'`
+  );
+  const query = `SELECT * EXCLUDE(language) FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup WHERE language = '${language.toLowerCase()}' ORDER BY sort_order, "${dimension.factTableColumn}" LIMIT ${sampleSize};`;
   logger.debug(`Querying the cube to get the preview using query ${query}`);
   const dimensionTable = await quack.all(query);
   const tableHeaders = Object.keys(dimensionTable[0]);
@@ -824,7 +826,7 @@ async function getLookupPreviewWithExtractor(
     });
   }
   const pageInfo = {
-    total_records: dimensionTable.length,
+    total_records: lookupTableSize.length,
     start_record: 1,
     end_record: dataArray.length
   };

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -9,7 +9,8 @@ import { LookupTablePatchDTO } from '../dtos/lookup-patch-dto';
 import { LookupTableExtractor } from '../extractors/lookup-table-extractor';
 import {
   columnIdentification,
-  convertDataTableToLookupTable, languageMatcherCaseStatement,
+  convertDataTableToLookupTable,
+  languageMatcherCaseStatement,
   lookForJoinColumn,
   validateLookupTableLanguages,
   validateLookupTableReferenceValues

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -9,7 +9,7 @@ import { LookupTablePatchDTO } from '../dtos/lookup-patch-dto';
 import { LookupTableExtractor } from '../extractors/lookup-table-extractor';
 import {
   columnIdentification,
-  convertDataTableToLookupTable,
+  convertDataTableToLookupTable, languageMatcherCaseStatement,
   lookForJoinColumn,
   validateLookupTableLanguages,
   validateLookupTableReferenceValues
@@ -167,11 +167,12 @@ export const createLookupTableInCube = async (
     logger.debug(`Built insert query: ${builtInsertQuery}`);
     await quack.exec(builtInsertQuery);
   } else {
+    const languageMatcher = languageMatcherCaseStatement(extractor.languageColumn);
     const notesStr = extractor.notesColumns ? `"${extractor.notesColumns[0].name}"` : 'NULL';
     const dataExtractorParts = `
       SELECT
         "${dimension.joinColumn}" as ${factTableColumn.columnName},
-        "${extractor.languageColumn}" as language,
+        ${languageMatcher} as language,
         "${extractor.descriptionColumns[0].name}" as description,
         ${notesStr} as notes,
         ${extractor.sortColumn ? `"${extractor.sortColumn}"` : 'NULL'} as sort_order,
@@ -325,10 +326,10 @@ export const validateLookupTable = async (
   await updatedDimension.save();
 
   try {
-    logger.debug('Passed validation preparing to send back the preview');
-    const dimensionTable = await quack.all(
-      `SELECT * FROM "${makeCubeSafeString(dimension.factTableColumn)}_lookup" WHERE language = '${language.toLowerCase()}' LIMIT ${sampleSize};`
-    );
+    const previewQuery = `SELECT * FROM "${makeCubeSafeString(dimension.factTableColumn)}_lookup" WHERE language = '${language.toLowerCase()}';`;
+    logger.debug(`Passed validation preparing to send back the preview using the following query:\n${previewQuery}`);
+    const dimensionTable = await quack.all(previewQuery);
+    logger.debug(`Preview query returned:\n${JSON.stringify(dimensionTable, null, 2)}`);
     const tableHeaders = Object.keys(dimensionTable[0]);
     const dataArray = dimensionTable.map((row) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -10,7 +10,8 @@ import { MeasureLookupPatchDTO } from '../dtos/measure-lookup-patch-dto';
 import { MeasureLookupTableExtractor } from '../extractors/measure-lookup-extractor';
 import {
   columnIdentification,
-  convertDataTableToLookupTable, languageMatcherCaseStatement,
+  convertDataTableToLookupTable,
+  languageMatcherCaseStatement,
   lookForJoinColumn,
   validateLookupTableLanguages,
   validateLookupTableReferenceValues,

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -10,7 +10,7 @@ import { MeasureLookupPatchDTO } from '../dtos/measure-lookup-patch-dto';
 import { MeasureLookupTableExtractor } from '../extractors/measure-lookup-extractor';
 import {
   columnIdentification,
-  convertDataTableToLookupTable,
+  convertDataTableToLookupTable, languageMatcherCaseStatement,
   lookForJoinColumn,
   validateLookupTableLanguages,
   validateLookupTableReferenceValues,
@@ -242,23 +242,11 @@ async function createMeasureTable(
       notesColumnDef = 'NULL';
     }
 
-    const measureMatcher: string[] = [];
-    SUPPORTED_LOCALES.map((locale) => {
-      const lang = locale.split('-')[0].toLowerCase();
-      const tLang = lang;
-      measureMatcher.push(`WHEN LOWER("${extractor.languageColumn}") LIKE '${lang}%' THEN '${locale.toLowerCase()}'`);
-      SUPPORTED_LOCALES.map((locale) => {
-        const lang = locale.split('-')[0].toLowerCase();
-        measureMatcher.push(
-          `WHEN LOWER("${extractor.languageColumn}") LIKE '%${t(`language.${lang}`, { lng: tLang }).toLowerCase()}%' THEN '${locale.toLowerCase()}'`
-        );
-      });
-    });
+    const measureMatcher = languageMatcherCaseStatement(extractor.languageColumn);
+
     buildMeasureViewQuery = `SELECT
                     "${joinColumn}" AS reference,
-                    CASE
-                      ${measureMatcher.join('\n')}
-                    END AS language,
+                    ${measureMatcher} AS language,
                     "${extractor.descriptionColumns[0].name}" AS description,
                     ${notesColumnDef} AS notes,
                     ${sortOrderDef} AS sort_order,

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -47,6 +47,25 @@ export function columnIdentification(info: DataTableDescription) {
   };
 }
 
+export const languageMatcherCaseStatement = (languageColumn: string | undefined): string => {
+  if (!languageColumn) return `''`;
+  const languageMatcher: string[] = [];
+  SUPPORTED_LOCALES.map((locale) => {
+    const lang = locale.split('-')[0].toLowerCase();
+    const tLang = lang;
+    languageMatcher.push(`WHEN LOWER("${languageColumn}") LIKE '${lang}%' THEN '${locale.toLowerCase()}'`);
+    SUPPORTED_LOCALES.map((locale) => {
+      const lang = locale.split('-')[0].toLowerCase();
+      languageMatcher.push(
+        `WHEN LOWER("${languageColumn}") LIKE '%${t(`language.${lang}`, { lng: tLang }).toLowerCase()}%' THEN '${locale.toLowerCase()}'`
+      );
+    });
+  });
+  return `CASE
+  ${languageMatcher.join('\n')}
+  END`;
+};
+
 // Look for the join column.  If there's a table matcher we always use this
 // If the user has called the lookup table column the same as the fact table column use this
 // If they've used the exact name in the guidance e.g. ref_code, reference_code, refcode use this


### PR DESCRIPTION
This was probably an oversight on my part but the languague algorithm I created for measures should also be applied to lookup tables both in the cube and in the during the journey.

The algorithm is now in its own function in the lookup-table-utils and is used consistently where its needed.