### PR TITLE
Fix role change check

### DIFF
--- a/src/utils/get-permissions-for-user.ts
+++ b/src/utils/get-permissions-for-user.ts
@@ -7,20 +7,23 @@ import { UserGroupWithRolesDTO } from '../dtos/user/user-group-with-roles-dto';
 export const getPermissionsForUserDTO = (user: UserDTO) => {
   return {
     ...pick(user, ['id', 'global_roles', 'status']),
-    groups: user.groups.map((group: UserGroupWithRolesDTO) => pick(group, 'id', 'roles'))
+    groups: user.groups.map((ugWithRoles: UserGroupWithRolesDTO) => ({
+      id: ugWithRoles.group.id,
+      roles: ugWithRoles.roles
+    }))
   };
 };
 
 export const getPermissionsForUser = (user: User) => {
   return {
     ...pick(user, ['id', 'global_roles', 'status']),
-    groups: user.groupRoles.map((group: UserGroupRole) => ({
-      id: group.groupId,
-      roles: group.roles
+    groups: user.groupRoles.map((groupRole: UserGroupRole) => ({
+      id: groupRole.groupId,
+      roles: groupRole.roles
     }))
   };
 };
 
 export const getUserGroupIdsForUser = (user: User) => {
-  return user.groupRoles.map((group: UserGroupRole) => group.groupId);
+  return user.groupRoles.map((groupRole: UserGroupRole) => groupRole.groupId);
 };


### PR DESCRIPTION
The role change forced logout was only detecting changes in the number of groups or a difference in roles, and not if you switched to have the same roles at a different group.