### PR TITLE
Add status code to exception to prevent 500

### DIFF
--- a/src/exceptions/cube-error-exception.ts
+++ b/src/exceptions/cube-error-exception.ts
@@ -6,6 +6,7 @@ export class CubeValidationException extends Error {
   public datasetId: string;
   public originalError: string;
   public fact: unknown;
+  public status = 400;
   constructor(public message: string) {
     super(message);
   }

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -2393,7 +2393,7 @@ async function createPrimaryKeyOnFactTable(
     logger.debug(`Alter Table query = ${alterTableQuery}`);
     await cubeDB.query(alterTableQuery);
   } catch (error) {
-    logger.error(error, `Failed to add primary key to the fact table`);
+    logger.warn(error, `Failed to add primary key to the fact table`);
     if ((error as Error).message.includes('could not create unique index')) {
       const exception = new CubeValidationException('Duplicate facts present');
       exception.type = CubeValidationType.UnknownDuplicateFact;


### PR DESCRIPTION
The status code was missing from the exception and it was causing an unexpected 500 error.  Also switched the primary key error log to be a warn instead as this is under some circumstances expected.