### PR TITLE
SW-926: CubeDB was missing the search path so validation check failed to find fact_table

### DIFF
--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -246,8 +246,6 @@ async function identifyIncompleteFacts(
       FactTableValidationExceptionType.UnknownError,
       400
     );
-  } finally {
-    cubeDB.release();
   }
   return undefined;
 }
@@ -293,8 +291,6 @@ async function identifyDuplicateFacts(
       FactTableValidationExceptionType.UnknownError,
       400
     );
-  } finally {
-    cubeDB.release();
   }
   return undefined;
 }

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -126,12 +126,12 @@ export const factTableValidatorFromSource = async (
     logger.error(err, 'Failed to apply primary key to fact table.');
     if ((err as Error).message.includes('could not create unique index')) {
       let error: FactTableValidationException | undefined;
-      error = await identifyDuplicateFacts(primaryKeyDef);
+      error = await identifyDuplicateFacts(cubeDB, primaryKeyDef);
       if (error) throw error;
-      error = await identifyIncompleteFacts(primaryKeyDef);
+      error = await identifyIncompleteFacts(cubeDB, primaryKeyDef);
       if (error) throw error;
     } else if ((err as Error).message.includes('contains null values')) {
-      const error = await identifyIncompleteFacts(primaryKeyDef);
+      const error = await identifyIncompleteFacts(cubeDB, primaryKeyDef);
       if (error) throw error;
       throw new FactTableValidationException(
         'Incomplete facts found in fact table.',
@@ -216,9 +216,11 @@ async function validateNoteCodesColumn(
   throw error;
 }
 
-async function identifyIncompleteFacts(primaryKeyDef: string[]): Promise<FactTableValidationException | undefined> {
+async function identifyIncompleteFacts(
+  cubeDB: QueryRunner,
+  primaryKeyDef: string[]
+): Promise<FactTableValidationException | undefined> {
   const pkeyDef = primaryKeyDef.map((key) => pgformat('%I IS NULL', key));
-  const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
   try {
     const incompleteFactQuery = pgformat(
       `SELECT * FROM (SELECT row_number() OVER () as line_number, * FROM fact_table) WHERE %s LIMIT 500;`,
@@ -250,7 +252,10 @@ async function identifyIncompleteFacts(primaryKeyDef: string[]): Promise<FactTab
   return undefined;
 }
 
-async function identifyDuplicateFacts(primaryKeyDef: string[]): Promise<FactTableValidationException | undefined> {
+async function identifyDuplicateFacts(
+  cubeDB: QueryRunner,
+  primaryKeyDef: string[]
+): Promise<FactTableValidationException | undefined> {
   const pkeyDef = primaryKeyDef.map((key) => pgformat('%I', key));
   const duplicateFactQuery = pgformat(
     `
@@ -266,8 +271,6 @@ async function identifyDuplicateFacts(primaryKeyDef: string[]): Promise<FactTabl
     pkeyDef.join(', '),
     pkeyDef.join(', ')
   );
-
-  const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
 
   try {
     logger.debug(`Running query to find duplicates:\n${duplicateFactQuery}`);


### PR DESCRIPTION
CubeDB query passthrough got missed in a couple of places when trying to fix the run away db connections in https://github.com/Marvell-Consulting/statswales-backend/pull/352

The validation was failing to query the fact table because the search path was not set to the correct cube.