### PR TITLE
Fix for fact table column names with spaces

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -514,7 +514,7 @@ export async function createLookupTableDimension(quack: Database, dataset: Datas
     const notesStr = extractor.notesColumns ? `"${extractor.notesColumns[0].name}"` : 'NULL';
     const dataExtractorParts = `
       SELECT
-        "${dimension.joinColumn}" as ${factTableColumn.columnName},
+        "${dimension.joinColumn}" as "${factTableColumn.columnName}",
         ${languageMatcher} as language,
         "${extractor.descriptionColumns[0].name}" as description,
         ${notesStr} as notes,

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -104,6 +104,7 @@ function createExtractor(
       notesColumns = protoLookupTable.dataTableDescriptions
         .filter((info) => info.columnName.toLowerCase().startsWith(noteStr))
         .map((info) => columnIdentification(info));
+    if (notesColumns && notesColumns.length === 0) notesColumns = undefined;
     const extractor: LookupTableExtractor = {
       tableLanguage,
       sortColumn: protoLookupTable.dataTableDescriptions.find((info) =>
@@ -155,7 +156,7 @@ export const createLookupTableInCube = async (
       const sortStr = extractor.sortColumn ? `"${extractor.sortColumn}"` : 'NULL';
       const hierarchyCol = extractor.hierarchyColumn ? `"${extractor.hierarchyColumn}"` : 'NULL';
       dataExtractorParts.push(
-        `SELECT "${dimension.joinColumn}" as ${factTableColumn.columnName},
+        `SELECT "${dimension.joinColumn}" as "${factTableColumn.columnName}",
         '${locale.toLowerCase()}' as language,
         ${descriptionColStr} as description,
         ${notesColStr} as notes,
@@ -172,7 +173,7 @@ export const createLookupTableInCube = async (
     const notesStr = extractor.notesColumns ? `"${extractor.notesColumns[0].name}"` : 'NULL';
     const dataExtractorParts = `
       SELECT
-        "${dimension.joinColumn}" as ${factTableColumn.columnName},
+        "${dimension.joinColumn}" as "${factTableColumn.columnName}",
         ${languageMatcher} as language,
         "${extractor.descriptionColumns[0].name}" as description,
         ${notesStr} as notes,

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -213,7 +213,7 @@ export const validateLookupTableReferenceValues = async (
   try {
     logger.debug(`Validating the lookup table`);
     const nonMatchedRows = await quack.all(
-      `SELECT line_number, fact_table_column, "${lookupTableName}".${joinColumn} as lookup_table_column
+      `SELECT line_number, fact_table_column, "${lookupTableName}"."${joinColumn}" as lookup_table_column
             FROM (SELECT row_number() OVER () as line_number, "${factTableColumn}" as fact_table_column FROM
             ${factTableName}) as fact_table LEFT JOIN "${lookupTableName}" ON
             CAST(fact_table.fact_table_column AS VARCHAR)=CAST("${lookupTableName}"."${joinColumn}" AS VARCHAR)
@@ -223,7 +223,7 @@ export const validateLookupTableReferenceValues = async (
     const rows = await quack.all(`SELECT COUNT(*) as total_rows FROM ${factTableName}`);
     if (nonMatchedRows.length === rows[0].total_rows) {
       logger.error(`The user supplied an incorrect lookup table and none of the rows matched`);
-      const nonMatchedFactTableValues = await quack.all(`SELECT DISTINCT ${factTableColumn} FROM ${factTableName};`);
+      const nonMatchedFactTableValues = await quack.all(`SELECT DISTINCT "${factTableColumn}" FROM ${factTableName};`);
       const nonMatchedLookupValues = await quack.all(`SELECT DISTINCT "${joinColumn}" FROM "${lookupTableName}";`);
       return viewErrorGenerators(400, dataset.id, 'patch', `errors.${validationType}_validation.no_reference_match`, {
         totalNonMatching: rows[0].total_rows,


### PR DESCRIPTION
There were still a few places where column names weren't properly quoted resulting in some SQL query failures.  This is the root cause of the bug for SW 707.  Most people have been using StatsWales 2 formats but this was the better StatsWales 3 format but its not been tested as strongly as the other routes.