### PR TITLE
revert change to /data route, not ready yet

### DIFF
--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -15,7 +15,6 @@ import {
   withAll,
   withDraftAndProviders,
   withDraftAndTopics,
-  withDraftAndDataTable,
   withDraftAndMeasure
 } from '../repositories/dataset';
 import { datasetIdValidator, hasError } from '../validators';
@@ -140,7 +139,7 @@ router.patch('/:dataset_id/metadata', jsonParser, loadDataset({}), updateMetadat
 
 // GET /dataset/:dataset_id/data
 // Returns the dataset with the current draft revision and data table
-router.get('/:dataset_id/data', loadDataset(withDraftAndDataTable), getDatasetById);
+router.get('/:dataset_id/data', loadDataset(withDraftForCube), getDatasetById);
 
 // POST /dataset/:dataset_id/data
 // Upload a data file to a dataset


### PR DESCRIPTION
/data route is still used by dimensions on the frontend, will remove it in the next perf pass, but for now just revert the change to the /data route.