### PR TITLE
Bugfix - SW-717 - dimension/measure names not exported

### DIFF
--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -68,7 +68,7 @@ export class TasklistStateDTO {
       status = TaskListStatus.Completed;
     }
 
-    const name = measure.metadata?.find((meta) => meta.language.includes(lang))?.name ?? measure.factTableColumn;
+    const name = measure.metadata?.find((meta) => meta.language.includes(lang))?.name || measure.factTableColumn;
 
     return { type: 'measure', id: measure.id, name, status };
   }
@@ -79,7 +79,7 @@ export class TasklistStateDTO {
     return dataset.dimensions?.reduce((dimensionStatus: DimensionStatus[], dimension) => {
       if (dimension.type === DimensionType.NoteCodes) return dimensionStatus;
 
-      const name = dimension.metadata.find((meta) => lang.includes(meta.language))?.name ?? 'unknown';
+      const name = dimension.metadata.find((meta) => lang.includes(meta.language))?.name || dimension.factTableColumn;
       let status: TaskListStatus;
 
       if (isUpdate) {

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -154,9 +154,7 @@ async function createUpdateDimension(dataset: Dataset, columnDescriptor: SourceA
     dataset,
     type: DimensionType.Raw,
     factTableColumn: columnInfo.columnName,
-    metadata: SUPPORTED_LOCALES.map((language: string) =>
-      DimensionMetadata.create({ language, name: columnInfo.columnName })
-    )
+    metadata: SUPPORTED_LOCALES.map((language: string) => DimensionMetadata.create({ language, name: '' }))
   }).save();
 }
 
@@ -216,9 +214,7 @@ async function createUpdateMeasure(dataset: Dataset, columnAssignment: SourceAss
   await Measure.create({
     dataset,
     factTableColumn: columnInfo.columnName,
-    metadata: SUPPORTED_LOCALES.map((language: string) =>
-      MeasureMetadata.create({ language, name: columnInfo.columnName })
-    )
+    metadata: SUPPORTED_LOCALES.map((language: string) => MeasureMetadata.create({ language, name: '' }))
   }).save();
 }
 

--- a/src/utils/collect-translations.ts
+++ b/src/utils/collect-translations.ts
@@ -17,11 +17,10 @@ export const collectTranslations = (dataset: Dataset, includeIds = false, revisi
 
   const translations: TranslationDTO[] = [
     ...(dataset.dimensions || []).map((dimension) => {
-      const factTableColumn = dimension.factTableColumn;
       const dimMetaEN = dimension.metadata?.find((meta) => meta.language.includes('en'));
       const dimMetaCY = dimension.metadata?.find((meta) => meta.language.includes('cy'));
-      const dimNameEN = dimMetaEN?.name === factTableColumn ? '' : dimMetaEN?.name;
-      const dimNameCY = dimMetaCY?.name === factTableColumn ? '' : dimMetaCY?.name;
+      const dimNameEN = dimMetaEN?.name;
+      const dimNameCY = dimMetaCY?.name;
 
       return {
         type: 'dimension',
@@ -37,8 +36,8 @@ export const collectTranslations = (dataset: Dataset, includeIds = false, revisi
             const factTableColumn = measure.factTableColumn;
             const measureMetaEN = measure.metadata.find((m) => m.language.includes('en'));
             const measureMetaCY = measure.metadata.find((m) => m.language.includes('cy'));
-            const measureNameEN = measureMetaEN?.name === factTableColumn ? '' : measureMetaEN?.name;
-            const measureNameCY = measureMetaCY?.name === factTableColumn ? '' : measureMetaCY?.name;
+            const measureNameEN = measureMetaEN?.name;
+            const measureNameCY = measureMetaCY?.name;
             return {
               type: 'measure',
               key: factTableColumn,


### PR DESCRIPTION
If dimension or measure names are the same as they appear in the fact table they are omitted from translations. This is probably unwanted behaviour as the user could have actually named the table "Measure" etc and currently there is no way to determine