### PR TITLE
Sw 683 fix maximum call stack size exceeded error

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -393,7 +393,7 @@ export async function createDateDimension(quack: Database, extractor: object | n
   if (!extractor) {
     throw new Error('Extractor not supplied');
   }
-  const columnData = await quack.all(`SELECT "${factTableColumn.columnName}" FROM ${FACT_TABLE_NAME};`);
+  const columnData = await quack.all(`SELECT DISTINCT "${factTableColumn.columnName}" FROM ${FACT_TABLE_NAME};`);
   const dateDimensionTable = dateDimensionReferenceTableCreator(extractor, columnData);
   await quack.exec(createDatePeriodTableQuery(factTableColumn));
   // Create the date_dimension table


### PR DESCRIPTION
When selecting the dates from the data/fact table I missed the DISTINCT call to only give us distinct values.  This exceeded JavaScripts limits for array max and min handling.