### PR TITLE
Fix e2e tests due to reference data issues

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -531,11 +531,10 @@ async function setupReferenceDataDimension(
           %L as fact_table_column,
           %L as dimension_name,
           reference_data_info.description as description,
-          hierarchy.parent_id as hierarchy,
+          NULL as hierarchy,
           reference_data.sort_order as sort_order
         FROM fact_table
         LEFT JOIN reference_data on CAST(fact_table.%I AS VARCHAR)=reference_data.item_id
-        LEFT JOIN hierarchy ON reference_data.item_id=hierarchy.item_id
         JOIN reference_data_info ON reference_data.item_id=reference_data_info.item_id
         AND reference_data_info.lang=%L
         ORDER BY sort_order, description);


### PR DESCRIPTION
The hierarchy reference data has multiple entries for the same item_id and we don't have enough to narrow it down to only a single parent based on current implementation.  We upcoming changes to reference data this problem goes away.  Fix for now is to disable hierarchies in reference data again.