### PR TITLE
Fix protocube saving

### DIFF
--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -82,6 +82,7 @@ export interface AppConfig {
   duckdb: {
     threads: number;
     memory: string;
+    writeTimeOut: number;
   };
 }
 

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -85,7 +85,8 @@ export const getDefaultConfig = (): AppConfig => {
     },
     duckdb: {
       threads: process.env.DUCKDB_THREADS ? parseInt(process.env.DUCKDB_THREADS, 10) : 1,
-      memory: process.env.DUCKDB_MEMORY || '125MB'
+      memory: process.env.DUCKDB_MEMORY || '125MB',
+      writeTimeOut: process.env.DUCKDB_WRITE_TIMEOUT ? parseInt(process.env.DUCKDB_WRITE_TIMEOUT, 10) : 150
     }
   };
 };

--- a/src/config/envs/local.ts
+++ b/src/config/envs/local.ts
@@ -50,7 +50,8 @@ export function getLocalConfig(): AppConfig {
     },
     duckdb: {
       threads: process.env.DUCKDB_THREADS ? parseInt(process.env.DUCKDB_THREADS, 10) : 1,
-      memory: process.env.DUCKDB_MEMORY || '125MB'
+      memory: process.env.DUCKDB_MEMORY || '125MB',
+      writeTimeOut: process.env.DUCKDB_WRITE_TIMEOUT ? parseInt(process.env.DUCKDB_WRITE_TIMEOUT, 10) : 150
     },
     storage: {
       store: (process.env.FILE_STORE as FileStore) || FileStore.DataLake

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -330,7 +330,7 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     });
     return;
   }
-  let duckdbFile;
+  let duckdbFile: string;
   try {
     duckdbFile = await factTableValidatorFromSource(dataset, validatedSourceAssignment);
   } catch (err) {
@@ -354,10 +354,12 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     return;
   }
   try {
+    logger.debug(`Saving duckdb file to blob storage: ${duckdbFile}`);
     const buffer = fs.readFileSync(duckdbFile);
+    logger.debug(`Buffer size: ${buffer.byteLength} bytes`);
     await req.fileService.saveBuffer(`${revision.id}-protocube.duckdb`, dataset.id, buffer);
     revision.onlineCubeFilename = `${revision.id}-protocube.duckdb`;
-    fs.unlinkSync(duckdbFile);
+    //fs.unlinkSync(duckdbFile);
     await revision.save();
   } catch (err) {
     logger.error(err, 'Failed to save duckdb file to blob storage');

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -359,7 +359,7 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     logger.debug(`Buffer size: ${buffer.byteLength} bytes`);
     await req.fileService.saveBuffer(`${revision.id}-protocube.duckdb`, dataset.id, buffer);
     revision.onlineCubeFilename = `${revision.id}-protocube.duckdb`;
-    //fs.unlinkSync(duckdbFile);
+    fs.unlinkSync(duckdbFile);
     await revision.save();
   } catch (err) {
     logger.error(err, 'Failed to save duckdb file to blob storage');

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -33,7 +33,7 @@ import { RevisionRepository } from '../repositories/revision';
 import { PeriodCovered } from '../interfaces/period-covered';
 
 import { dateDimensionReferenceTableCreator } from './time-matching';
-import { duckdb } from './duckdb';
+import {duckdb, DUCKDB_WRITE_TIMEOUT} from './duckdb';
 import { NumberExtractor, NumberType } from '../extractors/number-extractor';
 import { CubeValidationType } from '../enums/cube-validation-type';
 import { languageMatcherCaseStatement } from '../utils/lookup-table-utils';
@@ -1214,7 +1214,8 @@ export const createBaseCube = async (datasetId: string, endRevisionId: string): 
 
   logger.debug('Creating an in-memory database to hold the cube using DuckDB 🐤');
   const buildStart = performance.now();
-  const quack = await duckdb();
+  const tmpFile = tmp.tmpNameSync({ postfix: '.duckdb' });
+  const quack = await duckdb(tmpFile);
 
   const { measureColumn, notesCodeColumn, dataValuesColumn, factTableDef, factIdentifiers } =
     await createEmptyFactTableInCube(quack, dataset);
@@ -1303,32 +1304,12 @@ export const createBaseCube = async (datasetId: string, endRevisionId: string): 
     logger.debug(rawViewSQL);
     await quack.exec(rawViewSQL);
   }
-  const tmpFile = tmp.tmpNameSync({ postfix: '.db' });
-  try {
-    logger.debug(`Writing memory database to disk at ${tmpFile}`);
-    await quack.exec(`ATTACH '${tmpFile}' as outDB (BLOCK_SIZE 16384);`);
-    await quack.exec(`COPY FROM DATABASE memory TO outDB;`);
-    await quack.exec('DETACH outDB;');
-  } catch (err) {
-    logger.error(err, `Failed to write memory database to disk with error: ${err}`);
-    const error = new CubeValidationException('Failed to write memory database to disk');
-    error.type = CubeValidationType.CubeCreationFailed;
-    throw error;
-  } finally {
-    const end = performance.now();
-    const functionTime = Math.round(end - functionStart);
-    const buildTime = Math.round(end - buildStart);
-    logger.warn(`Cube function took ${functionTime}ms to complete and it took ${buildTime}ms to build the cube.`);
-    await quack.close();
-  }
-  // Pass the file handle to the calling method
-  // If used for preview you just want the file
-  // If it's the end of the publishing step you'll
-  // want to upload the file to the data lake.
   const end = performance.now();
   const functionTime = Math.round(end - functionStart);
   const buildTime = Math.round(end - buildStart);
   logger.warn(`Cube function took ${functionTime}ms to complete and it took ${buildTime}ms to build the cube.`);
