### PR TITLE
Add downloading all cube data from the data lake as a zip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "i18next-http-middleware": "^3.7.1",
         "iconv-lite": "^0.6.3",
         "jsonwebtoken": "^9.0.2",
+        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "multer": "^1.4.5-lts.1",
         "openid-client": "^5.7.1",
@@ -6451,6 +6452,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8122,6 +8129,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -8192,6 +8211,15 @@
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.18.tgz",
       "integrity": "sha512-okMm/MCoFrm1vByeVFLBdkFIXLSHy/AIK2AEGgY3eoicfWZeOZqv3GfhtQgICkzs/tqorAMm3a4GBg5qNCrqzg==",
       "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9653,6 +9681,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -11140,6 +11174,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "i18next-http-middleware": "^3.7.1",
     "iconv-lite": "^0.6.3",
     "jsonwebtoken": "^9.0.2",
+    "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "multer": "^1.4.5-lts.1",
     "openid-client": "^5.7.1",

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -39,6 +39,7 @@ import JSZip from 'jszip';
 import { DataLakeFileEntry } from '../interfaces/datalake-file-entry';
 import { StorageService } from '../interfaces/storage-service';
 import { FileImportDto } from '../dtos/file-import';
+import { FileImportType } from '../enums/file-import-type';
 
 export const listAllDatasets = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -368,16 +369,22 @@ async function addDirectoryToZip(
 function collectFiles(dataset: Dataset): Map<string, FileImportDto> {
   const files: Map<string, FileImportDto> = new Map<string, FileImportDto>();
   if (dataset.measure.lookupTable) {
-    files.set(dataset.measure.lookupTable.filename, FileImportDto.fromFileImport(dataset.measure.lookupTable));
+    const fileImport = FileImportDto.fromFileImport(dataset.measure.lookupTable);
+    fileImport.type = FileImportType.Measure;
+    files.set(dataset.measure.lookupTable.filename, fileImport);
   }
   dataset.dimensions.forEach((dimension) => {
     if (dimension.lookupTable) {
-      files.set(dimension.lookupTable.filename, FileImportDto.fromFileImport(dimension.lookupTable));
+      const fileImport = FileImportDto.fromFileImport(dimension.lookupTable);
+      fileImport.type = FileImportType.Dimension;
+      files.set(dimension.lookupTable.filename, fileImport);
     }
   });
   dataset.revisions.forEach((revision) => {
     if (revision.dataTable) {
-      files.set(revision.dataTable.filename, FileImportDto.fromFileImport(revision.dataTable));
+      const fileImport = FileImportDto.fromFileImport(revision.dataTable);
+      fileImport.type = FileImportType.DataTable;
+      files.set(revision.dataTable.filename, fileImport);
     }
   });
   return files;

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -36,10 +36,7 @@ import { getCubePreview } from './cube-controller';
 import { factTableValidatorFromSource } from '../services/fact-table-validator';
 import { FactTableValidationException } from '../exceptions/fact-table-validation-exception';
 import JSZip from 'jszip';
-import { DataLakeFileEntry } from '../interfaces/datalake-file-entry';
-import { StorageService } from '../interfaces/storage-service';
-import { FileImportDto } from '../dtos/file-import';
-import { FileImportType } from '../enums/file-import-type';
+import { addDirectoryToZip, collectFiles } from '../utils/dataset-controller-utils';
 
 export const listAllDatasets = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -342,55 +339,7 @@ export const getFactTableDefinition = async (req: Request, res: Response) => {
   res.json(factTableDto);
 };
 
-async function addDirectoryToZip(
-  zip: JSZip,
-  datasetFiles: Map<string, FileImportDto>,
-  directory: string,
-  fileService: StorageService
-) {
-  const directoryList = await fileService.listFiles(directory);
-  for (const fileEntry of directoryList) {
-    let filename: string;
-    if ((fileEntry as DataLakeFileEntry).name) {
-      const entry = fileEntry as DataLakeFileEntry;
-      if (entry.isDirectory) {
-        await addDirectoryToZip(zip, datasetFiles, `${directory}/${entry.name}`, fileService);
-        continue;
-      }
-      filename = (fileEntry as DataLakeFileEntry).name;
-    } else {
-      filename = fileEntry as string;
-    }
-    const originalFilename = datasetFiles.get(filename)?.filename || filename;
-    zip.file(originalFilename, await fileService.loadBuffer(filename, directory));
-  }
-}
-
-function collectFiles(dataset: Dataset): Map<string, FileImportDto> {
-  const files: Map<string, FileImportDto> = new Map<string, FileImportDto>();
-  if (dataset.measure.lookupTable) {
-    const fileImport = FileImportDto.fromFileImport(dataset.measure.lookupTable);
-    fileImport.type = FileImportType.Measure;
-    files.set(dataset.measure.lookupTable.filename, fileImport);
-  }
-  dataset.dimensions.forEach((dimension) => {
-    if (dimension.lookupTable) {
-      const fileImport = FileImportDto.fromFileImport(dimension.lookupTable);
-      fileImport.type = FileImportType.Dimension;
-      files.set(dimension.lookupTable.filename, fileImport);
-    }
-  });
-  dataset.revisions.forEach((revision) => {
-    if (revision.dataTable) {
-      const fileImport = FileImportDto.fromFileImport(revision.dataTable);
-      fileImport.type = FileImportType.DataTable;
-      files.set(revision.dataTable.filename, fileImport);
-    }
-  });
-  return files;
-}
-
-export const getEverythingFromDatalake = async (req: Request, res: Response) => {
+export const getAllFilesForDataset = async (req: Request, res: Response) => {
   const dataset: Dataset = res.locals.dataset;
   const datasetFiles = collectFiles(dataset);
   const zip = new JSZip();

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -137,6 +137,7 @@ export const downloadRawFactTable = async (req: Request, res: Response, next: Ne
   const { dataset, revision } = res.locals;
   logger.info('User requested to down files...');
   let readable: Readable;
+  logger.debug(`${JSON.stringify(revision)}`);
   if (!revision.dataTable) {
     logger.error("Revision doesn't have a data table, can't download file");
     next(new NotFoundException('errors.revision_id_invalid'));
@@ -169,8 +170,12 @@ export const downloadRawFactTable = async (req: Request, res: Response, next: Ne
     });
     return;
   }
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  res.writeHead(200, { 'Content-Type': 'text/csv' });
+  res.writeHead(200, {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Content-Type': `${revision.dataTable.mimeType}`,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Content-Disposition': `attachment; filename=${revision.dataTable.originalFilename}`
+  });
   readable.pipe(res);
 
   // Handle errors in the file stream

--- a/src/dtos/file-import.ts
+++ b/src/dtos/file-import.ts
@@ -1,0 +1,19 @@
+import { FileImportInterface } from '../entities/dataset/file-import.interface';
+
+export class FileImportDto {
+  filename: string;
+  mime_type: string;
+  file_type: string;
+  hash: string;
+  uploaded_at?: string;
+
+  static fromFileImport(fileImport: FileImportInterface) {
+    const dto = new FileImportDto();
+    dto.filename = fileImport.originalFilename || fileImport.filename;
+    dto.mime_type = fileImport.mimeType;
+    dto.file_type = fileImport.fileType;
+    dto.hash = fileImport.hash;
+    dto.uploaded_at = fileImport.uploadedAt?.toISOString();
+    return dto;
+  }
+}

--- a/src/dtos/file-import.ts
+++ b/src/dtos/file-import.ts
@@ -1,4 +1,5 @@
 import { FileImportInterface } from '../entities/dataset/file-import.interface';
+import { FileImportType } from '../enums/file-import-type';
 
 export class FileImportDto {
   filename: string;
@@ -6,6 +7,7 @@ export class FileImportDto {
   file_type: string;
   hash: string;
   uploaded_at?: string;
+  type: FileImportType;
 
   static fromFileImport(fileImport: FileImportInterface) {
     const dto = new FileImportDto();
@@ -14,6 +16,7 @@ export class FileImportDto {
     dto.file_type = fileImport.fileType;
     dto.hash = fileImport.hash;
     dto.uploaded_at = fileImport.uploadedAt?.toISOString();
+    dto.type = FileImportType.Unknown;
     return dto;
   }
 }

--- a/src/dtos/lookup-table-dto.ts
+++ b/src/dtos/lookup-table-dto.ts
@@ -4,6 +4,7 @@ export class LookupTableDTO {
   id: string;
   mime_type: string;
   filename: string;
+  original_filename: string | null;
   file_type: string;
   hash: string;
   uploaded_at?: string;
@@ -13,6 +14,7 @@ export class LookupTableDTO {
     dto.id = lookupTable.id;
     dto.mime_type = lookupTable.mimeType;
     dto.filename = lookupTable.filename;
+    dto.original_filename = lookupTable.originalFilename;
     dto.file_type = lookupTable.fileType;
     dto.hash = lookupTable.hash;
     dto.uploaded_at = lookupTable.uploadedAt?.toISOString();

--- a/src/entities/dataset/file-import.interface.ts
+++ b/src/entities/dataset/file-import.interface.ts
@@ -5,6 +5,7 @@ export interface FileImportInterface {
   mimeType: string;
   fileType: FileType;
   filename: string;
+  originalFilename: string | null;
   hash: string;
   uploadedAt: Date;
 }

--- a/src/entities/dataset/lookup-table.ts
+++ b/src/entities/dataset/lookup-table.ts
@@ -26,6 +26,9 @@ export class LookupTable extends BaseEntity implements FileImportInterface {
   @Column({ type: 'varchar', length: 255 })
   filename: string;
 
+  @Column({ name: 'original_filename', type: 'varchar', length: 255 })
+  originalFilename: string | null;
+
   @Column({ type: 'varchar', length: 255 })
   hash: string;
 

--- a/src/enums/file-import-type.ts
+++ b/src/enums/file-import-type.ts
@@ -1,0 +1,6 @@
+export enum FileImportType {
+  Dimension = 'dimension',
+  DataTable = 'data_table',
+  Measure = 'measure',
+  Unknown = 'unknown'
+}

--- a/src/interfaces/datalake-file-entry.ts
+++ b/src/interfaces/datalake-file-entry.ts
@@ -1,0 +1,5 @@
+export interface DataLakeFileEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}

--- a/src/interfaces/storage-service.ts
+++ b/src/interfaces/storage-service.ts
@@ -3,6 +3,7 @@ import { Readable } from 'node:stream';
 import { BlobDeleteIfExistsResponse, BlobServiceClient, BlobUploadCommonResponse } from '@azure/storage-blob';
 import { DataLakeServiceClient, FileUploadResponse, PathDeleteIfExistsResponse } from '@azure/storage-file-datalake';
 import { FileStore } from '../config/file-store.enum';
+import { DataLakeFileEntry } from './datalake-file-entry';
 
 export interface StorageService {
   getType(): FileStore;
@@ -21,5 +22,5 @@ export interface StorageService {
   loadStream(filename: string, directory: string): Promise<Readable>;
   delete(filename: string, directory: string): Promise<BlobDeleteIfExistsResponse | PathDeleteIfExistsResponse>;
   deleteDirectory(directory: string): Promise<void | PathDeleteIfExistsResponse>;
-  listFiles(directory: string): Promise<string[] | Record<string, unknown>[]>;
+  listFiles(directory: string): Promise<string[] | DataLakeFileEntry[]>;
 }

--- a/src/migrations/1743591867626-original-file-on-lookup.ts
+++ b/src/migrations/1743591867626-original-file-on-lookup.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class OriginalFileOnLookup1743591867626 implements MigrationInterface {
+  name = 'OriginalFileOnLookup1743591867626';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "lookup_table"
+            ADD "original_filename" character varying(255)
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "lookup_table" DROP COLUMN "original_filename"
+        `);
+  }
+}

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -42,8 +42,8 @@ import {
   updateSources,
   getDatasetById,
   deleteDraftDatasetById,
-  getEverythingFromDatalake,
-  listAllFilesInDataset
+  listAllFilesInDataset,
+  getAllFilesForDataset
 } from '../controllers/dataset';
 import { rateLimiter } from '../middleware/rate-limiter';
 
@@ -226,7 +226,7 @@ router.patch('/:dataset_id/topics', jsonParser, loadDataset(withDraftAndTopics),
 
 // GET /dataset/:dataset_id/download
 // Downloads everything from the datalake relating to this dataset as a zip file
-router.get('/:dataset_id/download', loadDataset(withDraftForCube), getEverythingFromDatalake);
+router.get('/:dataset_id/download', loadDataset(withDraftForCube), getAllFilesForDataset);
 
 // GET /dataset/:dataset_id/list-files
 // List all the files which are used to build the cube

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -41,7 +41,9 @@ import {
   updateTopics,
   updateSources,
   getDatasetById,
-  deleteDraftDatasetById
+  deleteDraftDatasetById,
+  getEverythingFromDatalake,
+  listAllFilesInDataset
 } from '../controllers/dataset';
 import { rateLimiter } from '../middleware/rate-limiter';
 
@@ -221,3 +223,11 @@ router.get('/:dataset_id/topics', jsonParser, loadDataset(withDraftAndTopics), g
 // PATCH /dataset/:dataset_id/topics
 // Updates the topics for the dataset
 router.patch('/:dataset_id/topics', jsonParser, loadDataset(withDraftAndTopics), updateTopics);
+
+// GET /dataset/:dataset_id/download
+// Downloads everything from the datalake relating to this dataset as a zip file
+router.get('/:dataset_id/download', loadDataset(withDraftForCube), getEverythingFromDatalake);
+
+// GET /dataset/:dataset_id/list-files
+// List all the files which are used to build the cube
+router.get('/:dataset_id/list-files', loadDataset(withDraftForCube), listAllFilesInDataset);

--- a/src/routes/dimension.ts
+++ b/src/routes/dimension.ts
@@ -6,7 +6,9 @@ import multer from 'multer';
 import { logger } from '../utils/logger';
 import {
   attachLookupTableToDimension,
+  downloadDimensionLookupTable,
   getDimensionInfo,
+  getDimensionLookupTableInfo,
   resetDimension,
   sendDimensionPreview,
   updateDimension,
@@ -82,3 +84,7 @@ router.patch('/by-id/:dimension_id', jsonParser, loadDimension(), updateDimensio
 // PATCH /:dataset_id/dimension/by-id/:dimension_id/meta
 // Updates the dimension metadata
 router.patch('/by-id/:dimension_id/metadata', jsonParser, loadDimension(), updateDimensionMetadata);
+
+router.get('/by-id/:dimension_id/lookup', loadDimension(), getDimensionLookupTableInfo);
+
+router.get('/by-id/:dimension_id/lookup/raw', loadDimension(), downloadDimensionLookupTable);

--- a/src/routes/measure.ts
+++ b/src/routes/measure.ts
@@ -5,6 +5,9 @@ import multer from 'multer';
 
 import {
   attachLookupTableToMeasure,
+  downloadMeasureLookupTable,
+  getMeasureInfo,
+  getMeasureLookupTableInfo,
   getPreviewOfMeasure,
   resetMeasure,
   updateMeasureMetadata
@@ -31,3 +34,9 @@ router.get('/preview', getPreviewOfMeasure);
 // PATCH /:dataset_id/dimension/by-id/:dimension_id/meta
 // Updates the dimension metadata
 router.patch('/metadata', jsonParser, updateMeasureMetadata);
+
+router.get('/', getMeasureInfo);
+
+router.get('/lookup', getMeasureLookupTableInfo);
+
+router.get('/lookup/raw', downloadMeasureLookupTable);

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -913,7 +913,7 @@ async function setupDimensions(
                 );
             });
             joinStatements.push(
-              `LEFT JOIN ${dimTable} on "${dimTable}"."${factTableColumn.columnName}"=${FACT_TABLE_NAME}."${factTableColumn.columnName}"`
+              `LEFT JOIN ${dimTable} ON "${dimTable}"."${factTableColumn.columnName}"=${FACT_TABLE_NAME}."${factTableColumn.columnName}" AND "${dimTable}"."language"='#LANG#'`
             );
             orderByStatements.push(`${dimTable}.end_date`);
           } else {

--- a/src/services/datalake-storage.ts
+++ b/src/services/datalake-storage.ts
@@ -15,6 +15,7 @@ import {
 import { FileStore } from '../config/file-store.enum';
 import { StorageService } from '../interfaces/storage-service';
 import { logger as parentLogger } from '../utils/logger';
+import { DataLakeFileEntry } from '../interfaces/datalake-file-entry';
 
 const logger = parentLogger.child({ module: 'DataLake' });
 
@@ -93,15 +94,15 @@ export default class DataLakeStorage implements StorageService {
     return this.getDirectoryClient(directory).deleteIfExists(true);
   }
 
-  public async listFiles(directory: string): Promise<Record<string, unknown>[]> {
+  public async listFiles(directory: string): Promise<DataLakeFileEntry[]> {
     const files = await this.fileSystemClient.listPaths({ path: directory });
-    const fileList = [];
+    const fileList: DataLakeFileEntry[] = [];
 
     for await (const file of files) {
       if (file.name === undefined) {
         continue;
       }
-      fileList.push({ name: basename(file.name), path: file.name, isDirectory: file.isDirectory });
+      fileList.push({ name: basename(file.name), path: file.name, isDirectory: file.isDirectory ?? false });
     }
 
     return fileList;

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -21,6 +21,7 @@ export function convertDataTableToLookupTable(dataTable: DataTable) {
   lookupTable.fileType = dataTable.fileType;
   lookupTable.filename = dataTable.filename;
   lookupTable.mimeType = dataTable.mimeType;
+  lookupTable.originalFilename = dataTable.originalFilename;
   lookupTable.hash = dataTable.hash;
   return lookupTable;
 }

--- a/test/helpers/test-helper.ts
+++ b/test/helpers/test-helper.ts
@@ -133,6 +133,7 @@ const rowRefLookupTable = () => {
   const lookupTable = new LookupTable();
   lookupTable.id = crypto.randomUUID().toLowerCase();
   lookupTable.filename = 'RowRefLookupTable.csv';
+  lookupTable.originalFilename = 'RowRefLookupTable.csv';
   lookupTable.fileType = FileType.Csv;
   lookupTable.isStatsWales2Format = true;
   lookupTable.mimeType = 'text/csv';

--- a/test/routes/view-dataset-contents.test.ts
+++ b/test/routes/view-dataset-contents.test.ts
@@ -85,12 +85,14 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
       'Health Visitor',
       'Average'
     ]);
+    // If this test fails don't just change the output to match.  It's failure implies something in the cube builder
+    // has changed the view significantly.  Probably a broken join statement.
     expect(res.body.data[23]).toEqual([
       24,
-      780,
-      '2021-22',
-      '01/04/2021',
-      '31/03/2022',
+      1007,
+      '2022-23',
+      '01/04/2022',
+      '31/03/2023',
       'Isle of Anglesey',
       'Other Staff',
       null


### PR DESCRIPTION
This improves raw file downloads for measure, dimension and data tables. The first two were completely missing and are now needed now we don't always have direcrt access to the datalake in the client estate.

Also added the option to pull down everything from the datalake for a given dataset.  This is helpful when trying to understand why a given dataset journey has failed.

Added a route to list all the file imports which made up a given dataset.  Again this provides us with extra diagnositic information for the developer page.

Fianlly fixed a small issue in the cube builder where there was a slightly broken join statement on date dimensions as the date dimension table switch from being monolinguagl to multilingual.