### PR TITLE
Reduce size of JWT tokens

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -11,7 +11,6 @@ import { User } from '../entities/user/user';
 import { AuthProvider } from '../enums/auth-providers';
 import { dataSource } from '../db/data-source';
 import { UserDTO } from '../dtos/user/user-dto';
-import { Locale } from '../enums/locale';
 
 const config = appConfig();
 const domain = new URL(config.auth.jwt.cookieDomain).hostname;
@@ -40,7 +39,7 @@ export const loginLocal: RequestHandler = async (req, res) => {
     logger.debug('existing user found');
 
     logger.info('local auth successful, creating JWT and returning user to the frontend');
-    const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
+    const payload = { user: UserDTO.fromUserForJWT(user) };
     const { secret, expiresIn, secure } = config.auth.jwt;
     const token = jwt.sign(payload, secret, { expiresIn });
 
@@ -73,7 +72,7 @@ export const loginGoogle: RequestHandler = (req, res, next) => {
 
       logger.info('google auth successful, creating JWT and returning user to the frontend');
 
-      const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
+      const payload = { user: UserDTO.fromUserForJWT(user) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
 
@@ -104,7 +103,7 @@ export const loginEntraID: RequestHandler = (req, res, next) => {
 
       logger.info('entraid auth successful, creating JWT and returning user to the frontend');
 
-      const payload = { user: UserDTO.fromUser(user, req.language as Locale) };
+      const payload = { user: UserDTO.fromUserForJWT(user) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
 

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -16,6 +16,20 @@ const config = appConfig();
 const domain = new URL(config.auth.jwt.cookieDomain).hostname;
 logger.debug(`JWT cookie domain is '${domain}'`);
 
+const checkTokenFitsInCookie = (token: string): void => {
+  const maxCookieSize = 4096; // Maximum size of a cookie in bytes
+  const tokenSize = Buffer.byteLength(token, 'utf8');
+
+  if (tokenSize > maxCookieSize) {
+    // our JWTs include a list of the user groups and roles - if the user has many groups the JWT can become too large
+    // to fit in a cookie. This is a limitation of cookies, not JWTs themselves.
+    // TODO: Consider using a different mechanism
+    throw new Error(`JWT token size (${tokenSize} bytes) exceeds the maximum cookie size (${maxCookieSize} bytes).`);
+  } else {
+    logger.debug(`JWT token is ${tokenSize} bytes (max: ${maxCookieSize})`);
+  }
+};
+
 // should only ever be used in testing environments
 export const loginLocal: RequestHandler = async (req, res) => {
   logger.debug('auth request from local form received');
@@ -42,6 +56,7 @@ export const loginLocal: RequestHandler = async (req, res) => {
     const payload = { user: UserDTO.fromUserForJWT(user) };
     const { secret, expiresIn, secure } = config.auth.jwt;
     const token = jwt.sign(payload, secret, { expiresIn });
+    checkTokenFitsInCookie(token);
 
     res.cookie('jwt', token, { secure, httpOnly: true, domain });
     res.redirect(returnURL);
@@ -75,6 +90,7 @@ export const loginGoogle: RequestHandler = (req, res, next) => {
       const payload = { user: UserDTO.fromUserForJWT(user) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
+      checkTokenFitsInCookie(token);
 
       res.cookie('jwt', token, { secure, httpOnly: true, domain });
       res.redirect(returnURL);
@@ -102,10 +118,10 @@ export const loginEntraID: RequestHandler = (req, res, next) => {
       }
 
       logger.info('entraid auth successful, creating JWT and returning user to the frontend');
-
       const payload = { user: UserDTO.fromUserForJWT(user) };
       const { secret, expiresIn, secure } = config.auth.jwt;
       const token = jwt.sign(payload, secret, { expiresIn });
+      checkTokenFitsInCookie(token);
 
       res.cookie('jwt', token, { secure, httpOnly: true, domain });
       res.redirect(returnURL);

--- a/src/dtos/user/user-dto.ts
+++ b/src/dtos/user/user-dto.ts
@@ -48,4 +48,25 @@ export class UserDTO {
 
     return dto;
   }
+
+  // Create a minimal UserDTO for JWT purposes to keep the size down
+  static fromUserForJWT(user: User): UserDTO {
+    const dto = new UserDTO();
+
+    dto.id = user.id;
+    dto.email = user.email;
+    dto.full_name = user.name;
+    dto.status = user.status;
+
+    dto.global_roles = user.globalRoles?.map((role) => role as GlobalRole) || [];
+
+    dto.groups = (user.groupRoles || []).map((userRole: UserGroupRole) => {
+      return {
+        group: { id: userRole.groupId },
+        roles: userRole.roles.map((role) => role as GroupRole)
+      };
+    });
+
+    return dto;
+  }
 }

--- a/src/middleware/passport-auth.ts
+++ b/src/middleware/passport-auth.ts
@@ -10,7 +10,6 @@ import { User } from '../entities/user/user';
 import { appConfig } from '../config';
 import { AuthProvider } from '../enums/auth-providers';
 import { asyncLocalStorage } from '../services/async-local-storage';
-import { Locale } from '../enums/locale';
 import { UserDTO } from '../dtos/user/user-dto';
 import { getPermissionsForUserDTO } from '../utils/get-permissions-for-user';
 
@@ -78,7 +77,7 @@ const initJwt = async (userRepository: Repository<User>, jwtConfig: Record<strin
 
           // compare the props that control permissions and force reauthentication if they are different
           // need to jsonify user object to convert to plain object for comparison
-          const refreshedUser = JSON.parse(JSON.stringify(UserDTO.fromUser(user, Locale.English)));
+          const refreshedUser = JSON.parse(JSON.stringify(UserDTO.fromUserForJWT(user)));
           const activePerms = getPermissionsForUserDTO(refreshedUser);
           const jwtPerms = getPermissionsForUserDTO(jwtUser);
 


### PR DESCRIPTION
We were hitting size limit (4kb) for the JWT cookie when the user is assigned to many (10+) groups.

This strips the token down to it's bear essentials (no group metadata) to keep the size down. Size with 10 groups is now 1kb.

We can potentially improve this further by switching signing algorithm to something more compressed, but that would require updating the way we do the secret.