### PR TITLE
Fix couldn't withdraw updatePendingApproval

### DIFF
--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -262,7 +262,14 @@ export class DatasetService {
     const dataset = await DatasetRepository.getById(datasetId, { endRevision: true, tasks: true });
     const publishingStatus = getPublishingStatus(dataset, dataset.endRevision!);
 
-    if (![PubStatus.PendingApproval, PubStatus.Scheduled, PubStatus.UpdateScheduled].includes(publishingStatus)) {
+    if (
+      ![
+        PubStatus.PendingApproval,
+        PubStatus.UpdatePendingApproval,
+        PubStatus.Scheduled,
+        PubStatus.UpdateScheduled
+      ].includes(publishingStatus)
+    ) {
       throw new BadRequestException('errors.withdraw.no_pending_publication');
     }
 


### PR DESCRIPTION
The sense-check for withdrawing was missing the "PubStatus.UpdatePendingApproval" status, so updates couldn't be withdrawn