### PR TITLE
SW-738: rename "Missing data" to "Not available"

### DIFF
--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -131,7 +131,7 @@
     "total": "Total",
     "low_reliability": "Low Reliability",
     "not_recorded": "None recorded in survey",
-    "missing_data": "Missing Data",
+    "missing_data": "Not available",
     "not_applicable": "Not Applicable"
   },
   "language": {


### PR DESCRIPTION
`X` note code should be labeled "Not available" rather than "Missing data"