### PR TITLE
Add the checkpoint command when exiting duckdb

### DIFF
--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -10,6 +10,7 @@ const config = appConfig();
 export const DUCKDB_WRITE_TIMEOUT = config.duckdb.writeTimeOut;
 
 export const safelyCloseDuckDb = async (quack: Database) => {
+  await quack.exec(`CHECKPOINT;`);
   await quack.close();
   return new Promise((f) => setTimeout(f, DUCKDB_WRITE_TIMEOUT));
 };


### PR DESCRIPTION
DuckDB has a checkpoint command which tells it sync whats in memory to disk.  I've added this to our safely close duckdb command.  The hope is that we can start experimenting with removing the timeout which waits a set number of milliseconds before returning the DuckDB close function.