### PR TITLE
Add env config for db pool (default to 5 connections)

### DIFF
--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -64,6 +64,9 @@ export interface AppConfig {
     database: string;
     ssl?: boolean;
     synchronize?: boolean;
+    poolSize?: number;
+    idleTimeoutMs?: number;
+    connectionTimeoutMs?: number;
   };
   auth: {
     providers: AuthProvider[];

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -47,7 +47,10 @@ export const getDefaultConfig = (): AppConfig => {
       password: process.env.DB_PASSWORD!,
       database: process.env.DB_DATABASE!,
       ssl: true,
-      synchronize: false
+      synchronize: false,
+      poolSize: parseInt(process.env.DB_POOL_SIZE || '5', 10),
+      idleTimeoutMs: parseInt(process.env.DB_IDLE_TIMEOUT_MS || '10000', 10),
+      connectionTimeoutMs: parseInt(process.env.DB_CONNECTION_TIMEOUT_MS || '2000', 10)
     },
     auth: {
       providers: [],

--- a/src/db/data-source.ts
+++ b/src/db/data-source.ts
@@ -22,7 +22,12 @@ const dataSourceOpts: DataSourceOptions = {
   synchronize: config.database.synchronize,
   logging: false,
   entities: [`${__dirname}/../entities/**/*.{ts,js}`],
-  migrations: [`${__dirname}/../migrations/*.{ts,js}`]
+  migrations: [`${__dirname}/../migrations/*.{ts,js}`],
+  extra: {
+    max: config.database.poolSize,
+    idleTimeoutMillis: config.database.idleTimeoutMs,
+    connectionTimeoutMillis: config.database.connectionTimeoutMs
+  }
 };
 
 export const dataSource = new DataSource(dataSourceOpts);


### PR DESCRIPTION
Provide a way to configure the postgres pool.

Set the default pool size to 5 instead of 10.