### PR TITLE
SW-604: list published topics and datasets

### DIFF
--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -17,6 +17,7 @@ import { outputCube } from './cube-controller';
 import { DuckdbOutputType } from '../enums/duckdb-outputs';
 import { createView } from '../services/consumer-view';
 import { DEFAULT_PAGE_SIZE } from '../services/csv-processor';
+import { TopicDTO } from '../dtos/topic-dto';
 
 export const listPublishedDatasets = async (req: Request, res: Response, next: NextFunction) => {
   logger.info('Listing published datasets...');
@@ -124,4 +125,16 @@ export const downloadPublishedDataset = async (req: Request, res: Response, next
     logger.debug('File stream ended');
     cleanUpCube(cubeFile);
   });
+};
+
+export const listPublishedTopics = async (req: Request, res: Response, next: NextFunction) => {
+  logger.info('fetching topics with at least one published dataset');
+  try {
+    const topics = await PublishedDatasetRepository.listPublishedTopics();
+    const topicDTOs = topics.map((topic) => TopicDTO.fromTopic(topic, req.language as Locale));
+    res.json(topicDTOs);
+  } catch (error) {
+    logger.error(error, 'Error listing published topics');
+    next(new UnknownException());
+  }
 };

--- a/src/dtos/published-topics-dto.ts
+++ b/src/dtos/published-topics-dto.ts
@@ -1,0 +1,10 @@
+import { ResultsetWithCount } from '../interfaces/resultset-with-count';
+import { DatasetListItemDTO } from './dataset-list-item-dto';
+import { TopicDTO } from './topic-dto';
+
+export interface PublishedTopicsDTO {
+  selectedTopic?: TopicDTO;
+  children?: TopicDTO[];
+  parents?: TopicDTO[];
+  datasets?: ResultsetWithCount<DatasetListItemDTO>;
+}

--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -1,4 +1,4 @@
-import { FindOneOptions, And, Not, IsNull, LessThan, FindOptionsRelations, In } from 'typeorm';
+import { FindOneOptions, And, Not, IsNull, LessThan, FindOptionsRelations, In, Like, Raw } from 'typeorm';
 import { has, set } from 'lodash';
 
 import { dataSource } from '../db/data-source';
@@ -6,7 +6,6 @@ import { Dataset } from '../entities/dataset/dataset';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item-dto';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 import { Locale } from '../enums/locale';
-import { listPublishedTopics } from '../controllers/consumer';
 import { Topic } from '../entities/dataset/topic';
 
 export const withAll: FindOptionsRelations<Dataset> = {
@@ -69,7 +68,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     return { data, count };
   },
 
-  async listPublishedTopics(topicPath?: string): Promise<Topic[]> {
+  async listPublishedTopics(topicId?: string): Promise<Topic[]> {
     const latestPublishedRevisions = await this.createQueryBuilder('d')
       .select('d.published_revision_id')
       .where('d.live IS NOT NULL')
@@ -79,10 +78,40 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
 
     const revisionIds = latestPublishedRevisions.map((revision) => revision.published_revision_id);
 
+    // if no topicId provided, fetch topics where path equals the id (i.e. root level topics)
+    const path = topicId ? { path: Like(`${topicId}.%`) } : { path: Raw('"Topic"."id"::text') };
+
     return this.manager.getRepository(Topic).find({
       where: {
-        revisionTopics: { revisionId: In(revisionIds) }
+        revisionTopics: { revisionId: In(revisionIds) },
+        ...path
       }
     });
+  },
+
+  async listPublishedByTopic(
+    topicId: string,
+    lang: Locale,
+    page: number,
+    limit: number
+  ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
+    const qb = this.createQueryBuilder('d')
+      .select(['d.id as id', 'rm.title as title', 'd.live as published_date'])
+      .innerJoin('d.publishedRevision', 'r')
+      .innerJoin('r.metadata', 'rm')
+      .innerJoin('r.revisionTopics', 'rt')
+      .where('rm.language LIKE :lang', { lang: `${lang}%` })
+      .andWhere('d.live IS NOT NULL')
+      .andWhere('d.live < NOW()')
+      .andWhere('rt.topicId = :topicId', { topicId })
+      .groupBy('d.id, rm.title, d.live')
+      .orderBy('d.live', 'DESC');
+
+    const offset = (page - 1) * limit;
+    const countQuery = qb.clone();
+    const resultQuery = qb.orderBy('d.live', 'DESC').offset(offset).limit(limit);
+    const [data, count] = await Promise.all([resultQuery.getRawMany(), countQuery.getCount()]);
+
+    return { data, count };
   }
 });

--- a/src/repositories/topic.ts
+++ b/src/repositories/topic.ts
@@ -1,8 +1,17 @@
+import { In } from 'typeorm';
 import { dataSource } from '../db/data-source';
 import { Topic } from '../entities/dataset/topic';
 
 export const TopicRepository = dataSource.getRepository(Topic).extend({
   async listAll(): Promise<Topic[]> {
     return this.find();
+  },
+
+  async getParents(path: string): Promise<Topic[]> {
+    const parentIds = path.split('.');
+
+    return this.find({
+      where: { id: In(parentIds) }
+    });
   }
 });

--- a/src/routes/consumer.ts
+++ b/src/routes/consumer.ts
@@ -43,7 +43,7 @@ export const loadPublishedDataset = (relations?: FindOptionsRelations<Dataset>) 
 
 // GET /published/topics
 // Returns a list of all topics with at least one published dataset
-consumerRouter.get('/topics', listPublishedTopics);
+consumerRouter.get('/topic{/:topic_id}', listPublishedTopics);
 
 // GET /published/list
 // Returns a list of all active datasets e.g. ones with imports

--- a/src/routes/consumer.ts
+++ b/src/routes/consumer.ts
@@ -6,7 +6,8 @@ import {
   listPublishedDatasets,
   getPublishedDatasetById,
   downloadPublishedDataset,
-  getPublishedDatasetView
+  getPublishedDatasetView,
+  listPublishedTopics
 } from '../controllers/consumer';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { PublishedDatasetRepository } from '../repositories/published-dataset';
@@ -39,6 +40,10 @@ export const loadPublishedDataset = (relations?: FindOptionsRelations<Dataset>) 
     next();
   };
 };
+
+// GET /published/topics
+// Returns a list of all topics with at least one published dataset
+consumerRouter.get('/topics', listPublishedTopics);
 
 // GET /published/list
 // Returns a list of all active datasets e.g. ones with imports

--- a/src/routes/topic.ts
+++ b/src/routes/topic.ts
@@ -15,7 +15,7 @@ topicRouter.get('/', async (req: Request, res: Response, next: NextFunction) => 
     const topicDTOs = topics.map((topic) => TopicDTO.fromTopic(topic, req.language as Locale));
     res.json(topicDTOs);
   } catch (error) {
-    logger.error('Error listing topics', error);
+    logger.error(error, 'Error listing topics');
     next(new UnknownException());
   }
 });


### PR DESCRIPTION
Provide a new endpoint for fetching topics that have at least one published dataset.

If a topic id is provided, then the list is filtered to child topics of the selected topic.

If the topic is a leaf topic (i.e. no children) then we also fetch the datasets for that topic.