### PR TITLE
Make sure there's always a note codes column

### DIFF
--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -135,6 +135,9 @@ export const validateSourceAssignment = (
         throw new SourceAssignmentException(`errors.source_assignment.invalid_source_type`);
     }
   });
+  if (!noteCodes) {
+    throw new SourceAssignmentException('errors.source_assignment.missing_footnotes');
+  }
 
   return { dataValues, measure, noteCodes, dimensions, ignore };
 };


### PR DESCRIPTION
Its been decided to mandate having a notes code column.  This small PR checks for the precense of a notes code column in the source assignment and if its missing throws an exception.