### PR TITLE
Move to using tsconfig bases for our tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@faker-js/faker": "^9.3.0",
+        "@tsconfig/node22": "^22.0.1",
         "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
@@ -2093,6 +2094,13 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.1.tgz",
+      "integrity": "sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@faker-js/faker": "^9.3.0",
+    "@tsconfig/node22": "^22.0.1",
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "@tsconfig/node22/tsconfig.json",
   "exclude": ["./coverage", "./dist", "./test", "jest.config.ts", "eslint.config.mjs", "./tools"],
   "compilerOptions": {
-    /* Projects */
-    /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "lib": [
-      "es6"
-    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-    /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "src" /* Specify the root folder within your source files. */,
     "resolveJsonModule": true /* Enable importing .json files. */,
     /* JavaScript Support */
@@ -16,13 +9,10 @@
     /* Emit */
     "outDir": "dist" /* Specify an output folder for all emitted files. */,
     /* Interop Constraints */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     /* Completeness */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "strictPropertyInitialization": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Some small config changes to move to using tsconfig bases.  This gives us a more recent version of JavaScript to compile to and a number of other languague benefits.  The base specifically targets node22 the version we're using.