### PR TITLE
SW-647 - Check related links when checking translations

### DIFF
--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -219,17 +219,20 @@ export class TasklistStateDTO {
     });
 
     const translationRequired = !metadataSynced || !metaFullyTranslated;
-    const exportStatus = lastExportedAt
-      ? exportStale
-        ? TaskStatus.Incomplete
-        : TaskStatus.Completed
-      : TaskStatus.NotStarted;
-    const importStatus =
-      lastImportedAt && lastImportedAt > lastMetaUpdateAt
-        ? exportStale || !relatedLinksTranslated
-          ? TaskStatus.Incomplete
-          : TaskStatus.Completed
-        : TaskStatus.NotStarted;
+
+    let exportStatus: TaskStatus;
+    if (lastExportedAt) {
+      exportStatus = exportStale ? TaskStatus.Incomplete : TaskStatus.Completed;
+    } else {
+      exportStatus = TaskStatus.NotStarted;
+    }
+
+    let importStatus: TaskStatus;
+    if (lastImportedAt && lastImportedAt > lastMetaUpdateAt) {
+      importStatus = exportStale || !relatedLinksTranslated ? TaskStatus.Incomplete : TaskStatus.Completed;
+    } else {
+      importStatus = TaskStatus.NotStarted;
+    }
 
     return {
       export: translationRequired ? exportStatus : TaskStatus.NotRequired,

--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -203,6 +203,10 @@ export class TasklistStateDTO {
       });
     });
 
+    const relatedLinksTranslated = every(revision.relatedLinks, (link) => {
+      return link.labelEN && link.labelCY;
+    });
+
     const lastExport = translationEvents?.find((event) => event.action === 'export');
 
     const existingTranslations = collectTranslations(dataset);
@@ -221,7 +225,11 @@ export class TasklistStateDTO {
         : TaskStatus.Completed
       : TaskStatus.NotStarted;
     const importStatus =
-      lastImportedAt && lastImportedAt > lastMetaUpdateAt ? TaskStatus.Completed : TaskStatus.NotStarted;
+      lastImportedAt && lastImportedAt > lastMetaUpdateAt
+        ? exportStale || !relatedLinksTranslated
+          ? TaskStatus.Incomplete
+          : TaskStatus.Completed
+        : TaskStatus.NotStarted;
 
     return {
       export: translationRequired ? exportStatus : TaskStatus.NotRequired,


### PR DESCRIPTION
* Updated task-state-dto to check translations are included for related links. Show incomplete label if any are missing