### PR TITLE
Fix column name recorded by setupMeasureNoDataValues

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1206,7 +1206,7 @@ function setupMeasureNoDataValues(
 ): void {
   SUPPORTED_LOCALES.map((locale) => {
     if (dataValuesColumn) {
-      columnNames.get(locale)?.add(dataValuesColumn.columnName);
+      columnNames.get(locale)?.add(t('column_headers.data_values', { lng: locale }));
       viewSelectStatementsMap
         .get(locale)
         ?.push(


### PR DESCRIPTION
The function was recording the column name from the fact table rather than the column name which we give it.  So when the previews were trying to select the column they were told the column didn't exist resulting in an error.