### PR TITLE
SW-874: enforce measure and data value column

### DIFF
--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -150,6 +150,10 @@ export const validateSourceAssignment = (
     throw new SourceAssignmentException('errors.source_assignment.missing_footnotes');
   }
 
+  if (validated.dimensions.length < 1) {
+    throw new SourceAssignmentException('errors.source_assignment.missing_dimensions');
+  }
+
   return validated;
 };
 

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -84,60 +84,73 @@ export const setupTextDimension = async (dimension: Dimension): Promise<void> =>
 };
 
 export const validateSourceAssignment = (
-  fileImport: DataTable,
+  dataTable: DataTable,
   sourceAssignment: SourceAssignmentDTO[]
 ): ValidatedSourceAssignment => {
-  let dataValues: SourceAssignmentDTO | null = null;
-  let noteCodes: SourceAssignmentDTO | null = null;
-  let measure: SourceAssignmentDTO | null = null;
-  const dimensions: SourceAssignmentDTO[] = [];
-  const ignore: SourceAssignmentDTO[] = [];
-  // logger.debug(`Validating source assignment from: ${JSON.stringify(sourceAssignment, null, 2)}`);
+  const validated: ValidatedSourceAssignment = {
+    dataValues: null,
+    measure: null,
+    noteCodes: null,
+    dimensions: [],
+    ignore: []
+  };
+
+  const validColumnNames = dataTable.dataTableDescriptions?.map((col: DataTableDescription) => col.columnName) || [];
 
   sourceAssignment.map((sourceInfo) => {
-    if (
-      !fileImport.dataTableDescriptions?.find(
-        (info: DataTableDescription) => info.columnName === sourceInfo.column_name
-      )
-    ) {
+    if (!validColumnNames.includes(sourceInfo.column_name)) {
       throw new SourceAssignmentException(`errors.source_assignment.invalid_column_name`);
     }
 
     switch (sourceInfo.column_type) {
       case FactTableColumnType.DataValues:
-        if (dataValues) {
+        if (validated.dataValues) {
           throw new SourceAssignmentException('errors.source_assignment.too_many_data_values');
         }
-        dataValues = sourceInfo;
+        validated.dataValues = sourceInfo;
         break;
+
       case FactTableColumnType.Measure:
-        if (measure) {
+        if (validated.measure) {
           throw new SourceAssignmentException('errors.source_assignment.too_many_measure');
         }
-        measure = sourceInfo;
+        validated.measure = sourceInfo;
         break;
+
       case FactTableColumnType.NoteCodes:
-        if (noteCodes) {
+        if (validated.noteCodes) {
           throw new SourceAssignmentException('errors.source_assignment.too_many_footnotes');
         }
-        noteCodes = sourceInfo;
+        validated.noteCodes = sourceInfo;
         break;
+
       case FactTableColumnType.Time:
       case FactTableColumnType.Dimension:
-        dimensions.push(sourceInfo);
+        validated.dimensions.push(sourceInfo);
         break;
+
       case FactTableColumnType.Ignore:
-        ignore.push(sourceInfo);
+        validated.ignore.push(sourceInfo);
         break;
+
       default:
         throw new SourceAssignmentException(`errors.source_assignment.invalid_source_type`);
     }
   });
-  if (!noteCodes) {
+
+  if (!validated.dataValues) {
+    throw new SourceAssignmentException('errors.source_assignment.missing_data_values');
+  }
+
+  if (!validated.measure) {
+    throw new SourceAssignmentException('errors.source_assignment.missing_measure');
+  }
+
+  if (!validated.noteCodes) {
     throw new SourceAssignmentException('errors.source_assignment.missing_footnotes');
   }
 
-  return { dataValues, measure, noteCodes, dimensions, ignore };
+  return validated;
 };
 
 async function createUpdateDimension(dataset: Dataset, columnDescriptor: SourceAssignmentDTO): Promise<void> {

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -97,7 +97,7 @@ export const validateSourceAssignment = (
 
   const validColumnNames = dataTable.dataTableDescriptions?.map((col: DataTableDescription) => col.columnName) || [];
 
-  sourceAssignment.map((sourceInfo) => {
+  sourceAssignment.forEach((sourceInfo) => {
     if (!validColumnNames.includes(sourceInfo.column_name)) {
       throw new SourceAssignmentException(`errors.source_assignment.invalid_column_name`);
     }


### PR DESCRIPTION
This updates the backend source validation to match the new rules applied on the frontend.

dataValues === 1
measure === 1
noteCodes === 1
dimensions > 0