+  await quack.close();
+  await new Promise((f) => setTimeout(f, DUCKDB_WRITE_TIMEOUT));
   return tmpFile;
 };
 
@@ -1487,6 +1468,7 @@ export const createBaseCubeFromProtoCube = async (
   const functionTime = Math.round(end - functionStart);
   const buildTime = Math.round(end - buildStart);
   logger.warn(`Cube function took ${functionTime}ms to complete and it took ${buildTime}ms to build the cube.`);
+  await new Promise((f) => setTimeout(f, DUCKDB_WRITE_TIMEOUT));
   return protoCubeFile;
 };
 

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -33,7 +33,7 @@ import { RevisionRepository } from '../repositories/revision';
 import { PeriodCovered } from '../interfaces/period-covered';
 
 import { dateDimensionReferenceTableCreator } from './time-matching';
-import {duckdb, DUCKDB_WRITE_TIMEOUT} from './duckdb';
+import { duckdb, DUCKDB_WRITE_TIMEOUT } from './duckdb';
 import { NumberExtractor, NumberType } from '../extractors/number-extractor';
 import { CubeValidationType } from '../enums/cube-validation-type';
 import { languageMatcherCaseStatement } from '../utils/lookup-table-utils';

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -7,6 +7,8 @@ const logger = parentLogger.child({ module: 'DuckDB' });
 
 const config = appConfig();
 
+export const DUCKDB_WRITE_TIMEOUT = 250;
+
 export const duckdb = async (cubeFile = ':memory:') => {
   logger.info(
     `Creating DuckDB instance with ${config.duckdb.threads} thread(s) and ${config.duckdb.memory} memory limit.`

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -9,6 +9,11 @@ const config = appConfig();
 
 export const DUCKDB_WRITE_TIMEOUT = config.duckdb.writeTimeOut;
 
+export const safelyCloseDuckDb = async (quack: Database) => {
+  await quack.close();
+  return new Promise((f) => setTimeout(f, DUCKDB_WRITE_TIMEOUT));
+};
+
 export const duckdb = async (cubeFile = ':memory:') => {
   logger.info(
     `Creating DuckDB instance with ${config.duckdb.threads} thread(s) and ${config.duckdb.memory} memory limit.`

--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -7,7 +7,7 @@ const logger = parentLogger.child({ module: 'DuckDB' });
 
 const config = appConfig();
 
-export const DUCKDB_WRITE_TIMEOUT = 250;
+export const DUCKDB_WRITE_TIMEOUT = config.duckdb.writeTimeOut;
 
 export const duckdb = async (cubeFile = ':memory:') => {
   logger.info(

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -2,7 +2,7 @@ import tmp from 'tmp';
 
 import { ValidatedSourceAssignment } from './dimension-processor';
 import { Dataset } from '../entities/dataset/dataset';
-import { duckdb, DUCKDB_WRITE_TIMEOUT } from './duckdb';
+import { duckdb, safelyCloseDuckDb } from './duckdb';
 import { FactTableColumn } from '../entities/dataset/fact-table-column';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { logger } from '../utils/logger';
@@ -147,8 +147,7 @@ export const factTableValidatorFromSource = async (
     }
   } finally {
     logger.debug('Closing duckdb database');
-    await quack.close();
-    await new Promise((f) => setTimeout(f, DUCKDB_WRITE_TIMEOUT));
+    await safelyCloseDuckDb(quack);
     logger.debug('Duckdb Closed');
   }
   return duckdbSaveFile;

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -2,7 +2,7 @@ import tmp from 'tmp';
 
 import { ValidatedSourceAssignment } from './dimension-processor';
 import { Dataset } from '../entities/dataset/dataset';
-import {duckdb, DUCKDB_WRITE_TIMEOUT} from './duckdb';
+import { duckdb, DUCKDB_WRITE_TIMEOUT } from './duckdb';
 import { FactTableColumn } from '../entities/dataset/fact-table-column';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { logger } from '../utils/logger';
@@ -136,12 +136,6 @@ export const factTableValidatorFromSource = async (
     await loadFileIntoCube(quack, dataTable, dataTableFile, 'data_table');
     await loadTableDataIntoFactTable(quack, factTableDef, FACT_TABLE_NAME, 'data_table');
     await quack.exec('DROP TABLE data_table;');
-    // const databases = await quack.all('SELECT database_name FROM duckdb_databases() WHERE database_name NOT IN (\'memory\', \'system\', \'temp\');');
-    // const dbName = databases[0].database_name;
-    // logger.debug(`Writing database ${dbName} to disk at ${duckdbSaveFile}`);
-    // await quack.exec(`ATTACH '${duckdbSaveFile}' as outDB (BLOCK_SIZE 16384);`);
-    // await quack.exec(`COPY FROM DATABASE "${dbName}" TO outDB;`);
-    // await quack.exec('DETACH outDB;');
   } catch (err) {
     let error = err as FactTableValidationException;
     logger.error(error, 'Failed to load data table into fact table');
@@ -182,7 +176,6 @@ async function identifyDuplicateFacts(
   quack: Database,
   primaryKeyDef: string[],
   error: FactTableValidationException
-
 ): Promise<FactTableValidationException> {
   try {
     const brokenFacts = await quack.all(`


### PR DESCRIPTION
It appears then when you do `ducked.close()` it returns before ducked finishes cleaning up its temp which can result in an empty duckdb file being written to the data lake.  This is especially important as we now partially build the cube once the column sources stage has been completed and use this protocube for previews and and dimension/measure validation.