### PR TITLE
SW-667 Remove parsing and processing of measure translations

### DIFF
--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -238,18 +238,6 @@ export class DatasetService {
 
     await RevisionRepository.save(revision);
 
-    if (measure?.metadata) {
-      logger.debug(`Updating measure translations...`);
-      const measureTranslation = translations.find((t) => t.type === 'measure')!;
-      await Promise.all(
-        measure.metadata?.map((metadata) => {
-          metadata.name =
-            (metadata.language === Locale.EnglishGb ? measureTranslation.english : measureTranslation.cymraeg) ?? '';
-          metadata.save();
-        })
-      );
-    }
-
     return DatasetRepository.getById(datasetId, {});
   }
 

--- a/src/utils/collect-translations.ts
+++ b/src/utils/collect-translations.ts
@@ -30,23 +30,6 @@ export const collectTranslations = (dataset: Dataset, includeIds = false, revisi
         id: dimension.id
       };
     }),
-    ...(dataset.measure
-      ? [
-          ((measure): TranslationDTO => {
-            const factTableColumn = measure.factTableColumn;
-            const measureMetaEN = measure.metadata.find((m) => m.language.includes('en'));
-            const measureMetaCY = measure.metadata.find((m) => m.language.includes('cy'));
-            const measureNameEN = measureMetaEN?.name;
-            const measureNameCY = measureMetaCY?.name;
-            return {
-              type: 'measure',
-              key: factTableColumn,
-              english: measureNameEN as string,
-              cymraeg: measureNameCY as string
-            };
-          })(dataset.measure)
-        ]
-      : []),
     ...metadataKeys.map((prop) => ({
       type: 'metadata',
       key: prop,


### PR DESCRIPTION
In order to allow the front-end to skip over the name of the measure we also need to remove the measure from translation processing.