### PR TITLE
Fix: add DTO validation rules for role selection

### DIFF
--- a/src/dtos/user/role-selection-dto.ts
+++ b/src/dtos/user/role-selection-dto.ts
@@ -1,8 +1,16 @@
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+
 import { GlobalRole } from '../../enums/global-role';
 import { GroupRole } from '../../enums/group-role';
 
 export class RoleSelectionDTO {
+  @IsEnum(['global', 'group'])
   type: 'global' | 'group';
+
+  @IsEnum([...Object.values(GlobalRole), ...Object.values(GroupRole)], { each: true })
   roles: GlobalRole[] | GroupRole[];
+
+  @IsUUID(4)
+  @IsOptional()
   groupId?: string;
 }


### PR DESCRIPTION
A recent PR bumped the version of `class-validator` which seems to have changed the behaviour where undefined validation rules for your DTO are now a fail (which kind of makes sense in case you forget to define them). This is now breaking saving of user roles.

Previously we were just using the class validator to convert the request body to an actual DTO instance [as all the role validation happens afterwards](https://github.com/Marvell-Consulting/statswales-backend/blob/d60433eb25ded82092d899604d8b6d7aee7d567e/src/controllers/admin.ts#L167-L187), but this is a good sense-check to run first as it makes sure the DTO is the correct shape.