### PR TITLE
SW-789: display revision providers on preview page

### DIFF
--- a/src/repositories/revision.ts
+++ b/src/repositories/revision.ts
@@ -28,6 +28,11 @@ export const withMetadata: FindOptionsRelations<Revision> = {
   metadata: true
 };
 
+export const withMetadataAndProviders: FindOptionsRelations<Revision> = {
+  metadata: true,
+  revisionProviders: { provider: true, providerSource: true }
+};
+
 export const RevisionRepository = dataSource.getRepository(Revision).extend({
   async getById(id: string, relations: FindOptionsRelations<Revision> = withDataTable): Promise<Revision> {
     const findOptions: FindOneOptions<Revision> = { where: { id }, relations };

--- a/src/routes/revision.ts
+++ b/src/routes/revision.ts
@@ -29,7 +29,7 @@ import { Revision } from '../entities/dataset/revision';
 import { hasError, revisionIdValidator } from '../validators';
 import { logger } from '../utils/logger';
 import { NotFoundException } from '../exceptions/not-found.exception';
-import { RevisionRepository, withMetadata } from '../repositories/revision';
+import { RevisionRepository, withMetadataAndProviders } from '../repositories/revision';
 
 // middleware that loads the revision and stores it in res.locals
 // leave relations undefined to load the default relations
@@ -83,11 +83,11 @@ router.post('/by-id/:revision_id', loadRevision(), regenerateRevisionCube);
 
 // GET /dataset/:dataset_id/revision/id/:revision_id
 // Returns details of a revision with metadata
-router.get('/by-id/:revision_id', loadRevision(withMetadata), getRevisionInfo);
+router.get('/by-id/:revision_id', loadRevision(withMetadataAndProviders), getRevisionInfo);
 
 // GET /dataset/:dataset_id/revision/id/:revision_id/preview
 // Returns details of a revision with its imports
-router.get('/by-id/:revision_id/preview', loadRevision(withMetadata), getRevisionPreview);
+router.get('/by-id/:revision_id/preview', loadRevision(), getRevisionPreview);
 
 router.get('/by-id/:revision_id/preview/filters', loadRevision(), getRevisionPreviewFilters);
 

--- a/test/routes/metadata.test.ts
+++ b/test/routes/metadata.test.ts
@@ -20,7 +20,7 @@ import { DataTableRepository } from '../../src/repositories/data-table';
 import { DataTableDto } from '../../src/dtos/data-table-dto';
 import { Locale } from '../../src/enums/locale';
 import { logger } from '../../src/utils/logger';
-import { withMetadata } from '../../src/repositories/revision';
+import { withMetadataAndProviders } from '../../src/repositories/revision';
 
 import { createFullDataset } from '../helpers/test-helper';
 import { getTestUser, getTestUserGroup } from '../helpers/get-test-user';
@@ -178,7 +178,7 @@ describe('API Endpoints for viewing dataset objects', () => {
     });
 
     test('Get a revision returns 200', async () => {
-      const revision = await Revision.findOne({ where: { id: revision1Id }, relations: withMetadata });
+      const revision = await Revision.findOne({ where: { id: revision1Id }, relations: withMetadataAndProviders });
       if (!revision) {
         throw new Error('Revision not found');
       }


### PR DESCRIPTION
When the providers got moved to the revision, they went missing from the preview/ consumer view. This is needed to restore them.