### PR TITLE
our build path changes for prod so we need an extra task for the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "seed:dataset": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/dataset.ts",
     "seed:ci": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/tests/seed.ts",
     "assign-default-group": "npm run typeorm-seeding -- -d ./src/db/data-source.ts ./src/seeders/groups.ts",
-    "init:ci": "typeorm migration:run -d ./dist/db/data-source.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/required/*.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/tests/seed.js"
+    "init:ci": "typeorm migration:run -d ./dist/db/data-source.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/required/*.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/tests/seed.js",
+    "init:prod": "typeorm migration:run -d ./dist/db/data-source.js && npm run seed-js -- -d ./dist/db/data-source.js ./dist/seeders/required/*.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This pull request introduces a new npm script to streamline production database initialization. The change adds the `init:prod` script to the `package.json` file, enabling migrations and required seeders to be applied in production environments.

Database initialization:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R38): Added the `init:prod` script to execute TypeORM migrations and seed required data for production environments.