### PR TITLE
SW-561: gather publisher org and contact email for dataset

### DIFF
--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -28,7 +28,7 @@ export const loadUserGroup = async (req: Request, res: Response, next: NextFunct
   }
 
   try {
-    const group = await UserGroupRepository.getById(req.params.user_group_id);
+    const group = await UserGroupRepository.getByIdWithDatasets(req.params.user_group_id);
     res.locals.userGroup = group;
     res.locals.userGroupId = group.id;
   } catch (error) {

--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -23,6 +23,8 @@ import { SortByInterface } from '../interfaces/sort-by-interface';
 import { FilterInterface } from '../interfaces/filterInterface';
 import { DownloadFormat } from '../enums/download-format';
 import { DEFAULT_PAGE_SIZE } from '../utils/page-defaults';
+import { UserGroupRepository } from '../repositories/user-group';
+import { PublisherDTO } from '../dtos/publisher-dto';
 
 export const listPublishedDatasets = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   /*
@@ -73,7 +75,14 @@ export const getPublishedDatasetById = async (req: Request, res: Response): Prom
     }
   */
   const dataset = await PublishedDatasetRepository.getById(res.locals.datasetId, withAll);
-  res.json(ConsumerDatasetDTO.fromDataset(dataset));
+  const datasetDTO = ConsumerDatasetDTO.fromDataset(dataset);
+
+  if (dataset.userGroupId) {
+    const userGroup = await UserGroupRepository.getByIdWithOrganisation(dataset.userGroupId);
+    datasetDTO.publisher = PublisherDTO.fromUserGroup(userGroup, req.language as Locale);
+  }
+
+  res.json(datasetDTO);
 };
 
 export const getPublishedDatasetView = async (req: Request, res: Response): Promise<void> => {

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -6,6 +6,7 @@ import { Revision } from '../entities/dataset/revision';
 
 import { DimensionDTO } from './dimension-dto';
 import { ConsumerRevisionDTO } from './consumer-revision-dto';
+import { PublisherDTO } from './publisher-dto';
 
 // WARNING: Make sure to filter any props the consumer side should not have access to
 export class ConsumerDatasetDTO {
@@ -16,6 +17,7 @@ export class ConsumerDatasetDTO {
   published_revision?: ConsumerRevisionDTO;
   start_date?: Date | null;
   end_date?: Date | null;
+  publisher?: PublisherDTO;
 
   static fromDataset(dataset: Dataset): ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();

--- a/src/dtos/publisher-dto.ts
+++ b/src/dtos/publisher-dto.ts
@@ -1,0 +1,24 @@
+import { UserGroup } from '../entities/user/user-group';
+import { OrganisationDTO } from './organisation-dto';
+import { Locale } from '../enums/locale';
+import { UserGroupListItemDTO } from './user/user-group-list-item-dto';
+
+export class PublisherDTO {
+  group: UserGroupListItemDTO;
+  organisation: OrganisationDTO;
+
+  static fromUserGroup(userGroup: UserGroup, lang: Locale): PublisherDTO {
+    const dto = new PublisherDTO();
+    dto.group = {
+      id: userGroup.id,
+      name: userGroup.metadata?.find((m) => m.language === lang)?.name || '',
+      email: userGroup.metadata?.find((m) => m.language === lang)?.email || ''
+    };
+
+    if (userGroup.organisation) {
+      dto.organisation = OrganisationDTO.fromOrganisation(userGroup.organisation, lang);
+    }
+
+    return dto;
+  }
+}

--- a/src/repositories/user-group.ts
+++ b/src/repositories/user-group.ts
@@ -7,7 +7,17 @@ import { Locale } from '../enums/locale';
 import { ResultsetWithCount } from '../interfaces/resultset-with-count';
 
 export const UserGroupRepository = dataSource.getRepository(UserGroup).extend({
-  async getById(id: string): Promise<UserGroup> {
+  async getByIdWithOrganisation(id: string): Promise<UserGroup> {
+    return this.findOneOrFail({
+      where: { id },
+      relations: {
+        metadata: true,
+        organisation: { metadata: true }
+      }
+    });
+  },
+
+  async getByIdWithDatasets(id: string): Promise<UserGroup> {
     return this.findOneOrFail({
       where: { id },
       relations: {


### PR DESCRIPTION
adds dataset user group & org info to the object returned for consumer view so that we can render it on the about page.