### PR TITLE
Use asynchronous file ops to avoid blocking

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
 import { performance } from 'node:perf_hooks';
-import fs from 'fs';
+import { writeFile } from 'node:fs/promises';
 
 import { NextFunction, Request, Response } from 'express';
 import { t } from 'i18next';
@@ -597,7 +597,7 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
     logger.debug(`Recreating datatable ${rev.dataTable?.id} in postgres data_tables database`);
     const tmpFile = tmp.fileSync({ postfix: rev.dataTable!.fileType });
     const buf = await req.fileService.loadBuffer(rev.dataTable!.filename, datasetId);
-    fs.writeFileSync(tmpFile.name, buf);
+    await writeFile(tmpFile.name, buf);
     await extractTableInformation(buf, rev.dataTable!, 'data_table');
     tmpFile.removeCallback();
   }

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import fs from 'fs';
+import { unlink, writeFile, access } from 'node:fs/promises';
 
 import { TableData } from 'duckdb-async';
 import { format as pgformat } from '@scaleleap/pg-format';
@@ -29,6 +29,13 @@ const sampleSize = 5;
 
 const logger = parentLogger.child({ module: 'CSVProcessor' });
 
+const fileExists = async (filePath: string): Promise<boolean> => {
+  return access(filePath).then(
+    () => true,
+    () => false
+  );
+};
+
 export async function extractTableInformation(
   fileBuffer: Buffer,
   dataTable: DataTable,
@@ -39,7 +46,9 @@ export async function extractTableInformation(
   const tempFile = tmp.tmpNameSync({ postfix: `.${dataTable.fileType}` });
   let tableHeaders: TableData;
   let createTableQuery: string;
-  fs.writeFileSync(tempFile, fileBuffer);
+
+  await writeFile(tempFile, fileBuffer);
+
   switch (dataTable.fileType) {
     case FileType.Csv:
     case FileType.GzipCsv:
@@ -67,8 +76,10 @@ export async function extractTableInformation(
     logger.error(error, `Something went wrong trying to extract table information using DuckDB.`);
     logger.debug('Closing DuckDB Memory Database');
     await quack.close();
+
     logger.debug(`Removing temp file ${tempFile} from disk`);
-    fs.unlinkSync(tempFile);
+    await unlink(tempFile);
+
     if ((error as DuckDBException).stack.includes('Invalid unicode')) {
       throw new FileValidationException(`File is encoding is not supported`, FileValidationErrorType.InvalidUnicode);
     } else if ((error as DuckDBException).stack.includes('CSV Error on Line')) {
@@ -90,7 +101,7 @@ export async function extractTableInformation(
     } catch (error) {
       logger.error(error, 'Something went wrong saving data table to postgres');
       await quack.close();
-      fs.unlinkSync(tempFile);
+      await unlink(tempFile);
     }
   }
 
@@ -106,7 +117,7 @@ export async function extractTableInformation(
     );
   } finally {
     await quack.close();
-    fs.unlinkSync(tempFile);
+    await unlink(tempFile);
   }
 
   if (tableHeaders.length === 0) {
@@ -293,8 +304,12 @@ export const getCSVPreview = async (
     return viewErrorGenerators(500, datasetId, 'csv', 'errors.preview.preview_failed', {});
   } finally {
     await quack.close();
-    if (cubeFile) fs.unlinkSync(cubeFile);
-    if (fs.existsSync(tempFile)) fs.unlinkSync(tempFile);
+    if (cubeFile) {
+      await unlink(cubeFile);
+    }
+    if (await fileExists(tempFile)) {
+      await unlink(tempFile);
+    }
   }
 };
 

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { unlink, writeFile, access } from 'node:fs/promises';
+import { unlink, writeFile } from 'node:fs/promises';
 
 import { TableData } from 'duckdb-async';
 import { format as pgformat } from '@scaleleap/pg-format';
@@ -23,18 +23,12 @@ import { DuckDBException } from '../exceptions/duckdb-exception';
 import { viewErrorGenerators, viewGenerator } from '../utils/view-error-generators';
 import { validateParams } from '../validators/preview-validator';
 import { SourceLocation } from '../enums/source-location';
+import { asyncFileExists } from '../utils/async-file-exists';
 
 export const DEFAULT_PAGE_SIZE = 100;
 const sampleSize = 5;
 
 const logger = parentLogger.child({ module: 'CSVProcessor' });
-
-const fileExists = async (filePath: string): Promise<boolean> => {
-  return access(filePath).then(
-    () => true,
-    () => false
-  );
-};
 
 export async function extractTableInformation(
   fileBuffer: Buffer,
@@ -307,7 +301,7 @@ export const getCSVPreview = async (
     if (cubeFile) {
       await unlink(cubeFile);
     }
-    if (await fileExists(tempFile)) {
+    if (await asyncFileExists(tempFile)) {
       await unlink(tempFile);
     }
   }

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { writeFile, unlink } from 'node:fs/promises';
 
 import tmp from 'tmp';
 import { format as pgformat } from '@scaleleap/pg-format';
@@ -270,10 +270,10 @@ export const validateLookupTable = async (
   const lookupTableTmpFile = tmp.tmpNameSync({ postfix: `.${lookupTable.fileType}` });
   try {
     logger.debug(`Writing the lookup table to disk: ${lookupTableTmpFile}`);
-    fs.writeFileSync(lookupTableTmpFile, buffer);
+    await writeFile(lookupTableTmpFile, buffer);
     logger.debug(`Loading lookup table into DuckDB`);
     await loadFileIntoDatabase(quack, lookupTable, lookupTableTmpFile, lookupTableName);
-    fs.unlinkSync(lookupTableTmpFile);
+    await unlink(lookupTableTmpFile);
   } catch (err) {
     await quack.close();
     logger.error(err, `Something went wrong trying to load the lookup table into the cube`);

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { writeFile, unlink } from 'node:fs/promises';
 
 import { Database, DuckDbError } from 'duckdb-async';
 import { format as pgformat } from '@scaleleap/pg-format';
@@ -404,9 +404,9 @@ export const validateMeasureLookupTable = async (
 
   const lookupTableTmpFile = tmp.tmpNameSync({ postfix: `.${lookupTable.fileType}` });
   try {
-    fs.writeFileSync(lookupTableTmpFile, buffer);
+    await writeFile(lookupTableTmpFile, buffer);
     await loadFileIntoDatabase(quack, lookupTable, lookupTableTmpFile, lookupTableName);
-    fs.unlinkSync(lookupTableTmpFile);
+    await unlink(lookupTableTmpFile);
   } catch (err) {
     await quack.close();
     logger.error(err, `Something went wrong trying to load data in to DuckDB with the following error: ${err}`);

--- a/src/utils/async-file-exists.ts
+++ b/src/utils/async-file-exists.ts
@@ -1,0 +1,8 @@
+import { access } from 'fs/promises';
+
+export const asyncFileExists = async (filePath: string): Promise<boolean> => {
+  return access(filePath).then(
+    () => true,
+    () => false
+  );
+};

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 
 import tmp from 'tmp';
 import { Database } from 'duckdb-async';
@@ -35,7 +35,7 @@ export const getFileImportAndSaveToDisk = async (
   const fileService = getFileService();
   const importTmpFile = tmp.tmpNameSync({ postfix: `.${importFile.fileType}` });
   const buffer = await fileService.loadBuffer(importFile.filename, dataset.id);
-  fs.writeFileSync(importTmpFile, buffer);
+  await writeFile(importTmpFile, buffer);
   return importTmpFile;
 };
 


### PR DESCRIPTION
We should not be using any synchronous file operations as this will block the app for other users. Node is single-threaded.

There are still tmp files being written synchronously which will need looking at, but the `tmp` library does not support promises (callback hell) so not gonna do that in this pass. There's a `tmp-promises` but there might be a better solution.

