### PR TITLE
Remove the "include all" hydration option to prevent massive queries

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -4,14 +4,16 @@ import { last, sortBy } from 'lodash';
 import { User } from '../entities/user/user';
 import {
   DatasetRepository,
-  withAll,
+  withDeveloperPreview,
   withDimensions,
   withDraftAndMeasure,
   withDraftAndMetadata,
   withDraftAndProviders,
   withDraftAndTopics,
   withDraftForCube,
-  withFactTable
+  withFactTable,
+  withLatestRevision,
+  withStandardPreview
 } from '../repositories/dataset';
 import { Locale } from '../enums/locale';
 import { logger } from '../utils/logger';
@@ -83,12 +85,20 @@ export const listAllDatasets = async (req: Request, res: Response, next: NextFun
 export const getDatasetById = async (req: Request, res: Response) => {
   const datasetId: string = res.locals.datasetId;
   const hydrate = req.query.hydrate as DatasetInclude;
-  let dataset: Dataset = res.locals.dataset;
+
+  let dataset: Dataset = res.locals.dataset; // plain dataset without any relations
 
   switch (hydrate) {
-    case DatasetInclude.All:
-      // use as a last resort, this is the kitchen sink and very expensive / slow
-      dataset = await DatasetRepository.getById(datasetId, withAll);
+    case DatasetInclude.Preview:
+      dataset = await DatasetRepository.getById(datasetId, withStandardPreview);
+      break;
+
+    case DatasetInclude.Developer:
+      dataset = await DatasetRepository.getById(datasetId, withDeveloperPreview);
+      break;
+
+    case DatasetInclude.LatestRevision:
+      dataset = await DatasetRepository.getById(datasetId, withLatestRevision);
       break;
 
     case DatasetInclude.Data:

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -59,14 +59,21 @@ import { FindOptionsRelations } from 'typeorm';
 import { getFilters } from '../services/consumer-view';
 
 export const getDataTable = async (req: Request, res: Response, next: NextFunction) => {
+  const revision: Revision = res.locals.revision;
+
+  if (!revision.dataTableId) {
+    throw new NotFoundException('errors.revision.no_data_table');
+  }
+
   try {
     const dataTable = await DataTable.findOneOrFail({
-      where: { id: req.params.id },
+      where: { id: revision.dataTableId },
       relations: { dataTableDescriptions: true, revision: true }
     });
     const dto = DataTableDto.fromDataTable(dataTable);
     res.json(dto);
   } catch (_err) {
+    logger.error(_err, `There was a problem fetching the data table for revision ${revision.id}`);
     next(new UnknownException());
   }
 };

--- a/src/enums/dataset-include.ts
+++ b/src/enums/dataset-include.ts
@@ -1,5 +1,7 @@
 export enum DatasetInclude {
-  All = 'all',
+  Preview = 'preview',
+  Developer = 'developer',
+  LatestRevision = 'latest',
   Meta = 'metadata',
   Data = 'data',
   Measure = 'measure',

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -17,22 +17,24 @@ import { PeriodCovered } from '../interfaces/period-covered';
 import { User } from '../entities/user/user';
 import { getUserGroupIdsForUser } from '../utils/get-permissions-for-user';
 
-export const withAll: FindOptionsRelations<Dataset> = {
+export const withStandardPreview: FindOptionsRelations<Dataset> = {
+  createdBy: true,
+  dimensions: { metadata: true },
+  measure: { metadata: true },
+  revisions: true,
+  tasks: true
+};
+
+export const withDeveloperPreview: FindOptionsRelations<Dataset> = {
   createdBy: true,
   factTable: true,
-  dimensions: { metadata: true, lookupTable: true },
-  measure: { lookupTable: true, measureTable: true },
-  draftRevision: {
-    metadata: true,
-    dataTable: true,
-    revisionProviders: { provider: true },
-    revisionTopics: { topic: true }
-  },
-  revisions: {
-    dataTable: true,
-    metadata: true
-  },
-  tasks: true
+  dimensions: { metadata: true },
+  measure: { metadata: true, measureTable: true, lookupTable: true },
+  revisions: { metadata: true }
+};
+
+export const withLatestRevision: FindOptionsRelations<Dataset> = {
+  endRevision: { metadata: true }
 };
 
 export const withFactTable: FindOptionsRelations<Dataset> = {
@@ -77,22 +79,6 @@ export const withDraftForCube: FindOptionsRelations<Dataset> = {
   dimensions: { metadata: true, lookupTable: true },
   measure: { metadata: true, measureTable: true, lookupTable: true },
   revisions: { dataTable: { dataTableDescriptions: true } }
-};
-
-export const withDraftForTasklistState: FindOptionsRelations<Dataset> = {
-  draftRevision: {
-    metadata: true,
-    dataTable: true,
-    revisionProviders: true,
-    revisionTopics: true,
-    previousRevision: {
-      metadata: true,
-      revisionProviders: true,
-      revisionTopics: true
-    }
-  },
-  dimensions: { metadata: true },
-  measure: { measureTable: true, metadata: true }
 };
 
 const listAllQuery = (qb: QueryBuilder<Dataset>, lang: Locale) => {


### PR DESCRIPTION
The `IncludeAll` relations option was basically a "give me everything including the kitchen sink" for a dataset object graph.

Most of the time we do not need absolutely everything, and on the rare occasions we might, we should fetch it piece by piece instead of relying on TypeORM to generate an efficient query.

This should hopefully reduce pressure on the query builder and might also help with memory.