### PR TITLE
Align frontend views and start to add build log to cube handler

### DIFF
--- a/src/controllers/cube-controller.ts
+++ b/src/controllers/cube-controller.ts
@@ -38,7 +38,7 @@ export const getCubePreview = async (
         dataset_id: dataset.id
       };
     }
-    const previewQuery = `SELECT int_line_number, * FROM (SELECT row_number() OVER () as int_line_number, * FROM default_view_${lang}) LIMIT ${size} OFFSET ${(page - 1) * size}`;
+    const previewQuery = `SELECT * FROM default_view_${lang} LIMIT ${size} OFFSET ${(page - 1) * size}`;
     const preview = await quack.all(previewQuery);
     const startLine = Number(preview[0].int_line_number);
     const lastLine = Number(preview[preview.length - 1].int_line_number);

--- a/src/controllers/cube-controller.ts
+++ b/src/controllers/cube-controller.ts
@@ -36,8 +36,7 @@ export const getCubePreview = async (
       return { status: 400, errors, dataset_id: dataset.id };
     }
     const previewQuery = `
-      SELECT int_line_number, *
-      FROM (SELECT row_number() OVER () as int_line_number, * FROM default_view_${lang})
+      SELECT * FROM default_view_${lang}
       LIMIT ${size}
       OFFSET ${(page - 1) * size}
     `;

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -289,12 +289,14 @@ async function attachUpdateDataTableToRevision(
   revision.dataTable = dataTable;
   const quack = await duckdb();
 
+  const buildLog: string[] = [];
   try {
-    await updateFactTableValidator(quack, dataset, revision);
+    await updateFactTableValidator(quack, dataset, revision, buildLog);
   } catch (err) {
     const error = err as CubeValidationException;
     if (error.type === CubeValidationType.DuplicateFact) {
       error.type = CubeValidationType.UnknownDuplicateFact;
+      error.buildLog = buildLog;
     }
     logger.debug('Closing DuckDB instance');
     const end = performance.now();

--- a/src/enums/cube-validation-type.ts
+++ b/src/enums/cube-validation-type.ts
@@ -1,6 +1,12 @@
 export enum CubeValidationType {
   FactTable = 'fact_table',
+  NoFactTable = 'no_fact_table',
+  FactTableCreateFailed = 'fact_table_create_failed',
   FactTableColumnMissing = 'fact_table_column_missing',
+  UnknownErrLoadingFactTablesFailed = 'loading_fact_tables_failed',
+  NoDataTables = 'no_data_tables',
+  DataLakeError = 'data_lake_error',
+  NoNotesCodeColumn = 'no_notes_code_column',
   DuplicateFact = 'duplicate_fact',
   UnknownDuplicateFact = 'unknown_duplicate_fact',
   Dimension = 'dimension',

--- a/src/exceptions/cube-error-exception.ts
+++ b/src/exceptions/cube-error-exception.ts
@@ -4,9 +4,18 @@ export class CubeValidationException extends Error {
   public type: CubeValidationType;
   public revisionId: string;
   public datasetId: string;
-  public originalError: string;
-  public fact: unknown;
-  constructor(public message: string) {
+  public originalError?: unknown;
+  public buildLog?: string[];
+
+  constructor(
+    public message: string,
+    datasetId: string,
+    revisionId: string,
+    type: CubeValidationType
+  ) {
     super(message);
+    this.datasetId = datasetId;
+    this.revisionId = revisionId;
+    this.type = type;
   }
 }

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -458,7 +458,7 @@ export const validateUpdatedDateDimension = async (
 ): Promise<undefined> => {
   const errors = await validateDateDimension(quack, dataset, dimension, factTableColumn);
   if (errors) {
-    const err = new CubeValidationException('Validation failed');
+    const err = new CubeValidationException('Validation failed', dataset.id, 'unkn', CubeValidationType.Dimension);
     err.type = CubeValidationType.DimensionNonMatchedRows;
     throw err;
   }

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -202,9 +202,12 @@ export const checkForReferenceErrors = async (
     'dimension'
   );
   if (referenceErrors) {
-    const err = new CubeValidationException('Validation failed');
-    err.type = CubeValidationType.DimensionNonMatchedRows;
-    throw err;
+    throw new CubeValidationException(
+      'Validation failed',
+      dataset.id,
+      'unknown',
+      CubeValidationType.DimensionNonMatchedRows
+    );
   }
   return undefined;
 };

--- a/src/utils/create-fact-table.ts
+++ b/src/utils/create-fact-table.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 
 export async function createEmptyCubeWithFactTable(dataset: Dataset): Promise<Database> {
   const draftRevision = dataset.draftRevision;
+  const buildLog: string[] = [];
 
   if (!draftRevision) {
     throw new Error('No draft revision present on the dataset');
@@ -29,7 +30,8 @@ export async function createEmptyCubeWithFactTable(dataset: Dataset): Promise<Da
     try {
       const { notesCodeColumn, dataValuesColumn, factTableDef, factIdentifiers } = await createEmptyFactTableInCube(
         quack,
-        dataset
+        dataset,
+        buildLog
       );
       await loadFactTables(
         quack,
@@ -38,7 +40,8 @@ export async function createEmptyCubeWithFactTable(dataset: Dataset): Promise<Da
         factTableDef,
         dataValuesColumn,
         notesCodeColumn,
-        factIdentifiers
+        factIdentifiers,
+        buildLog
       );
     } catch (error) {
       await quack.close();

--- a/test/routes/view-dataset-contents.test.ts
+++ b/test/routes/view-dataset-contents.test.ts
@@ -72,17 +72,15 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
     expect(res.body.total_pages).toBe(1);
     expect(res.body.page_size).toBe(100);
     expect(res.body.headers).toEqual([
-      { index: -1, name: 'int_line_number', source_type: 'line_number' },
-      { index: 0, name: 'Data Values', source_type: 'unknown' },
-      { index: 1, name: 'YearCode', source_type: 'unknown' },
-      { index: 2, name: 'Start Date', source_type: 'unknown' },
-      { index: 3, name: 'End Date', source_type: 'unknown' },
-      { index: 4, name: 'AreaCode', source_type: 'unknown' },
-      { index: 5, name: 'RowRef', source_type: 'unknown' },
-      { index: 6, name: 'Notes', source_type: 'unknown' }
+      { index: -1, name: 'Data Values', source_type: 'unknown' },
+      { index: 0, name: 'YearCode', source_type: 'unknown' },
+      { index: 1, name: 'Start Date', source_type: 'unknown' },
+      { index: 2, name: 'End Date', source_type: 'unknown' },
+      { index: 3, name: 'AreaCode', source_type: 'unknown' },
+      { index: 4, name: 'RowRef', source_type: 'unknown' },
+      { index: 5, name: 'Notes', source_type: 'unknown' }
     ]);
     expect(res.body.data[0]).toEqual([
-      1,
       4.030567686,
       '2021-22',
       '01/04/2021',
@@ -94,7 +92,6 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
     // If this test fails don't just change the output to match.  It's failure implies something in the cube builder
     // has changed the view significantly.  Probably a broken join statement.
     expect(res.body.data[23]).toEqual([
-      24,
       1007,
       '2022-23',
       '01/04/2022',


### PR DESCRIPTION
The Developer, Consumer and Preview views are now all using the same view so it makes sense to align the views and remove line numbers.

Additionally spent some time adding additional logging and improving some error handling in the cube handler.  Adding a build log we can pass to the frontend to understand why a build has failed and at what point.