### PR TITLE
Allow large files (500MB) to be streamed to clamAV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,7 @@ services:
     platform: linux/amd64 # no arm64 image currently available, force amd64
     ports:
       - '3310:3310'
+    environment:
+      CLAMD_CONF_MaxFileSize: 500M
+      CLAMD_CONF_MaxScanSize: 500M
+      CLAMD_CONF_StreamMaxLength: 500M

--- a/src/middleware/file-streaming.ts
+++ b/src/middleware/file-streaming.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { parseFormData } from 'pechkin';
 import { Internal } from 'pechkin/dist/types.js';
+import { merge } from 'lodash';
 
 import { logger } from '../utils/logger';
 import { BadRequestException } from '../exceptions/bad-request.exception';
@@ -15,8 +16,14 @@ export const fileStreaming = (
   busboyConfig?: Internal.BusboyConfig
 ) => {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const defaultFileConfig: Partial<Internal.Config> = {
+      maxFileByteLength: 500 * 1024 * 1024 // 500MB
+    };
+
+    const finalConfig = merge({}, defaultFileConfig, config);
+
     try {
-      const { fields, files } = await parseFormData(req, config, fileFieldConfigOverride, busboyConfig);
+      const { fields, files } = await parseFormData(req, finalConfig, fileFieldConfigOverride, busboyConfig);
       req.body = fields;
       req.files = files;
       return next();


### PR DESCRIPTION
I've picked an arbitrary limit of 500MB... I think ClamAV has a hard limit of 4GB but that's only feasible with a lot more memory dedicated to the container (I think we set 3GB?). 1GB might be doable, but haven't tested it.

I don't think it's completely unreasonable to ask publishers to break up datasets larger than 500MB in to several revisions?

The env vars will need adding to our ClamAV containers @easternbloc.