### PR TITLE
Update duckdb.ts to use schema name in connection name

### DIFF
--- a/src/services/duckdb.ts
+++ b/src/services/duckdb.ts
@@ -50,6 +50,6 @@ export const linkToPostgresSchema = async (quack: Database, schema: 'lookup_tabl
       PASSWORD '${config.database.password}'
     );
   `);
-  await quack.exec(pgformat(`ATTACH '' AS data_tables_db (TYPE postgres, SCHEMA %L);`, schema));
-  await quack.exec(`USE data_tables_db;`);
+  await quack.exec(pgformat(`ATTACH '' AS %I (TYPE postgres, SCHEMA %L);`, `${schema}_db`, schema));
+  await quack.exec(pgformat(`USE %I;`, `${schema}_db`));
 };


### PR DESCRIPTION
During the PR process I dropped the two connection methods for a single method which takes an argument for the schema to connect to.  The Schema wasn't passed to the connection name or used when the initial connection is made.