### PR TITLE
Fix an issue in date matching where the year didn't advance

### DIFF
--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -236,7 +236,10 @@ function periodTableCreator(
               : `${t('date_format.quarter_abr', { lng: locale })}${quarterIndex} ${format(displayYear, 'yyyy')}-${format(add(displayYear, { years: 1 }), 'yy')}`;
           break;
         case GeneratorType.Month:
-          description = `${t(`months.${monthNo}`, { lng: locale })} ${format(displayYear, 'yyyy')}`;
+          description =
+            dateFormat.type === YearType.Calendar
+              ? `${t(`months.${monthNo}`, { lng: locale })} ${format(displayYear, 'yyyy')}`
+              : `${t(`months.${monthNo}`, { lng: locale })} ${format(displayYear, 'yyyy')}-${format(add(displayYear, { years: 1 }), 'yy')}`;
           break;
       }
 
@@ -291,14 +294,14 @@ function periodTableCreator(
         }
         break;
       case GeneratorType.Month:
-        if (monthIndex <= 12) {
+        if (monthIndex < 12) {
           if (monthIndex % 3 === 0) quarterIndex++;
           monthIndex++;
         } else {
           monthIndex = 1;
           quarterIndex = 1;
         }
-        if (displayYear !== displayYear && monthIndex === 1) {
+        if (year !== displayYear && monthIndex === 1) {
           displayYear = year;
         }
     }


### PR DESCRIPTION
The display year was failing to advance when processing month data. This will have caused issues for create and update journeies using month based data.  The issue showed itself more when trying to create the filter table in the cube builder as this failed due to a bad primary key constraint.