### PR TITLE
default db sync to false

### DIFF
--- a/src/config/envs/ci.ts
+++ b/src/config/envs/ci.ts
@@ -35,7 +35,7 @@ export function getCIConfig(): AppConfig {
       password: process.env.TEST_DB_PASSWORD || 'postgres',
       database: process.env.TEST_DB_DATABASE || 'statswales-backend-test',
       ssl: false,
-      synchronize: true
+      synchronize: process.env.TEST_DB_SYNC === 'true' ? true : false
     },
     rateLimit: {
       windowMs: -1 // disable rate limiting in CI

--- a/test/helpers/jest-setup.ts
+++ b/test/helpers/jest-setup.ts
@@ -10,5 +10,6 @@ process.env.TEST_DB_PORT = '5433';
 process.env.TEST_DB_USERNAME = 'postgres';
 process.env.TEST_DB_PASSWORD = 'postgres';
 process.env.TEST_DB_DATABASE = 'statswales-backend-test';
+process.env.TEST_DB_SYNC = 'true';
 
 process.env.APP_ENV = 'ci';


### PR DESCRIPTION
We've added auto-running of migrations to the container startup, so we can disable sync in most instances.

Currently localstack feature in the frontend is broken because it's trying to migrate after the autosync.

We still need it for tests as the db gets dropped between test runs.