### PR TITLE
SW-640: Select group that owns the dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "migration:create": "npm run typeorm migration:create",
     "seed:required": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/*.ts",
     "seed:e2e": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./test/fixtures/seed-test-fixtures.ts",
-    "seed:ci": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./test/fixtures/seed-test-fixtures.ts"
+    "seed:ci": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./test/fixtures/seed-test-fixtures.ts",
+    "assign-default-group": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/groups.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/config/envs/local.ts
+++ b/src/config/envs/local.ts
@@ -40,7 +40,7 @@ export function getLocalConfig(): AppConfig {
       windowMs: -1 // disable rate limiting on local
     },
     auth: {
-      providers: [AuthProvider.Google, AuthProvider.EntraId, AuthProvider.Local],
+      providers: [AuthProvider.EntraId],
       jwt: {
         secret: process.env.JWT_SECRET || 'jwtsecret',
         expiresIn: process.env.JWT_EXPIRES_IN || '6h',

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -8,15 +8,16 @@ import { Repository } from 'typeorm';
 import { appConfig } from '../config';
 import { logger } from '../utils/logger';
 import { User } from '../entities/user/user';
-import { sanitiseUser } from '../utils/sanitise-user';
 import { AuthProvider } from '../enums/auth-providers';
 import { dataSource } from '../db/data-source';
+import { UserDTO } from '../dtos/user/user-dto';
+import { Locale } from '../enums/locale';
 
 const config = appConfig();
 const domain = new URL(config.auth.jwt.cookieDomain).hostname;
 logger.debug(`JWT cookie domain is '${domain}'`);
 
-// TODO: remove once EntraID is available for WG users
+// should only ever be used in testing environments
 export const loginLocal: RequestHandler = async (req, res) => {
   logger.debug('auth request from local form received');
 
@@ -36,7 +37,7 @@ export const loginLocal: RequestHandler = async (req, res) => {
     logger.debug('existing user found');
 
     logger.info('local auth successful, creating JWT and returning user to the frontend');
-    const payload = { user: sanitiseUser(user) };
+    const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
     const { secret, expiresIn, secure } = config.auth.jwt;
     const token = jwt.sign(payload, secret, { expiresIn });
 
@@ -69,7 +70,7 @@ export const loginGoogle: RequestHandler = (req, res, next) => {
 
       logger.info('google auth successful, creating JWT and returning user to the frontend');
 
-      const payload = { user: sanitiseUser(user) };
+      const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
 
@@ -100,7 +101,7 @@ export const loginEntraID: RequestHandler = (req, res, next) => {
 
       logger.info('entraid auth successful, creating JWT and returning user to the frontend');
 
-      const payload = { user: sanitiseUser(user) };
+      const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
 

--- a/src/dtos/user/user-dto.ts
+++ b/src/dtos/user/user-dto.ts
@@ -18,9 +18,9 @@ export class UserDTO {
   global_roles: GlobalRole[];
   groups: UserGroupWithRolesDTO[];
   status: UserStatus;
-  created_at: Date;
-  updated_at: Date;
-  last_login_at: Date;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string;
 
   static fromUser(user: User, lang: Locale): UserDTO {
     const dto = new UserDTO();
@@ -33,9 +33,9 @@ export class UserDTO {
     dto.family_name = user.familyName;
     dto.full_name = user.name;
     dto.status = user.status;
-    dto.created_at = user.createdAt;
-    dto.updated_at = user.updatedAt;
-    dto.last_login_at = user.lastLoginAt;
+    dto.created_at = user.createdAt.toISOString();
+    dto.updated_at = user.updatedAt.toISOString();
+    dto.last_login_at = user.lastLoginAt?.toISOString();
 
     dto.global_roles = user.globalRoles?.map((role) => role as GlobalRole) || [];
 

--- a/src/dtos/user/user-dto.ts
+++ b/src/dtos/user/user-dto.ts
@@ -18,8 +18,8 @@ export class UserDTO {
   global_roles: GlobalRole[];
   groups: UserGroupWithRolesDTO[];
   status: UserStatus;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
   last_login_at?: string;
 
   static fromUser(user: User, lang: Locale): UserDTO {
@@ -33,13 +33,13 @@ export class UserDTO {
     dto.family_name = user.familyName;
     dto.full_name = user.name;
     dto.status = user.status;
-    dto.created_at = user.createdAt.toISOString();
-    dto.updated_at = user.updatedAt.toISOString();
+    dto.created_at = user.createdAt?.toISOString();
+    dto.updated_at = user.updatedAt?.toISOString();
     dto.last_login_at = user.lastLoginAt?.toISOString();
 
     dto.global_roles = user.globalRoles?.map((role) => role as GlobalRole) || [];
 
-    dto.groups = user.groupRoles?.map((userRole: UserGroupRole) => {
+    dto.groups = (user.groupRoles || []).map((userRole: UserGroupRole) => {
       return {
         group: UserGroupDTO.fromUserGroup(userRole.group, lang),
         roles: userRole.roles.map((role) => role as GroupRole)

--- a/src/enums/global-role.ts
+++ b/src/enums/global-role.ts
@@ -1,3 +1,4 @@
 export enum GlobalRole {
-  ServiceAdmin = 'service_admin'
+  ServiceAdmin = 'service_admin',
+  Developer = 'developer'
 }

--- a/src/middleware/passport-auth.ts
+++ b/src/middleware/passport-auth.ts
@@ -3,7 +3,7 @@ import { Issuer, Strategy as OpenIdStrategy, TokenSet, UserinfoResponse } from '
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Strategy as JWTStrategy, ExtractJwt } from 'passport-jwt';
 import { DataSource, Repository } from 'typeorm';
-import { isEqual, pick } from 'lodash';
+import { isEqual } from 'lodash';
 
 import { logger } from '../utils/logger';
 import { User } from '../entities/user/user';
@@ -12,6 +12,7 @@ import { AuthProvider } from '../enums/auth-providers';
 import { asyncLocalStorage } from '../services/async-local-storage';
 import { Locale } from '../enums/locale';
 import { UserDTO } from '../dtos/user/user-dto';
+import { getPermissionsForUser } from '../utils/get-permissions-for-user';
 
 const config = appConfig();
 
@@ -75,16 +76,14 @@ const initJwt = async (userRepository: Repository<User>, jwtConfig: Record<strin
             return;
           }
 
-          // convert user dto to a plain object so we can compare with jwt payload
-          const refreshedUser = JSON.parse(JSON.stringify(UserDTO.fromUser(user, Locale.English)));
-
           // compare the props that control permissions and force reauthentication if they are different
-          const permissionsProps = ['id', 'global_roles', 'groups', 'status'];
-          const jwtPerms = pick(jwtUser, permissionsProps);
-          const activePerms = pick(refreshedUser, permissionsProps);
+          // need to jsonify user object to convert to plain object for comparison
+          const refreshedUser = JSON.parse(JSON.stringify(UserDTO.fromUser(user, Locale.English)));
+          const activePerms = getPermissionsForUser(refreshedUser);
+          const jwtPerms = getPermissionsForUser(jwtUser);
 
           if (!isEqual(jwtPerms, activePerms)) {
-            logger.warn('User permissions have changed, user should re-authenticate');
+            logger.warn({ jwtPerms, activePerms }, 'User permissions have changed, user should re-authenticate');
             done(null, undefined, { message: 'User permissions have changed, please re-authenticate' });
             return;
           }

--- a/src/middleware/passport-auth.ts
+++ b/src/middleware/passport-auth.ts
@@ -85,8 +85,8 @@ const initJwt = async (userRepository: Repository<User>, jwtConfig: Record<strin
 
           if (!isEqual(jwtPerms, activePerms)) {
             logger.warn('User permissions have changed, user should re-authenticate');
-            // done(null, undefined, { message: 'User permissions have changed, please re-authenticate' });
-            // return;
+            done(null, undefined, { message: 'User permissions have changed, please re-authenticate' });
+            return;
           }
 
           // store the user context for code that does not have access to the request object

--- a/src/middleware/passport-auth.ts
+++ b/src/middleware/passport-auth.ts
@@ -60,7 +60,10 @@ const initJwt = async (userRepository: Repository<User>, jwtConfig: Record<strin
         logger.debug('authenticating request with JWT...');
 
         try {
-          const user = await userRepository.findOneBy({ id: jwtPayload?.user?.id });
+          const user = await userRepository.findOne({
+            where: { id: jwtPayload?.user?.id },
+            relations: { groupRoles: { group: true } }
+          });
 
           if (!user) {
             logger.error('jwt auth failed: user account could not be found');
@@ -114,14 +117,18 @@ const initEntraId = async (userRepository: Repository<User>, entraIdConfig: Reco
         }
 
         try {
-          // TODO: EntraID only provides full name, we might want to avoid splitting it?
+          // EntraID seems to only provide full name, splitting it this way might not give us the correct
+          // given/family name order depending on the user's culture
           const [givenName, familyName] = userInfo.name ? userInfo.name.split(' ') : [undefined, undefined];
 
           logger.debug('checking if user has previously logged in...');
 
-          const existingUserById = await userRepository.findOneBy({
-            provider: AuthProvider.EntraId,
-            providerUserId: userInfo.sub
+          const existingUserById = await userRepository.findOne({
+            where: {
+              provider: AuthProvider.EntraId,
+              providerUserId: userInfo.sub
+            },
+            relations: { groupRoles: { group: true } }
           });
 
           if (existingUserById) {
@@ -141,7 +148,10 @@ const initEntraId = async (userRepository: Repository<User>, entraIdConfig: Reco
           }
 
           logger.debug('no previous login found, falling back to email...');
-          const existingUserByEmail = await userRepository.findOneBy({ email: userInfo.email });
+          const existingUserByEmail = await userRepository.findOne({
+            where: { email: userInfo.email },
+            relations: { groupRoles: { group: true } }
+          });
 
           if (existingUserByEmail) {
             logger.debug('user found by email, associating user record with entraid account');
@@ -186,46 +196,61 @@ const initGoogle = async (userRepository: Repository<User>, googleConfig: Record
       async (accessToken, refreshToken, profile, done): Promise<void> => {
         logger.debug('auth callback from google received');
 
-        if (!profile?._json?.email) {
-          logger.error('google auth failed: account has no email address');
-          done(null, undefined, {
-            message: 'google account does not have an email, use another provider'
-          });
+        if (!profile?.id || !profile?._json?.email) {
+          logger.error('google auth failed: account is missing user id or email address and we need both');
+          done(null, undefined, { message: 'google account does not have a user id or email, cannot login' });
           return;
         }
 
         try {
           logger.debug('checking if user has previously logged in...');
-          const existingUser = await userRepository.findOneBy({ email: profile._json.email });
+          const existingUserById = await userRepository.findOne({
+            where: {
+              provider: AuthProvider.Google,
+              providerUserId: profile?.id
+            },
+            relations: { groupRoles: { group: true } }
+          });
 
-          if (existingUser && existingUser.provider !== 'google') {
-            logger.warn(`google: email was previously used via another provider (${existingUser.provider})`);
+          if (existingUserById) {
+            logger.debug('user found by provider id, updating user record with latest details from google');
 
-            // TODO: find a better way to merge providers rather than overwriting
-            existingUser.provider = 'google';
-            existingUser.providerUserId = profile.id;
-            existingUser.lastLoginAt = new Date();
-            await existingUser.save();
-            done(null, existingUser);
+            await userRepository
+              .merge(existingUserById, {
+                email: profile._json.email,
+                givenName: profile.name?.givenName,
+                familyName: profile.name?.familyName,
+                lastLoginAt: new Date()
+              })
+              .save();
+
+            done(null, existingUserById);
             return;
           }
 
-          if (!existingUser) {
-            logger.debug('no previous login found, creating new user');
+          logger.debug('no previous login found, falling back to email...');
+          const existingUserByEmail = await userRepository.findOne({
+            where: { email: profile._json.email },
+            relations: { groupRoles: { group: true } }
+          });
 
-            const user = await userRepository.save({
-              provider: 'google',
-              providerUserId: profile.id,
-              email: profile._json.email,
-              givenName: profile.name?.givenName,
-              familyName: profile.name?.familyName,
-              lastLoginAt: new Date()
-            });
-            done(null, user);
-            return;
+          if (existingUserByEmail) {
+            logger.debug('user found by email, associating user record with google account');
+
+            await userRepository
+              .merge(existingUserByEmail, {
+                provider: AuthProvider.Google,
+                providerUserId: profile.id,
+                givenName: profile.name?.givenName,
+                familyName: profile.name?.familyName,
+                lastLoginAt: new Date()
+              })
+              .save();
           }
-          logger.debug('existing user found');
-          done(null, existingUser);
+
+          logger.error('No matching user found, cannot log in');
+          done(null, undefined, { message: 'User not recognised' });
+          return;
         } catch (error) {
           logger.error(error);
           done(null, undefined, { message: 'Unknown error' });

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -52,7 +52,7 @@ export const UserRepository = dataSource.getRepository(User).extend({
     await this.manager.transaction(async (transactionEm) => {
       const user = await transactionEm.findOneOrFail(User, {
         where: { id: userId },
-        relations: { groupRoles: true }
+        relations: { groupRoles: { group: true } }
       });
 
       // delete all existing group roles

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -52,7 +52,7 @@ export const UserRepository = dataSource.getRepository(User).extend({
     await this.manager.transaction(async (transactionEm) => {
       const user = await transactionEm.findOneOrFail(User, {
         where: { id: userId },
-        relations: { groupRoles: { group: true } }
+        relations: { groupRoles: { group: { metadata: true } } }
       });
 
       // delete all existing group roles

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -18,7 +18,7 @@ if (config.auth.providers.includes(AuthProvider.EntraId)) {
   auth.get('/entraid/callback', loginEntraID);
 }
 
-// TODO: remove once EntraID is available for WG users
+// Should only be used in testing environments
 if (config.auth.providers.includes(AuthProvider.Local)) {
   auth.get('/local', loginLocal);
 }

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -2,12 +2,13 @@ import { Request, Response, Router } from 'express';
 import passport from 'passport';
 import { isString } from 'lodash';
 
-import { sanitiseUser } from '../utils/sanitise-user';
 import { User } from '../entities/user/user';
 import { dataSource } from '../db/data-source';
 import { logger } from '../utils/logger';
 import { SUPPORTED_LOCALES } from '../middleware/translation';
 import { StorageService } from '../interfaces/storage-service';
+import { Locale } from '../enums/locale';
+import { UserDTO } from '../dtos/user/user-dto';
 
 const healthcheck = Router();
 
@@ -59,7 +60,7 @@ healthcheck.get('/language', (req, res) => {
 
 // for testing jwt auth is working
 healthcheck.get('/jwt', passport.authenticate('jwt', { session: false }), (req, res) => {
-  res.json({ message: 'success', user: sanitiseUser(req.user as User) });
+  res.json({ message: 'success', user: UserDTO.fromUser(req.user as User, req.language as Locale) });
 });
 
 export const healthcheckRouter = healthcheck;

--- a/src/seeders/groups.ts
+++ b/src/seeders/groups.ts
@@ -1,0 +1,33 @@
+import { Seeder } from '@jorgebodega/typeorm-seeding';
+import { DataSource, DeepPartial, IsNull } from 'typeorm';
+
+import { logger } from '../utils/logger';
+import { Locale } from '../enums/locale';
+import { UserGroup } from '../entities/user/user-group';
+import { Dataset } from '../entities/dataset/dataset';
+
+// using hard coded uuids so that we can re-run the seeder for updates without creating new records
+const stage1Group: DeepPartial<UserGroup> = {
+  id: '24bf9f9c-898a-4d23-ae1e-35a6ff30ee63',
+  metadata: [
+    { name: 'Cam 1', email: 'cam1@example.com', language: Locale.WelshGb },
+    { name: 'Stage 1', email: 'stage1@example.com', language: Locale.EnglishGb }
+  ]
+};
+
+const defaultGroups: DeepPartial<UserGroup>[] = [stage1Group];
+
+export default class UserGroupSeeder extends Seeder {
+  async run(dataSource: DataSource): Promise<void> {
+    await this.seedUserGroups(dataSource);
+  }
+
+  async seedUserGroups(dataSource: DataSource): Promise<UserGroup[]> {
+    const savedGroups = await dataSource.getRepository(UserGroup).save(defaultGroups);
+
+    logger.info('assigning any unassigned datasets to the stage 1 group');
+    await dataSource.getRepository(Dataset).update({ userGroupId: IsNull() }, { userGroupId: stage1Group.id });
+
+    return savedGroups;
+  }
+}

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -40,10 +40,10 @@ export class DatasetService {
     this.lang = lang;
   }
 
-  async createNew(title: string, createdBy: User): Promise<Dataset> {
+  async createNew(title: string, userGroupId: string, createdBy: User): Promise<Dataset> {
     logger.info(`Creating new dataset...`);
 
-    const dataset = await DatasetRepository.create({ createdBy }).save();
+    const dataset = await DatasetRepository.create({ createdBy, userGroupId }).save();
     const firstRev = await RevisionRepository.create({ dataset, createdBy, revisionIndex: 1 }).save();
     await RevisionRepository.createMetadata(firstRev, title, this.lang);
 

--- a/src/utils/get-permissions-for-user.ts
+++ b/src/utils/get-permissions-for-user.ts
@@ -1,0 +1,10 @@
+import { pick } from 'lodash';
+import { UserDTO } from '../dtos/user/user-dto';
+import { UserGroupWithRolesDTO } from '../dtos/user/user-group-with-roles-dto';
+
+export const getPermissionsForUser = (user: UserDTO) => {
+  return {
+    ...pick(user, ['id', 'global_roles', 'status']),
+    groups: user.groups.map((group: UserGroupWithRolesDTO) => pick(group, 'id', 'roles'))
+  };
+};

--- a/src/utils/sanitise-user.ts
+++ b/src/utils/sanitise-user.ts
@@ -1,8 +1,0 @@
-import { pick } from 'lodash';
-
-import { User } from '../entities/user/user';
-
-// strip anything from the user object that we do not want to expose to the client
-export const sanitiseUser = (user: User): Partial<User> => {
-  return pick(user, ['id', 'email', 'givenName', 'familyName']);
-};

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -23,3 +23,5 @@ export const pageNumberValidator = () => check('page_number').trim().notEmpty().
 export const pageSizeValidator = () => check('page_size').trim().notEmpty().isInt().toInt();
 
 export const userStatusValidator = () => body('status').isIn(Object.values(UserStatus));
+
+export const userGroupIdValidator = (userGroupIds: string[]) => body('user_group_id').isIn(userGroupIds);

--- a/test/helpers/auth-header.ts
+++ b/test/helpers/auth-header.ts
@@ -1,13 +1,14 @@
 import jwt from 'jsonwebtoken';
 
+import { UserDTO } from '../../src/dtos/user/user-dto';
 import { User } from '../../src/entities/user/user';
-import { sanitiseUser } from '../../src/utils/sanitise-user';
 import { appConfig } from '../../src/config';
+import { Locale } from '../../src/enums/locale';
 
 const config = appConfig();
 
 export const getAuthHeader = (user: User) => {
-  const payload = { user: sanitiseUser(user) };
+  const payload = { user: UserDTO.fromUser(user, Locale.English) };
   const token = jwt.sign(payload, config.auth.jwt.secret);
   return { Authorization: `Bearer ${token}` };
 };

--- a/test/helpers/get-test-user.ts
+++ b/test/helpers/get-test-user.ts
@@ -7,7 +7,7 @@ import { User } from '../../src/entities/user/user';
 export const getTestUser = (givenName = 'test', familyName = 'user'): User => {
   const user = new User();
   user.email = `${givenName}.${familyName}@example.com`;
-  user.provider = 'test';
+  user.provider = 'local';
   user.providerUserId = randomUUID().toLowerCase();
   user.givenName = capitalize(givenName);
   user.familyName = capitalize(familyName);

--- a/test/routes/healthcheck.test.ts
+++ b/test/routes/healthcheck.test.ts
@@ -4,13 +4,13 @@ import app from '../../src/app';
 import { initDb } from '../../src/db/init';
 import DatabaseManager from '../../src/db/database-manager';
 import { initPassport } from '../../src/middleware/passport-auth';
-import { sanitiseUser } from '../../src/utils/sanitise-user';
 import { SUPPORTED_LOCALES } from '../../src/middleware/translation';
 import { Locale } from '../../src/enums/locale';
 import { logger } from '../../src/utils/logger';
 
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
+import { UserDTO } from '../../src/dtos/user/user-dto';
 
 jest.mock('../../src/services/blob-storage', () => {
   return function BlobStorage() {
@@ -123,7 +123,7 @@ describe('Healthcheck', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         message: 'success',
-        user: sanitiseUser(testUser)
+        user: UserDTO.fromUser(testUser, Locale.English)
       });
     });
   });

--- a/test/routes/metadata.test.ts
+++ b/test/routes/metadata.test.ts
@@ -22,7 +22,7 @@ import { logger } from '../../src/utils/logger';
 import { withMetadata } from '../../src/repositories/revision';
 
 import { createFullDataset } from '../helpers/test-helper';
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
 import BlobStorage from '../../src/services/blob-storage';
 

--- a/test/routes/provider.test.ts
+++ b/test/routes/provider.test.ts
@@ -10,7 +10,7 @@ import { Provider } from '../../src/entities/dataset/provider';
 import { ProviderSource } from '../../src/entities/dataset/provider-source';
 import { ProviderSourceDTO } from '../../src/dtos/provider-source-dto';
 
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
 
 // Need to mock blob storage as it is included in services middleware for every route

--- a/test/routes/publisher-journey.test.ts
+++ b/test/routes/publisher-journey.test.ts
@@ -25,10 +25,13 @@ import { RevisionRepository } from '../../src/repositories/revision';
 import { RevisionMetadataDTO } from '../../src/dtos/revistion-metadata-dto';
 
 import { createFullDataset, createSmallDataset } from '../helpers/test-helper';
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
 import BlobStorage from '../../src/services/blob-storage';
 import { MAX_PAGE_SIZE, MIN_PAGE_SIZE } from '../../src/validators/preview-validator';
+import { UserGroup } from '../../src/entities/user/user-group';
+import { GroupRole } from '../../src/enums/group-role';
+import { UserGroupRole } from '../../src/entities/user/user-group-role';
 
 jest.mock('../../src/services/blob-storage');
 
@@ -43,6 +46,8 @@ const revision1Id = '85f0e416-8bd1-4946-9e2c-1c958897c6ef';
 const import1Id = 'fa07be9d-3495-432d-8c1f-d0fc6daae359';
 const user: User = getTestUser('test', 'user');
 
+let userGroup: UserGroup;
+
 let datasetService: DatasetService;
 
 describe('API Endpoints', () => {
@@ -51,6 +56,15 @@ describe('API Endpoints', () => {
     try {
       dbManager = await initDb();
       await initPassport(dbManager.getDataSource());
+
+      userGroup = UserGroup.create({
+        metadata: [
+          { name: 'Test', language: Locale.EnglishGb },
+          { name: 'Test CY', language: Locale.WelshGb }
+        ]
+      });
+      await userGroup.save();
+      user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
       await user.save();
       await createFullDataset(dataset1Id, revision1Id, import1Id, user);
       datasetService = new DatasetService(Locale.EnglishGb);
@@ -79,7 +93,7 @@ describe('API Endpoints', () => {
     });
 
     test('Creates and returns a dataset with a title', async () => {
-      const data = { title: 'My test datatset' };
+      const data = { title: 'My test datatset', user_group_id: userGroup.id };
       const res = await request(app).post('/dataset').set(getAuthHeader(user)).send(data);
       expect(res.status).toBe(201);
       const dataset = await DatasetRepository.getById(res.body.id, withDraftAndMetadata);
@@ -87,7 +101,7 @@ describe('API Endpoints', () => {
     });
 
     test('Upload returns 400 if no file attached', async () => {
-      const dataset = await datasetService.createNew('Test Dataset 1', user);
+      const dataset = await datasetService.createNew('Test Dataset 1', userGroup.id, user);
       const res = await request(app).post(`/dataset/${dataset.id}/data`).set(getAuthHeader(user));
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'No CSV data provided' });
@@ -95,7 +109,7 @@ describe('API Endpoints', () => {
     });
 
     test('Upload returns 201 if a file is attached', async () => {
-      const dataset = await datasetService.createNew('Test Dataset 2', user);
+      const dataset = await datasetService.createNew('Test Dataset 2', userGroup.id, user);
       const csvFile = path.resolve(__dirname, `../sample-files/csv/sure-start-short.csv`);
       const res = await request(app)
         .post(`/dataset/${dataset.id}/data`)

--- a/test/routes/topic.test.ts
+++ b/test/routes/topic.test.ts
@@ -9,7 +9,7 @@ import { Topic } from '../../src/entities/dataset/topic';
 import { TopicDTO } from '../../src/dtos/topic-dto';
 import { Locale } from '../../src/enums/locale';
 
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
 
 // Need to mock blob storage as it is included in services middleware for every route

--- a/test/routes/view-dataset-contents.test.ts
+++ b/test/routes/view-dataset-contents.test.ts
@@ -13,7 +13,7 @@ import { DatasetRepository } from '../../src/repositories/dataset';
 import { RevisionRepository } from '../../src/repositories/revision';
 
 import { createFullDataset } from '../helpers/test-helper';
-import { getTestUser } from '../helpers/get-user';
+import { getTestUser } from '../helpers/get-test-user';
 import { getAuthHeader } from '../helpers/auth-header';
 import BlobStorage from '../../src/services/blob-storage';
 


### PR DESCRIPTION
Various fixes around user roles and permissions.

 * Create dataset route now requires an id for the group that owns the dataset
 * The JWT now includes the user's groups and roles for the system
 * If a user's perms change, JWT auth will fail and the user will be required to log in again
 * Updated google auth to keep it in sync with EntraID behaviour