### PR TITLE
Found a bug when processing half processed cubes

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1671,21 +1671,13 @@ function setupMeasureNoDataValues(
         .get(locale)
         ?.push(pgformat('NULL AS %I', `${t('column_headers.measure', { lng: locale })}_hierarchy`));
 
-      viewSelectStatementsMap
-        .get(locale)
-        ?.push(pgformat('%I', FACT_TABLE_NAME, t('column_headers.measure', { lng: locale })));
-      rawSelectStatementsMap
-        .get(locale)
-        ?.push(pgformat('%I', FACT_TABLE_NAME, t('column_headers.measure', { lng: locale })));
-      defaultSortSelectStatementsMap
-        .get(locale)
-        ?.push(pgformat('%I', FACT_TABLE_NAME, t('column_headers.measure', { lng: locale })));
+      viewSelectStatementsMap.get(locale)?.push(pgformat('%I', t('column_headers.measure', { lng: locale })));
+      rawSelectStatementsMap.get(locale)?.push(pgformat('%I', t('column_headers.measure', { lng: locale })));
+      defaultSortSelectStatementsMap.get(locale)?.push(pgformat('%I', t('column_headers.measure', { lng: locale })));
       defaultSortSelectStatementsMap
         .get(locale)
         ?.push(pgformat('%I', `${t('column_headers.measure', { lng: locale })}_sort`));
-      rawSortSelectStatementsMap
-        .get(locale)
-        ?.push(pgformat('%I', '%I', FACT_TABLE_NAME, t('column_headers.measure', { lng: locale })));
+      rawSortSelectStatementsMap.get(locale)?.push(pgformat('%I', t('column_headers.measure', { lng: locale })));
       rawSortSelectStatementsMap
         .get(locale)
         ?.push(pgformat('%I', `${t('column_headers.measure', { lng: locale })}_sort`));


### PR DESCRIPTION
Just after you assign sources and havent set up the measure there's an error in the SQL to select the columns for the default view.  This causes view creation to fail which might cause a few issues for cube preview.  This small PR fixes this issue.