### PR TITLE
Add CASCADE when dropping tables from unpublished cubes

### DIFF
--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -260,8 +260,10 @@ export const validateLookupTable = async (
 
   const quack = await duckdb();
   await linkToPostgres(quack, revision.id, false);
-  await quack.exec(pgformat(`DROP TABLE IF EXISTS %I`, `${makeCubeSafeString(dimension.factTableColumn)}_lookup`));
-  await quack.exec(pgformat('DROP TABLE IF EXISTS %I', lookupTableName));
+  await quack.exec(
+    pgformat(`DROP TABLE IF EXISTS %I CASCADE;`, `${makeCubeSafeString(dimension.factTableColumn)}_lookup`)
+  );
+  await quack.exec(pgformat('DROP TABLE IF EXISTS %I CASCADE;', lookupTableName));
 
   try {
     logger.debug(`Loading lookup table into DuckDB`);

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -289,7 +289,7 @@ async function createMeasureTable(
     }
     // logger.debug(`Extracting lookup table contents to measure using query:\n ${insertQuery}`);
     await quack.exec(insertQuery);
-    await quack.exec(`DROP TABLE ${lookupTable};`);
+    await quack.exec(`DROP TABLE ${lookupTable} CASCADE;`);
     // const measureTable = await quack.all(`SELECT * FROM measure;`);
     // logger.debug(`Creating measureTable from lookup using result:\n${JSON.stringify(measureTable, null, 2)}`);
   } catch (err) {
@@ -390,8 +390,8 @@ export const validateMeasureLookupTable = async (
   const quack = await duckdb();
   try {
     await linkToPostgres(quack, draftRevision.id, false);
-    await quack.exec(pgformat(`DROP TABLE IF EXISTS %I.%I;`, draftRevision.id, 'measure'));
-    await quack.exec(pgformat(`DROP TABLE IF EXISTS %I.%I;`, draftRevision.id, 'preview_table'));
+    await quack.exec(pgformat(`DROP TABLE IF EXISTS %I.%I CASCADE;`, draftRevision.id, 'measure'));
+    await quack.exec(pgformat(`DROP TABLE IF EXISTS %I.%I CASCADE;`, draftRevision.id, 'preview_table'));
   } catch (error) {
     logger.error(error, 'Something went wrong trying to link to postgres database');
     return viewErrorGenerators(500, dataset.id, 'patch', 'errors.cube_builder.fact_table_creation_failed', {});


### PR DESCRIPTION
Fixes an issue where trying to drop existing tables fails because of dependant objects within the cube.