### PR TITLE
Fix the tasklist to show when a dimension needs an update

### DIFF
--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -87,7 +87,7 @@ export class TasklistStateDTO {
         const updateTask = revision.tasks?.dimensions.find((task) => task.id === dimension.id);
 
         if (updateTask) {
-          status = updateTask.lookupTableUpdated ? TaskListStatus.Updated : TaskListStatus.Unchanged;
+          status = updateTask.lookupTableUpdated ? TaskListStatus.Updated : TaskListStatus.NotStarted;
         }
       } else {
         status = dimension.extractor === null ? TaskListStatus.NotStarted : TaskListStatus.Completed;


### PR DESCRIPTION
When a dimension needs an update its task should show as not started.  Just fixes the state when there is an update task present and now sends the correct state.