### PR TITLE
Make cube pool a singleton and fail early if can't connect

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,24 +26,10 @@ import { adminRouter } from './routes/admin';
 import { devRouter } from './routes/developer';
 import { taskRouter } from './routes/task';
 import { userRouter } from './routes/user';
-import { Pool } from 'pg';
 
 const app: Application = express();
 const config = appConfig();
 checkConfig();
-
-export const pool = new Pool({
-  host: appConfig().database.host,
-  port: appConfig().database.port,
-  ssl: appConfig().database.ssl,
-  database: appConfig().database.database,
-  user: appConfig().database.username,
-  password: appConfig().database.password,
-  max: 10, // set pool max size to 10
-  idleTimeoutMillis: 1000, // close idle clients after 1 second
-  connectionTimeoutMillis: 1000, // return an error after 1 second if connection could not be established
-  maxUses: 7500 // close (and replace) a connection after it has been used 7500 times (see below for discussion)
-});
 
 logger.info(`App config loaded for '${config.env}' env`);
 

--- a/src/db/cube-db.ts
+++ b/src/db/cube-db.ts
@@ -1,0 +1,29 @@
+import { Pool } from 'pg';
+import { appConfig } from '../config';
+
+const config = appConfig().database;
+
+let cubeDB: Pool | undefined = undefined;
+
+/**
+ * Returns a singleton of the CubeDB Pool.
+ *
+ * This is the cube database configuration. For the main application database, see data-source.ts.
+ */
+export function getCubeDB(): Pool {
+  if (!cubeDB) {
+    cubeDB = new Pool({
+      host: config.host,
+      port: config.port,
+      ssl: config.ssl,
+      user: config.username,
+      password: config.password,
+      database: config.database,
+      max: 10,
+      idleTimeoutMillis: 1000,
+      connectionTimeoutMillis: 1000,
+      maxUses: 7500
+    });
+  }
+  return cubeDB;
+}

--- a/src/db/data-source.ts
+++ b/src/db/data-source.ts
@@ -6,6 +6,11 @@ import { appConfig } from '../config';
 
 const config = appConfig();
 
+/**
+ * Data source configuration for TypeORM.
+ *
+ * This is the main application database configuration. For the cube databases, see pool.ts.
+ */
 const dataSourceOpts: DataSourceOptions = {
   type: 'postgres',
   host: config.database.host,

--- a/src/db/database-manager.ts
+++ b/src/db/database-manager.ts
@@ -27,7 +27,7 @@ class DatabaseManager {
   }
 
   async initializeDataSource(): Promise<void> {
-    this.logger.debug(`DB '${this.dataSource.options.database}' initializing...`);
+    this.logger.debug(`Application DB '${this.dataSource.options.database}' initializing...`);
 
     if (!this.dataSource.isInitialized) {
       try {
@@ -38,7 +38,7 @@ class DatabaseManager {
       }
     }
 
-    this.logger.info(`DB '${this.dataSource.options.database}' initialized`);
+    this.logger.info(`Application DB '${this.dataSource.options.database}' initialized`);
     this.entityManager = this.dataSource.createEntityManager();
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import app from './app';
 import { logger } from './utils/logger';
 import { initDb, initEntitySubscriber } from './db/init';
 import { initPassport } from './middleware/passport-auth';
+import { getCubeDB } from './db/cube-db';
 
 const PORT = appConfig().backend.port;
 
@@ -13,6 +14,13 @@ Promise.resolve()
   .then(async () => {
     const dbManager = await initDb();
     await initEntitySubscriber(dbManager.getDataSource());
+
+    const cubeDB = getCubeDB();
+    const cubeClient = await cubeDB.connect();
+    await cubeClient.query('SELECT NOW()');
+    cubeClient.release();
+    logger.info('Cube DB initialized');
+
     await initPassport(dbManager.getDataSource());
   })
   .then(() => {

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -43,8 +43,8 @@ import { FactTableValidationExceptionType } from '../enums/fact-table-validation
 import { CubeType } from '../enums/cube-type';
 import { DateExtractor } from '../extractors/date-extractor';
 import { StorageService } from '../interfaces/storage-service';
-import { pool } from '../app';
 import { QueryResult } from 'pg';
+import { getCubeDB } from '../db/cube-db';
 
 export const FACT_TABLE_NAME = 'fact_table';
 
@@ -1999,9 +1999,8 @@ export const createAllCubeFiles = async (
 
   const quack = await duckdb();
   await linkToPostgres(quack, endRevisionId, false);
-  /*
-  TODO Write code to to use native libraries to produce parquet, csv, excel and json outputs
-   */
+
+  // TODO Write code to to use native libraries to produce parquet, csv, excel and json outputs
   for (const locale of SUPPORTED_LOCALES) {
     const lang = locale.toLowerCase().split('-')[0];
     const xlsxFile = tmp.tmpNameSync({ postfix: '.xlsx' });
@@ -2023,7 +2022,8 @@ export const createAllCubeFiles = async (
 };
 
 export const getCubeTimePeriods = async (revisionId: string): Promise<PeriodCovered> => {
-  const periodCoverage: QueryResult<{ key: string; value: string }> = await pool.query(
+  const cubeDB = getCubeDB();
+  const periodCoverage: QueryResult<{ key: string; value: string }> = await cubeDB.query(
     pgformat(`SELECT key, value FROM %I.metadata WHERE key in ('start_date', 'end_date')`, revisionId)
   );
   return {


### PR DESCRIPTION
Moves the cube db pool config to it's own file, and make sure it only creates a single instance.

Tests the cube db connection on startup so the container will fail to start if the cube db can't connect.