### PR TITLE
Update Dockerfile to run apt upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-slim
 
 # Install build tools and ICU libs (adjust as needed for your app)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
     build-essential \
     python3 \
     curl \


### PR DESCRIPTION
Currently we don't upgrade the currently installed packages meaning we're on whatever packages were present when the base image was created.  This should reduce the number of security alerts coming from container image scanning.