### PR TITLE
Build a new cube with the new revision

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -756,6 +756,7 @@ export const createNewRevision = async (req: Request, res: Response, next: NextF
 
   try {
     const dataset = await req.datasetService.createRevision(res.locals.datasetId, user);
+    await createAllCubeFiles(dataset.id, dataset.draftRevision!.id);
     res.status(201);
     res.json(RevisionDTO.fromRevision(dataset.draftRevision!));
   } catch (err) {


### PR DESCRIPTION
We failed to add the code to build a new cube with the creation of a new revision.  This means that everything other than metadata and the data table routes break as they assume a cube is already present.

This one line PR fixes all those issues.