### PR TITLE
Use the correct server URL for each env in the api docs

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -18,7 +18,7 @@ const doc = {
     description: `This page will help you use the public API for StatsWales. If you need any other support,
       <a href="mailto:StatsWales@gov.wales">contact StatsWales<a>.`
   },
-  servers: [{ description: 'Development', url: 'https://api.dev.stats.cymru/v1' }],
+  servers: [{ description: 'Development', url: '{{backendURL}}' }],
   components: {
     parameters: {
       language: {

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -18,7 +18,7 @@ const doc = {
     description: `This page will help you use the public API for StatsWales. If you need any other support,
       <a href="mailto:StatsWales@gov.wales">contact StatsWales<a>.`
   },
-  servers: [{ description: 'Development', url: '{{backendURL}}' }],
+  servers: [{ description: 'Public API', url: '{{backendURL}}' }],
   components: {
     parameters: {
       language: {

--- a/src/routes/consumer/v1/docs.ts
+++ b/src/routes/consumer/v1/docs.ts
@@ -1,11 +1,16 @@
 import { Router } from 'express';
 import swaggerUi, { SwaggerUiOptions } from 'swagger-ui-express';
 
-import consumerApiSpec from './openapi.json';
+import spec from './openapi.json';
+import { appConfig } from '../../../config';
 
 export const apiDocRouter = Router();
 
 const opts: SwaggerUiOptions = {};
+const config = appConfig();
+
+// Replace the placeholder in the OpenAPI spec with the actual backend URL
+const consumerApiSpec = JSON.parse(JSON.stringify(spec).replaceAll('{{backendURL}}', config.backend.url));
 
 apiDocRouter.use('/', swaggerUi.serve);
 apiDocRouter.get('/', swaggerUi.setup(consumerApiSpec, opts));

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -8,7 +8,7 @@
   "servers": [
     {
       "description": "Development",
-      "url": "https://api.dev.stats.cymru/v1"
+      "url": "{{backendURL}}"
     }
   ],
   "paths": {

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "description": "Development",
+      "description": "Public API",
       "url": "{{backendURL}}"
     }
   ],


### PR DESCRIPTION
Previously we hardcoded the dev URL, but that doesn't work when viewing the docs on other environments.

Instead, use a placeholder when generating the json spec, and then replace it with the correct backendUrl when serving the docs.