### PR TITLE
SW-946: clear any existing PK before attempting to assign one

### DIFF
--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -33,6 +33,8 @@ export const factTableValidatorFromSource = async (
     );
   }
 
+  logger.debug(`Validating fact table for revision ${revision.id}`);
+
   if (!dataset.factTable) {
     throw new Error(`Unable to find fact table for dataset ${dataset.id}`);
   }
@@ -119,6 +121,14 @@ export const factTableValidatorFromSource = async (
   }
 
   try {
+    logger.debug(`Dropping primary key if it exists on fact_table`);
+    const dropPKQuery = pgformat(
+      `ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I;`,
+      FACT_TABLE_NAME,
+      `${FACT_TABLE_NAME}_pkey`
+    );
+    await cubeDB.query(dropPKQuery);
+    logger.debug(`Adding primary key to fact table ${FACT_TABLE_NAME} with columns: ${primaryKeyDef.join(', ')}`);
     const pkQuery = pgformat('ALTER TABLE %I ADD PRIMARY KEY (%I)', FACT_TABLE_NAME, primaryKeyDef);
     await cubeDB.query(pkQuery);
     await validateNoteCodesColumn(cubeDB, validatedSourceAssignment.noteCodes, FACT_TABLE_NAME);

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -128,7 +128,7 @@ export const factTableValidatorFromSource = async (
       `${FACT_TABLE_NAME}_pkey`
     );
     await cubeDB.query(dropPKQuery);
-    logger.debug(`Adding primary key to fact table ${FACT_TABLE_NAME} with columns: ${primaryKeyDef.join(', ')}`);
+    logger.debug(`Adding primary key to fact_table with columns: ${primaryKeyDef.join(', ')}`);
     const pkQuery = pgformat('ALTER TABLE %I ADD PRIMARY KEY (%I)', FACT_TABLE_NAME, primaryKeyDef);
     await cubeDB.query(pkQuery);
     await validateNoteCodesColumn(cubeDB, validatedSourceAssignment.noteCodes, FACT_TABLE_NAME);


### PR DESCRIPTION
When attempting to re-assign sources, the fact table already exists in the cube, and attempting to add a PK will fail with the error:

> multiple primary keys for table \"fact_table\" are not allowed

To prevent this, remove any existing PK first so that we're starting from a blank slate.