### PR TITLE
Add support for parent ids on the fileimport object

### DIFF
--- a/src/dtos/file-import.ts
+++ b/src/dtos/file-import.ts
@@ -8,6 +8,7 @@ export class FileImportDto {
   hash: string;
   uploaded_at?: string;
   type: FileImportType;
+  parent_id?: string;
 
   static fromFileImport(fileImport: FileImportInterface) {
     const dto = new FileImportDto();

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -25,6 +25,7 @@ export const withAll: FindOptionsRelations<Dataset> = {
     revisionTopics: { topic: true }
   },
   revisions: {
+    dataTable: true,
     metadata: true
   }
 };

--- a/src/utils/dataset-controller-utils.ts
+++ b/src/utils/dataset-controller-utils.ts
@@ -34,12 +34,14 @@ export const collectFiles = (dataset: Dataset): Map<string, FileImportDto> => {
   if (dataset.measure.lookupTable) {
     const fileImport = FileImportDto.fromFileImport(dataset.measure.lookupTable);
     fileImport.type = FileImportType.Measure;
+    fileImport.parent_id = dataset.id;
     files.set(dataset.measure.lookupTable.filename, fileImport);
   }
   dataset.dimensions.forEach((dimension) => {
     if (dimension.lookupTable) {
       const fileImport = FileImportDto.fromFileImport(dimension.lookupTable);
       fileImport.type = FileImportType.Dimension;
+      fileImport.parent_id = dimension.id;
       files.set(dimension.lookupTable.filename, fileImport);
     }
   });
@@ -47,6 +49,7 @@ export const collectFiles = (dataset: Dataset): Map<string, FileImportDto> => {
     if (revision.dataTable) {
       const fileImport = FileImportDto.fromFileImport(revision.dataTable);
       fileImport.type = FileImportType.DataTable;
+      fileImport.parent_id = revision.id;
       files.set(revision.dataTable.filename, fileImport);
     }
   });


### PR DESCRIPTION
Small PR to add support for parent ids on the file list object to save having to look for the parent id when the frontend consumes this.

Also expanded the all option to include the revisions data table. This has useful information for the developer view.