### PR TITLE
Fix download format param in api docs

### DIFF
--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -22,6 +22,7 @@ import { PublishedTopicsDTO } from '../dtos/published-topics-dto';
 import { TopicRepository } from '../repositories/topic';
 import { SortByInterface } from '../interfaces/sort-by-interface';
 import { FilterInterface } from '../interfaces/filterInterface';
+import { DownloadFormat } from '../enums/download-format';
 
 export const listPublishedDatasets = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   /*
@@ -190,7 +191,8 @@ export const downloadPublishedDataset = async (req: Request, res: Response, next
   const formatError = await hasError(formatValidator(), req);
 
   if (formatError) {
-    next(new BadRequestException('file format must be specified (csv, parquet, excel, duckdb)'));
+    const availableFormats = Object.values(DownloadFormat).join(', ');
+    next(new BadRequestException(`file format must be specified (${availableFormats})`));
     return;
   }
 

--- a/src/enums/download-format.ts
+++ b/src/enums/download-format.ts
@@ -1,7 +1,7 @@
 export enum DownloadFormat {
-  Csv = 'csv',
-  DuckDb = 'duckdb',
   Json = 'json',
-  Xlsx = 'xlsx',
-  Parquet = 'parquet'
+  Csv = 'csv',
+  Xlsx = 'xlsx'
+  // DuckDb = 'duckdb',
+  // Parquet = 'parquet'
 }

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -289,7 +289,7 @@
       },
       "format": {
         "name": "format",
-        "in": "query",
+        "in": "path",
         "description": "File format for the download",
         "required": true,
         "schema": {
@@ -297,11 +297,8 @@
           "enum": [
             "json",
             "csv",
-            "xlsx",
-            "parquet",
-            "duckdb"
-          ],
-          "default": "json"
+            "xlsx"
+          ]
         },
         "example": "csv"
       },

--- a/src/routes/consumer/v1/schema.ts
+++ b/src/routes/consumer/v1/schema.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
+import { DownloadFormat } from '../../../enums/download-format';
+
 export const schema = {
   info: {
     version: '1.0.0',
@@ -35,10 +37,10 @@ export const schema = {
       },
       format: {
         name: 'format',
-        in: 'query',
+        in: 'path',
         description: 'File format for the download',
         required: true,
-        schema: { type: 'string', enum: ['json', 'csv', 'xlsx', 'parquet', 'duckdb'], default: 'json' },
+        schema: { type: 'string', enum: Object.values(DownloadFormat) },
         example: 'csv'
       },
       page_number: {

--- a/src/utils/download-headers.ts
+++ b/src/utils/download-headers.ts
@@ -12,20 +12,20 @@ export const getDownloadHeaders = (datasetId: string, format: string, contentLen
   };
 
   switch (format) {
-    case DownloadFormat.Csv:
-      return { ...defaultHeaders, 'content-type': 'text/csv; charset=utf-8' };
-
-    case DownloadFormat.DuckDb:
-      return { ...defaultHeaders, 'content-type': 'application/octet-stream' };
-
     case DownloadFormat.Json:
       return { ...defaultHeaders, 'content-type': 'application/json; charset=utf-8' };
 
-    case DownloadFormat.Parquet:
-      return { ...defaultHeaders, 'content-type': 'application/vnd.apache.parquet' };
+    case DownloadFormat.Csv:
+      return { ...defaultHeaders, 'content-type': 'text/csv; charset=utf-8' };
 
     case DownloadFormat.Xlsx:
       return { ...defaultHeaders, 'content-type': 'application/vnd.ms-excel' };
+
+    // case DownloadFormat.DuckDb:
+    //   return { ...defaultHeaders, 'content-type': 'application/octet-stream' };
+
+    // case DownloadFormat.Parquet:
+    //   return { ...defaultHeaders, 'content-type': 'application/vnd.apache.parquet' };
 
     default:
       throw new BadRequestException('unsupported file format');


### PR DESCRIPTION
The format was showing in both the path and as a query param. This fixes it.

Formats available in the docs should now auto-update as we re-introduce other formats (duckdb etc)