### PR TITLE
Api doc fixes

### DIFF
--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -224,21 +224,25 @@ export const listRootTopics = async (req: Request, res: Response, next: NextFunc
 
 export const listSubTopics = async (req: Request, res: Response, next: NextFunction) => {
   /*
-    #swagger.summary = 'Get a list of sub-topics for a given top-level topic'
+    #swagger.summary = 'Get a list of what sits under a given topic'
     #swagger.description = `Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',
-      which can have sub-topics, such as 'Dental services'. This endpoint returns a list of the sub-topics for a given
-      top-level topic_id. If the top-level topic has no sub-topics, the endpoint will return a list of the published
-      datasets for that topic instead.`
+      which can have sub-topics, such as 'Dental services'. For a given topic_id, this endpoint returns a list of what
+      sits under that topic - either sub-topics or published datasets tagged directly to that topic.`
     #swagger.autoQuery = false
+     #swagger.parameters['page_size'] = {
+      description: 'Number of datasets per page when datasets are returned',
+      in: 'query',
+      type: 'integer',
+      default: 1000
+    }
     #swagger.parameters['$ref'] = [
       '#/components/parameters/language',
       '#/components/parameters/topic_id',
-      '#/components/parameters/page_number',
-      '#/components/parameters/page_size'
+      '#/components/parameters/page_number'
     ]
     #swagger.responses[200] = {
-      description: 'A list of the sub-topics for a given top-level topic, or a list of the published datasets for a
-        given top-level topic if it has no sub-topics',
+      description: 'A list of what sits under a given topic - either sub-topics or published datasets tagged directly
+       to that topic.',
       schema: { $ref: "#/components/schemas/PublishedTopics" }
     }
   */

--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -192,9 +192,9 @@ export const downloadPublishedDataset = async (req: Request, res: Response, next
 export const listRootTopics = async (req: Request, res: Response, next: NextFunction) => {
   /*
     #swagger.summary = 'Get a list of top-level topics'
-    #swagger.description = 'Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',
+    #swagger.description = `Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',
       which can have sub-topics, such as 'Dental services'. This endpoint returns a list of all top-level topics that
-      have at least one published dataset tagged to them.'
+      have at least one published dataset tagged to them.`
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = ['#/components/parameters/language']
     #swagger.responses[200] = {
@@ -225,10 +225,10 @@ export const listRootTopics = async (req: Request, res: Response, next: NextFunc
 export const listSubTopics = async (req: Request, res: Response, next: NextFunction) => {
   /*
     #swagger.summary = 'Get a list of sub-topics for a given top-level topic'
-    #swagger.description = 'Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',
+    #swagger.description = `Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',
       which can have sub-topics, such as 'Dental services'. This endpoint returns a list of the sub-topics for a given
       top-level topic_id. If the top-level topic has no sub-topics, the endpoint will return a list of the published
-      datasets for that topic instead.'
+      datasets for that topic instead.`
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = [
       '#/components/parameters/language',

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -71,9 +71,18 @@
     },
     "/topic/{topic_id}": {
       "get": {
-        "summary": "Get a list of sub-topics for a given top-level topic",
-        "description": "Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',  which can have sub-topics, such as 'Dental services'. This endpoint returns a list of the sub-topics for a given  top-level topic_id. If the top-level topic has no sub-topics, the endpoint will return a list of the published  datasets for that topic instead.",
+        "summary": "Get a list of what sits under a given topic",
+        "description": "Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',  which can have sub-topics, such as 'Dental services'. For a given topic_id, this endpoint returns a list of what  sits under that topic - either sub-topics or published datasets tagged directly to that topic.",
         "parameters": [
+          {
+            "name": "page_size",
+            "description": "Number of datasets per page when datasets are returned",
+            "in": "query",
+            "default": 1000,
+            "schema": {
+              "type": "integer"
+            }
+          },
           {
             "$ref": "#/components/parameters/language"
           },
@@ -82,14 +91,11 @@
           },
           {
             "$ref": "#/components/parameters/page_number"
-          },
-          {
-            "$ref": "#/components/parameters/page_size"
           }
         ],
         "responses": {
           "200": {
-            "description": "A list of the sub-topics for a given top-level topic, or a list of the published datasets for a  given top-level topic if it has no sub-topics",
+            "description": "A list of what sits under a given topic - either sub-topics or published datasets tagged directly  to that topic.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -44,7 +44,7 @@
     "/topic": {
       "get": {
         "summary": "Get a list of top-level topics",
-        "description": "Datasets are tagged to topics. There are top-level topics, such as ",
+        "description": "Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',  which can have sub-topics, such as 'Dental services'. This endpoint returns a list of all top-level topics that  have at least one published dataset tagged to them.",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"
@@ -72,7 +72,7 @@
     "/topic/{topic_id}": {
       "get": {
         "summary": "Get a list of sub-topics for a given top-level topic",
-        "description": "Datasets are tagged to topics. There are top-level topics, such as ",
+        "description": "Datasets are tagged to topics. There are top-level topics, such as 'Health and social care',  which can have sub-topics, such as 'Dental services'. This endpoint returns a list of the sub-topics for a given  top-level topic_id. If the top-level topic has no sub-topics, the endpoint will return a list of the published  datasets for that topic instead.",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"


### PR DESCRIPTION
Full description for topic endpoints was not displaying due to single quote marks being used.

Default page size is different for those endpoints so override the inherited definition.