### PR TITLE
Fix login issue with match by email

### DIFF
--- a/src/middleware/passport-auth.ts
+++ b/src/middleware/passport-auth.ts
@@ -182,6 +182,9 @@ const initEntraId = async (userRepository: Repository<User>, entraIdConfig: Reco
                 lastLoginAt: new Date()
               })
               .save();
+
+            done(null, existingUserByEmail);
+            return;
           }
 
           logger.error('No matching user found, cannot log in');
@@ -263,6 +266,9 @@ const initGoogle = async (userRepository: Repository<User>, googleConfig: Record
                 lastLoginAt: new Date()
               })
               .save();
+
+            done(null, existingUserByEmail);
+            return;
           }
 
           logger.error('No matching user found, cannot log in');


### PR DESCRIPTION
On the first login where we don't have an Entra user id yet but we do have an email, I'd missed the successful return of the user so that they actually get logged in and instead it was falling through to the "no matching user" error.

The user could re-attempt login and it would be successful the second time around because we were saving the user id on the first attempt.