### PR TITLE
move ci seeds to src/ so they exist in final image

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are a number of fixtures (e.g. test users and sample datasets) used by the
 `/test/fixtures`. These must be loaded into the dev or test database before the e2e tests are run:
 
 ```bash
-npm run seed:e2e
+npm run seed:ci
 ```
 
 ## Data migrations

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start": "node dist/server.js",
     "typeorm": "typeorm-ts-node-commonjs",
     "typeorm-seeding": "ts-node ./node_modules/@jorgebodega/typeorm-seeding/dist/cli.js",
+    "seed-js": "node ./node_modules/@jorgebodega/typeorm-seeding/dist/cli.js",
     "migration:show": "npm run typeorm migration:show -- --dataSource=./src/db/data-source.ts",
     "migration:run": "npm run typeorm migration:run -- --dataSource=./src/db/data-source.ts",
     "migration:run-prod": "typeorm migration:run --dataSource=./dist/db/data-source.js",
@@ -31,9 +32,9 @@
     "migration:create": "npm run typeorm migration:create",
     "seed:required": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/required/*.ts",
     "seed:dataset": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/dataset.ts",
-    "seed:e2e": "npm run seed:ci",
-    "seed:ci": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./test/fixtures/seed-test-fixtures.ts",
-    "assign-default-group": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/groups.ts"
+    "seed:ci": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/tests/seed.ts",
+    "assign-default-group": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/groups.ts",
+    "init:ci": "typeorm migration:run -d ./dist/db/data-source.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/required/*.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/tests/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/src/seeders/tests/fixtures/datasets.ts
+++ b/src/seeders/tests/fixtures/datasets.ts
@@ -123,8 +123,7 @@ const generatePublishedDataset = (): DeepPartial<Dataset> => {
   };
 };
 
-const csvData = `
-YearCode,AreaCode,Data,RowRef,Measure,NoteCodes
+const csvData = `YearCode,AreaCode,Data,RowRef,Measure,NoteCodes
 202223,512,1.442546584,2,2,
 202223,512,1.563664596,3,2,
 202223,512,3.220496894,1,2,

--- a/src/seeders/tests/fixtures/datasets.ts
+++ b/src/seeders/tests/fixtures/datasets.ts
@@ -1,17 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import path from 'node:path';
+import fs from 'node:fs';
 
 import { v4 as uuid } from 'uuid';
 import { DeepPartial } from 'typeorm';
 import { faker } from '@faker-js/faker';
 
-import { Dataset } from '../../src/entities/dataset/dataset';
+import { Dataset } from '../../../entities/dataset/dataset';
 
 import { publisher1 } from './users';
-import { Designation } from '../../src/enums/designation';
-import { RevisionMetadata } from '../../src/entities/dataset/revision-metadata';
+import { Designation } from '../../../enums/designation';
+import { RevisionMetadata } from '../../../entities/dataset/revision-metadata';
 import { testGroup } from './group';
-import { Locale } from '../../src/enums/locale';
+import { Locale } from '../../../enums/locale';
 
 export const uploadPageTest: DeepPartial<Dataset> = {
   id: '936c1ab4-2b33-4b13-8949-4316a156d24b',
@@ -122,14 +123,43 @@ const generatePublishedDataset = (): DeepPartial<Dataset> => {
   };
 };
 
-const sureStartShort = path.join(__dirname, `../sample-files/csv/sure-start-short.csv`);
+const csvData = `
+YearCode,AreaCode,Data,RowRef,Measure,NoteCodes
+202223,512,1.442546584,2,2,
+202223,512,1.563664596,3,2,
+202223,512,3.220496894,1,2,
+202223,512,929.0,2,1,
+202223,512,1007.0,3,1,
+202223,512,2074.0,1,1,
+202223,596,0.93745237,3,2,a
+202223,596,1.635044737,2,2,a
+202223,596,3.53077987,1,2,a
+202223,596,33213.0,3,1,t
+202223,596,57928.0,2,1,t
+202223,596,125092.0,1,1,t
+202122,512,1.190839695,3,2,
+202122,512,1.253435115,2,2,
+202122,512,3.458015267,1,2,
+202122,512,780.0,3,1,
+202122,512,821.0,2,1,
+202122,512,2265.0,1,1,
+202122,596,1.060637144,3,2,a
+202122,596,1.507751824,2,2,a
+202122,596,4.030567686,1,2,a
+202122,596,36190.0,3,1,t
+202122,596,51446.0,2,1,t
+202122,596,137527.0,1,1,t
+`;
+
+const tmpFilePath = path.join(__dirname, `./sure-start-short.csv`);
+fs.writeFileSync(tmpFilePath, csvData);
 
 export const testDatasets = [
   { dataset: uploadPageTest },
-  { dataset: previewPageTestA, csvPath: sureStartShort },
-  { dataset: previewPageTestB, csvPath: sureStartShort },
-  { dataset: sourcesPageTest, csvPath: sureStartShort },
-  { dataset: metadataTestA, csvPath: sureStartShort },
-  { dataset: metadataTestB, csvPath: sureStartShort }
+  { dataset: previewPageTestA, csvPath: tmpFilePath },
+  { dataset: previewPageTestB, csvPath: tmpFilePath },
+  { dataset: sourcesPageTest, csvPath: tmpFilePath },
+  { dataset: metadataTestA, csvPath: tmpFilePath },
+  { dataset: metadataTestB, csvPath: tmpFilePath }
   // ...Array.from({ length: 22 }, () => ({ dataset: generatePublishedDataset(), csvPath: sureStartShort }))
 ];

--- a/src/seeders/tests/fixtures/datasets.ts
+++ b/src/seeders/tests/fixtures/datasets.ts
@@ -151,7 +151,10 @@ const csvData = `YearCode,AreaCode,Data,RowRef,Measure,NoteCodes
 `;
 
 const tmpFilePath = path.join(__dirname, `./sure-start-short.csv`);
-fs.writeFileSync(tmpFilePath, csvData);
+
+export const setupTmpCsv = (): void => {
+  fs.writeFileSync(tmpFilePath, csvData);
+};
 
 export const testDatasets = [
   { dataset: uploadPageTest },

--- a/src/seeders/tests/fixtures/group.ts
+++ b/src/seeders/tests/fixtures/group.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from 'typeorm';
 
-import { UserGroup } from '../../src/entities/user/user-group';
-import { Locale } from '../../src/enums/locale';
+import { UserGroup } from '../../../entities/user/user-group';
+import { Locale } from '../../../enums/locale';
 
 // using hard coded uuids so that we can re-run the seeder for updates without creating new records
 export const testGroup: DeepPartial<UserGroup> = {

--- a/src/seeders/tests/fixtures/users.ts
+++ b/src/seeders/tests/fixtures/users.ts
@@ -1,9 +1,9 @@
 import { DeepPartial } from 'typeorm';
 
-import { User } from '../../src/entities/user/user';
-import { GlobalRole } from '../../src/enums/global-role';
-import { GroupRole } from '../../src/enums/group-role';
 import { testGroup } from './group';
+import { User } from '../../../entities/user/user';
+import { GlobalRole } from '../../../enums/global-role';
+import { GroupRole } from '../../../enums/group-role';
 
 export const admin1: DeepPartial<User> = {
   id: '044d94c5-91ba-495e-a718-31c597a0a30b',

--- a/src/seeders/tests/seed.ts
+++ b/src/seeders/tests/seed.ts
@@ -11,7 +11,7 @@ import { AppEnv } from '../../config/env.enum';
 import { validateAndUpload } from '../../services/csv-processor';
 
 import { testUsers } from './fixtures/users';
-import { testDatasets } from './fixtures/datasets';
+import { setupTmpCsv, testDatasets } from './fixtures/datasets';
 import { Revision } from '../../entities/dataset/revision';
 import { UserGroup } from '../../entities/user/user-group';
 import { testGroup } from './fixtures/group';
@@ -48,6 +48,8 @@ export default class SeedTestFixtures extends Seeder {
   async seedDatasets(dataSource: DataSource): Promise<void> {
     console.log(`Seeding ${testDatasets.length} test datasets...`);
     const entityManager = dataSource.createEntityManager();
+
+    setupTmpCsv();
 
     for (const testDataset of testDatasets) {
       try {

--- a/src/seeders/tests/seed.ts
+++ b/src/seeders/tests/seed.ts
@@ -4,17 +4,18 @@ import { Seeder } from '@jorgebodega/typeorm-seeding';
 import { DataSource } from 'typeorm';
 import { omit } from 'lodash';
 
-import { User } from '../../src/entities/user/user';
-import { Dataset } from '../../src/entities/dataset/dataset';
-import { appConfig } from '../../src/config';
-import { AppEnv } from '../../src/config/env.enum';
-import { validateAndUpload } from '../../src/services/csv-processor';
+import { User } from '../../entities/user/user';
+import { Dataset } from '../../entities/dataset/dataset';
+import { appConfig } from '../../config';
+import { AppEnv } from '../../config/env.enum';
+import { validateAndUpload } from '../../services/csv-processor';
 
-import { testUsers } from './users';
-import { testDatasets } from './datasets';
-import { Revision } from '../../src/entities/dataset/revision';
-import { UserGroup } from '../../src/entities/user/user-group';
-import { testGroup } from './group';
+import { testUsers } from './fixtures/users';
+import { testDatasets } from './fixtures/datasets';
+import { Revision } from '../../entities/dataset/revision';
+import { UserGroup } from '../../entities/user/user-group';
+import { testGroup } from './fixtures/group';
+import { TempFile } from '../../interfaces/temp-file';
 
 const config = appConfig();
 
@@ -30,7 +31,7 @@ export default class SeedTestFixtures extends Seeder {
     await this.seedDatasets(dataSource);
   }
 
-  async seedTestGroup(dataSource: DataSource) {
+  async seedTestGroup(dataSource: DataSource): Promise<void> {
     console.log(`seeding test group...`);
     const entityManager = dataSource.createEntityManager();
     const group = entityManager.create(UserGroup, testGroup);
@@ -55,11 +56,11 @@ export default class SeedTestFixtures extends Seeder {
         const dataset = await entityManager.getRepository(Dataset).create(partialDataset).save();
 
         if (revision && testDataset.csvPath) {
-          const file = {
+          const file: TempFile = {
             mimetype: 'text/csv',
             originalname: 'test-fixture.csv',
             path: testDataset.csvPath
-          } as any;
+          };
           const dataTable = await validateAndUpload(file, dataset.id, 'data_table');
 
           revision = await entityManager.getRepository(Revision).save({


### PR DESCRIPTION
Now that the backend image no longer contains the test dir, we need another way of seeding the e2e testing environment for the playwright tests on the frontend.
