### PR TITLE
Fix some map(async calls and strip a lot of logging

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -594,7 +594,7 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
     .filter((rev) => !!rev?.dataTable);
 
   for (const rev of revisionTree) {
-    logger.debug(`Recreating datatable ${rev.dataTable!.id} in postgres data_tables database`);
+    logger.debug(`Recreating datatable ${rev.dataTable?.id} in postgres data_tables database`);
     const tmpFile = tmp.fileSync({ postfix: rev.dataTable!.fileType });
     const buf = await req.fileService.loadBuffer(rev.dataTable!.filename, datasetId);
     fs.writeFileSync(tmpFile.name, buf);

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -141,7 +141,7 @@ export const createView = async (
     filterQuery ? `WHERE ${filterQuery}` : '',
     sortByQuery ? `ORDER BY ${sortByQuery}` : ''
   );
-  logger.debug(`Base query: ${baseQuery}`);
+  // logger.debug(`Base query: ${baseQuery}`);
 
   try {
     const cubeDB = getCubeDB();
@@ -150,7 +150,7 @@ export const createView = async (
       pageSize,
       baseQuery
     );
-    logger.debug(`Totals query: ${totalsQuery}`);
+    // logger.debug(`Totals query: ${totalsQuery}`);
     const totals = await cubeDB.query(totalsQuery);
     const totalPages = Number(totals.rows[0].totalPages) > 0 ? Number(totals.rows[0].totalPages) : 1;
     const totalLines = Number(totals.rows[0].totalLines);
@@ -161,7 +161,7 @@ export const createView = async (
     }
 
     const dataQuery = pgformat('%s LIMIT %L OFFSET %L', baseQuery, pageSize, (pageNumber - 1) * pageSize);
-    logger.debug(`Data query: ${dataQuery}`);
+    // logger.debug(`Data query: ${dataQuery}`);
     const queryResult: QueryResult<unknown[]> = await cubeDB.query(dataQuery);
     const preview = queryResult.rows;
 

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -61,7 +61,7 @@ export async function extractTableInformation(
       throw new Error('Unknown file type');
   }
   try {
-    logger.debug(`Executing query to create base fact table: ${pgformat(createTableQuery, tableName, tempFile)}`);
+    logger.debug(`Creating base fact table`);
     await quack.exec(pgformat(createTableQuery, tableName, tempFile));
   } catch (error) {
     logger.error(error, `Something went wrong trying to extract table information using DuckDB.`);

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -238,10 +238,10 @@ export class DatasetService {
     logger.debug(`Updating measure translations...`);
     const measureTranslation = translations.find((t) => t.type === 'measure')!;
     await Promise.all(
-      measure.metadata.map(async (metadata) => {
+      measure.metadata.map((metadata) => {
         metadata.name =
           (metadata.language === Locale.EnglishGb ? measureTranslation.english : measureTranslation.cymraeg) ?? '';
-        await metadata.save();
+        metadata.save();
       })
     );
 

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -311,12 +311,10 @@ export const createDimensionsFromSourceAssignment = async (
     await createUpdateMeasure(dataset, measure);
   }
 
-  await Promise.all(
-    dimensions.map((dimensionCreationDTO: SourceAssignmentDTO) => {
-      logger.debug(`Creating dimension column: ${JSON.stringify(dimensionCreationDTO)}`);
-      createUpdateDimension(dataset, dimensionCreationDTO);
-    })
-  );
+  for (const dimensionCreationDTO of dimensions) {
+    logger.debug(`Creating dimension column: ${JSON.stringify(dimensionCreationDTO)}`);
+    await createUpdateDimension(dataset, dimensionCreationDTO);
+  }
 
   try {
     if (ignore) {
@@ -596,12 +594,9 @@ export const createAndValidateDateDimension = async (
       logger.debug(`populating ${safeColumnName}_lookup table for locale ${locale}`);
       const lang = locale.toLowerCase();
 
-      // TODO: updated async in .map() to promise.all... can this be parallelized or should it be sequential?
-      await Promise.all(
-        dateDimensionTable.map((row) => {
-          stmt.run(row.dateCode, lang, row.description, null, t(row.type, { lng: locale }), row.start, row.end);
-        })
-      );
+      for (const row of dateDimensionTable) {
+        await stmt.run(row.dateCode, lang, row.description, null, t(row.type, { lng: locale }), row.start, row.end);
+      }
     }
     await stmt.finalize();
   } catch (error) {

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -191,7 +191,7 @@ async function removeIgnoreAndUnknownColumns(dataset: Dataset, ignoreColumns: So
     factTableColumns = await FactTableColumn.findBy({ id: dataset.id, columnDatatype: FactTableColumnType.Unknown });
     logger.debug(`Found ${factTableColumns.length} columns in fact table...`);
   } catch (error) {
-    logger.error(error, `Something went wrong trying to find columns in fact table with error: ${error}`);
+    logger.error(error, `Something went wrong trying to find columns in fact table`);
   }
 
   const unknownColumns = await FactTableColumn.findBy({ id: dataset.id, columnDatatype: FactTableColumnType.Unknown });
@@ -478,7 +478,8 @@ export const validateDateDimension = async (
       LEFT JOIN "${makeCubeSafeString(factTableColumn.columnName)}_lookup"
       ON fact_table.fact_table_date="${makeCubeSafeString(factTableColumn.columnName)}_lookup"."${factTableColumn.columnName}"
       WHERE "${factTableColumn.columnName}" IS NULL;`;
-    logger.debug(`Matching query is:\n${matchingQuery}`);
+    // logger.debug(`Matching query is:\n${matchingQuery}`);
+
     const nonMatchedRows = await quack.all(matchingQuery);
     if (nonMatchedRows.length > 0) {
       if (nonMatchedRows.length === preview.length) {
@@ -502,7 +503,8 @@ export const validateDateDimension = async (
               LEFT JOIN "${makeCubeSafeString(factTableColumn.columnName)}_lookup"
               ON fact_table.fact_table_date="${makeCubeSafeString(factTableColumn.columnName)}_lookup"."${factTableColumn.columnName}"
              WHERE "${factTableColumn.columnName}" IS NULL;`;
-        logger.debug(`Non matching rows query is:\n${nonMatchingRowsQuery}`);
+
+        // logger.debug(`Non matching rows query is:\n${nonMatchingRowsQuery}`);
         const nonMatchedRowSample = await quack.all(nonMatchingRowsQuery);
         const nonMatchingValues = nonMatchedRowSample
           .map((item) => item.fact_table_date)
@@ -564,7 +566,7 @@ export const createAndValidateDateDimension = async (
     dataset.draftRevision!.id,
     tableName
   );
-  logger.debug(`Preview query is: ${previewQuery}`);
+  // logger.debug(`Preview query is: ${previewQuery}`);
   const preview = await quack.all(previewQuery);
   try {
     // logger.debug(`Preview is: ${JSON.stringify(preview)}`);
@@ -730,7 +732,7 @@ async function getPreviewWithNumberExtractor(
   );
   const totalLines = Number(totals[0].totalLines);
 
-  logger.debug(`query = ${query}`);
+  // logger.debug(`query = ${query}`);
   const preview = await quack.all(query);
   const tableHeaders = Object.keys(preview[0]);
   const dataArray = preview.map((row) => Object.values(row));
@@ -791,11 +793,19 @@ async function getLookupPreviewWithExtractor(
   quack: Database,
   language: string
 ) {
+  const safeColName = makeCubeSafeString(dimension.factTableColumn);
   const lookupTableSize = await quack.all(
-    `SELECT * FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup WHERE language = '${language.toLowerCase()}'`
+    `SELECT * FROM ${safeColName}_lookup WHERE language = '${language.toLowerCase()}'`
   );
-  const query = `SELECT * EXCLUDE(language) FROM ${makeCubeSafeString(dimension.factTableColumn)}_lookup WHERE language = '${language.toLowerCase()}' ORDER BY sort_order, "${dimension.factTableColumn}" LIMIT ${sampleSize};`;
-  logger.debug(`Querying the cube to get the preview using query ${query}`);
+  const query = `
+    SELECT * EXCLUDE(language)
+    FROM ${safeColName}_lookup
+    WHERE language = '${language.toLowerCase()}'
+    ORDER BY sort_order, "${dimension.factTableColumn}"
+    LIMIT ${sampleSize};
+  `;
+
+  // logger.debug(`Querying the cube to get the preview using query ${query}`);
   const dimensionTable = await quack.all(query);
   const tableHeaders = Object.keys(dimensionTable[0]);
   const dataArray = dimensionTable.map((row) => Object.values(row));
@@ -869,7 +879,7 @@ export const getDimensionPreview = async (dataset: Dataset, dimension: Dimension
     }
     return viewDto;
   } catch (error) {
-    logger.error(`Something went wrong trying to create dimension preview with the following error: ${error}`);
+    logger.error(error, `Something went wrong trying to create dimension preview`);
     return viewErrorGenerators(500, dataset.id, 'none', 'errors.dimension.preview_failed', {});
   } finally {
     await quack.close();

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -128,7 +128,8 @@ export const factTableValidatorFromSource = async (
   );
   const createQuery = pgformat(`CALL postgres_execute('postgres_db', %L);`, factTableCreationQuery);
 
-  logger.debug(`Creating initial fact table in cube using query:\n${createQuery}`);
+  // logger.debug(`Creating initial fact table in cube using query:\n${createQuery}`);
+
   try {
     await quack.exec(createQuery);
   } catch (err) {
@@ -262,7 +263,9 @@ async function identifyDuplicateFacts(
                 FROM data_table GROUP BY ${primaryKeyDef.join(', ')} HAVING fact_count > 1
             )
         ) LIMIT 500;`;
-    logger.debug(`Running query to find duplicates:\n${duplicateQuery}`);
+
+    // logger.debug(`Running query to find duplicates:\n${duplicateQuery}`);
+
     const brokenFacts = await quack.all(duplicateQuery);
     const { headers, data } = tableDataToViewTable(brokenFacts);
     error.data = data;

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -236,7 +236,7 @@ async function createMeasureTable(
       );
     }
     buildMeasureViewQuery = `${viewComponents.join('\nUNION\n')}`;
-    logger.debug(`Extracting SW2 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
+    // logger.debug(`Extracting SW2 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
   } else {
     // logger.debug(`Extractor = ${JSON.stringify(extractor, null, 2)}`);
     if (extractor.notesColumns && extractor.notesColumns.length > 0) {
@@ -247,18 +247,20 @@ async function createMeasureTable(
 
     const measureMatcher = languageMatcherCaseStatement(extractor.languageColumn);
 
-    buildMeasureViewQuery = `SELECT
-                    "${joinColumn}" AS reference,
-                    ${measureMatcher} AS language,
-                    "${extractor.descriptionColumns[0].name}" AS description,
-                    ${notesColumnDef} AS notes,
-                    ${sortOrderDef} AS sort_order,
-                    ${formatColumn} AS format,
-                    ${decimalColumnDef} AS decimals,
-                    ${measureTypeDef} AS measure_type,
-                    ${hierarchyDef} AS hierarchy
-                FROM ${lookupTable}\n`;
-    logger.debug(`Extracting SW3 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
+    buildMeasureViewQuery = `
+      SELECT
+        "${joinColumn}" AS reference,
+        ${measureMatcher} AS language,
+        "${extractor.descriptionColumns[0].name}" AS description,
+        ${notesColumnDef} AS notes,
+        ${sortOrderDef} AS sort_order,
+        ${formatColumn} AS format,
+        ${decimalColumnDef} AS decimals,
+        ${measureTypeDef} AS measure_type,
+        ${hierarchyDef} AS hierarchy
+      FROM ${lookupTable}
+    `;
+    // logger.debug(`Extracting SW3 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
   }
   try {
     const insertQuery = `INSERT INTO measure (${buildMeasureViewQuery});`;
@@ -290,7 +292,7 @@ async function createMeasureTable(
         );
       }
     }
-    logger.debug(`Extracting lookup table contents to measure using query:\n ${insertQuery}`);
+    // logger.debug(`Extracting lookup table contents to measure using query:\n ${insertQuery}`);
     await quack.exec(insertQuery);
     await quack.exec(`DROP TABLE ${lookupTable};`);
     // const measureTable = await quack.all(`SELECT * FROM measure;`);
@@ -494,7 +496,7 @@ export const validateMeasureLookupTable = async (
     return tableValidationErrors;
   }
 
-  logger.debug(`Measure table validation successful.  Now saving measure.`);
+  logger.debug(`Measure table validation successful. Now saving measure.`);
   // Clean up previously uploaded measure
   await cleanUpMeasure(dataset.measure.id);
   if (updatedMeasure.lookupTable) await updatedMeasure.lookupTable.save();
@@ -594,7 +596,7 @@ async function getMeasurePreviewWithExtractor(dataset: Dataset, measure: Measure
       lang.toLowerCase(),
       sampleSize
     );
-    logger.debug(`Querying the cube to get the preview using query: ${query}`);
+    // logger.debug(`Querying the cube to get the preview using query: ${query}`);
     const measureTable = await quack.all(query);
     const tableHeaders = Object.keys(measureTable[0]);
     const dataArray = measureTable.map((row) => Object.values(row));

--- a/src/services/reference-data-handler.ts
+++ b/src/services/reference-data-handler.ts
@@ -189,7 +189,7 @@ export const validateReferenceData = async (
         WHERE categories.category='${confirmedReferenceDataCategory}';
     `);
 
-  logger.debug(`Column passed reference data checks.  Setting up dimension.`);
+  logger.debug(`Column passed reference data checks. Setting up dimension.`);
   await setupDimension(
     dimension,
     categoriesPresent.map((row) => Object.values(row)[0])
@@ -210,18 +210,18 @@ export const validateReferenceData = async (
         `;
     const allMatches = await quack.all(allMatchesQuery);
     const previewQuery = `
-            SELECT DISTINCT fact_table."${dimension.factTableColumn}", reference_data_info.description
-            FROM fact_table
-            LEFT JOIN reference_data
-                ON CAST(fact_table."${dimension.factTableColumn}" AS VARCHAR)=reference_data.item_id
-            JOIN reference_data_info
-                ON reference_data.item_id=reference_data_info.item_id
-                AND reference_data.category_key=reference_data_info.category_key
-                AND reference_data.version_no=reference_data_info.version_no
-            WHERE reference_data_info.lang='${lang.toLowerCase()}'
-            LIMIT ${sampleSize};
-        `;
-    logger.debug(`Preview query = ${previewQuery}`);
+      SELECT DISTINCT fact_table."${dimension.factTableColumn}", reference_data_info.description
+      FROM fact_table
+      LEFT JOIN reference_data
+          ON CAST(fact_table."${dimension.factTableColumn}" AS VARCHAR)=reference_data.item_id
+      JOIN reference_data_info
+          ON reference_data.item_id=reference_data_info.item_id
+          AND reference_data.category_key=reference_data_info.category_key
+          AND reference_data.version_no=reference_data_info.version_no
+      WHERE reference_data_info.lang='${lang.toLowerCase()}'
+      LIMIT ${sampleSize};
+    `;
+    // logger.debug(`Preview query = ${previewQuery}`);
     const dimensionTable = await quack.all(previewQuery);
     const tableHeaders = Object.keys(dimensionTable[0]);
     const dataArray = dimensionTable.map((row) => Object.values(row));

--- a/src/services/time-matching.ts
+++ b/src/services/time-matching.ts
@@ -285,18 +285,18 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: TableDa
   return referenceTable;
 }
 
-export function dateDimensionReferenceTableCreator(dateFormat: DateExtractor, dataColumn: TableData) {
+export function dateDimensionReferenceTableCreator(extractor: DateExtractor, dataColumn: TableData) {
   const columnData = [];
 
   for (const row of dataColumn) {
     columnData.push(Object.values(row)[0]);
   }
 
-  if (dateFormat.dateFormat) {
+  if (extractor.dateFormat) {
     logger.debug('Creating specific date table...');
-    return specificDateTableCreator(dateFormat, columnData);
+    return specificDateTableCreator(extractor, columnData);
   } else {
     logger.debug('Creating period table...');
-    return createAllTypesOfPeriod(dateFormat, columnData);
+    return createAllTypesOfPeriod(extractor, columnData);
   }
 }

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -70,6 +70,6 @@ export const loadFileIntoDatabase = async (
         FileValidationErrorType.UnknownMimeType
       );
   }
-  logger.debug(`Creating table ${tableName} from ${fileImport.fileType} file with query: ${createTableQuery}`);
+  logger.debug(`Creating table ${tableName} from ${fileImport.fileType} file`);
   await quack.exec(createTableQuery);
 };


### PR DESCRIPTION
I've commented out a ton of excessive logging where we do not need it in there all the time.

We should only be dumping full SQL queries or objects as and when we need to investigate them.

Even if the log level is set higher than "debug", the work is still done to prepare the log message before it gets skipped by the logger.

