### PR TITLE
bugfix, consumer view for empty filters

### DIFF
--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -167,6 +167,25 @@ export const createView = async (
 
     const startLine = pageSize * (pageNumber - 1) + 1;
     const lastLine = pageNumber * pageSize + pageSize;
+
+    // PATCH: Handle empty preview result
+    if (!preview || preview.length === 0) {
+      const currentDataset = await DatasetRepository.getById(dataset.id);
+      return {
+        dataset: DatasetDTO.fromDataset(currentDataset),
+        current_page: pageNumber,
+        page_info: {
+          total_records: totalLines,
+          start_record: 0,
+          end_record: 0
+        },
+        page_size: pageSize,
+        total_pages: totalPages,
+        headers: [],
+        data: []
+      };
+    }
+
     const tableHeaders = Object.keys(preview[0]);
     const dataArray = preview.map((row) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);


### PR DESCRIPTION
return empty results instead of error if preview is empty

If a filter returns no results, return empty data and headers, preventing TypeError on Object.keys(preview[0]).