### PR TITLE
Switch docker-compose and predev to use Valkey

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: statswales-backend-test
 
-  redis:
-    image: redis:latest
+  valkey:
+    image: valkey/valkey:latest
     ports:
       - "6379:6379"
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest --coverage",
     "test:ci": "jest --ci --coverage --config=jest.config.ts",
     "check": "npm-run-all prettier:fix lint:fix test build",
-    "predev": "bash -c ' func() { if [ $(command -v podman) ]; then podman compose up -d db-dev redis; else docker compose up -d db-dev redis; fi }; func'",
+    "predev": "bash -c ' func() { if [ $(command -v podman) ]; then podman compose up -d db-dev valkey; else docker compose up -d db-dev valkey; fi }; func'",
     "dev:check": "npm-run-all check dev",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts | pino-colada",
     "start": "node dist/server.js",


### PR DESCRIPTION
As we're moving towards using Valkey in our environments its probably a good idea that we're testing and developing against Valkey locally. This PR just updates the docker-compose and package.json to use Valkey instead of Redis.