### PR TITLE
Add validation rules to input DTOs

### DIFF
--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -74,6 +74,11 @@ export const createUserGroup = async (req: Request, res: Response, next: NextFun
     const group = await UserGroupRepository.createGroup(meta);
     res.json(UserGroupDTO.fromUserGroup(group, req.language as Locale));
   } catch (err) {
+    if (err instanceof BadRequestException) {
+      next(err);
+      return;
+    }
+
     logger.error(err, 'Error creating group');
     next(new UnknownException());
   }
@@ -110,7 +115,7 @@ export const getUserGroupById = async (req: Request, res: Response) => {
   res.json(UserGroupDTO.fromUserGroup(group, req.language as Locale));
 };
 
-export const updateUserGroup = async (req: Request, res: Response) => {
+export const updateUserGroup = async (req: Request, res: Response, next: NextFunction) => {
   let group = res.locals.userGroup;
 
   try {
@@ -118,6 +123,11 @@ export const updateUserGroup = async (req: Request, res: Response) => {
     group = await UserGroupRepository.updateGroup(group, dto);
     res.json(UserGroupDTO.fromUserGroup(group, req.language as Locale));
   } catch (err) {
+    if (err instanceof BadRequestException) {
+      next(err);
+      return;
+    }
+
     logger.error(err, 'Error updating group');
     throw new UnknownException();
   }

--- a/src/dtos/task-decision-dto.ts
+++ b/src/dtos/task-decision-dto.ts
@@ -1,4 +1,10 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
 export class TaskDecisionDTO {
+  @IsEnum(['approve', 'reject'])
   decision?: 'approve' | 'reject' | undefined;
+
+  @IsString()
+  @IsOptional()
   reason?: string;
 }

--- a/src/dtos/user/user-create-dto.ts
+++ b/src/dtos/user/user-create-dto.ts
@@ -1,3 +1,6 @@
+import { IsEmail } from 'class-validator';
+
 export class UserCreateDTO {
+  @IsEmail()
   email: string;
 }

--- a/src/dtos/user/user-group-dto.ts
+++ b/src/dtos/user/user-group-dto.ts
@@ -8,12 +8,26 @@ import { UserDTO } from './user-dto';
 import { UserGroupMetadataDTO } from './user-group-metadata-dto';
 import { UserGroupRole } from '../../entities/user/user-group-role';
 import { UserWithRolesDTO } from './user-with-roles-dto';
+import { IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class UserGroupDTO {
+  @IsUUID(4)
   id: string;
+
+  @IsString()
+  @IsOptional()
   prefix?: string;
+
+  @Type(() => UserGroupMetadataDTO)
+  @ValidateNested({ each: true })
+  @IsOptional()
   metadata?: UserGroupMetadataDTO[];
+
+  @IsUUID(4)
+  @IsOptional()
   organisation_id?: string;
+
   organisation?: OrganisationDTO;
   users?: UserWithRolesDTO[];
   user_count?: number;


### PR DESCRIPTION
A breaking change in `class-validator` dependency means DTOs with no validation rules set are now a validation fail instead of a pass by default.

The options are either to add validation rules, or pass `forbidUnknownValues: false`, so I've gone with the former.