### PR TITLE
run local blobstorage on docker compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
 
   blobstorage:
     image: mcr.microsoft.com/azure-storage/azurite
-    container_name: 'azurite'
     # command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --debug=/tmp/debug.log
     ports:
       - "10000:10000"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest --coverage",
     "test:ci": "jest --ci --coverage --config=jest.config.ts",
     "check": "npm-run-all prettier:fix lint:fix test clean build",
-    "predev": "bash -c ' func() { if [ $(command -v podman) ]; then podman compose up -d db-dev valkey clamav; else docker compose up -d db-dev valkey clamav; fi }; func'",
+    "predev": "bash -c ' func() { if [ $(command -v podman) ]; then podman compose up -d blobstorage db-dev valkey clamav; else docker compose up -d blobstorage db-dev valkey clamav; fi }; func'",
     "dev:check": "npm-run-all check dev",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts | pino-colada",
     "start": "node dist/server.js",


### PR DESCRIPTION
The datalake on the dev env is no-longer publicly accessible, so start up the emulated blobstorage (azurite) container and use that for the file store by default on localhost.

You will need the config from the env-example: https://github.com/Marvell-Consulting/statswales-backend/blob/main/.env-example#L35-L40