### PR TITLE
SW-567 - Fix translations task labels for unchanged revisions

### DIFF
--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -168,6 +168,21 @@ export class TasklistStateDTO {
     revision: Revision,
     translationEvents?: EventLog[]
   ): TranslationStatus {
+    const isUpdate = Boolean(revision.previousRevisionId);
+
+    if (isUpdate && revision.previousRevision) {
+      const newTranslations = collectTranslations(dataset);
+      const previousTranslations = collectTranslations(dataset, false, revision.previousRevision);
+
+      // Compare draft revision with previous version
+      if (isEqual(newTranslations, previousTranslations)) {
+        return {
+          import: TaskStatus.Unchanged,
+          export: TaskStatus.Unchanged
+        };
+      }
+    }
+
     const lastExportedAt = translationEvents?.find((event) => event.action === 'export')?.createdAt;
     const lastImportedAt = translationEvents?.find((event) => event.action === 'import')?.createdAt;
 

--- a/src/utils/collect-translations.ts
+++ b/src/utils/collect-translations.ts
@@ -1,11 +1,12 @@
+import { Revision } from '../entities/dataset/revision';
 import { RelatedLink } from '../dtos/related-link-dto';
 import { TranslationDTO } from '../dtos/translations-dto';
 import { Dataset } from '../entities/dataset/dataset';
 import { translatableMetadataKeys } from '../types/translatable-metadata';
 import { pick } from 'lodash';
 
-export const collectTranslations = (dataset: Dataset, includeIds = false): TranslationDTO[] => {
-  const revision = dataset.draftRevision!;
+export const collectTranslations = (dataset: Dataset, includeIds = false, revision?: Revision): TranslationDTO[] => {
+  revision = revision || dataset.draftRevision!;
   const metadataEN = revision.metadata?.find((meta) => meta.language.includes('en'));
   const metadataCY = revision.metadata?.find((meta) => meta.language.includes('cy'));
 


### PR DESCRIPTION
* Updated collectTranslations helper to accept an optional revision to process
* Updated translationStatus dto to return `unchaged` early if translations from draft and previous version match