### PR TITLE
SW-969 Notes code columns when update can become empty rather than null

### DIFF
--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -1298,6 +1298,17 @@ async function loadFactTablesWithUpdates(
   }
 }
 
+async function cleanupNotesCodeColumn(cubeDB: QueryRunner, notesCodeColumn: FactTableColumn): Promise<void> {
+  await cubeDB.query(
+    pgformat(
+      `UPDATE %I SET %I = NULL WHERE %I = '';`,
+      FACT_TABLE_NAME,
+      notesCodeColumn.columnName,
+      notesCodeColumn.columnName
+    )
+  );
+}
+
 export async function loadFactTables(
   cubeDB: QueryRunner,
   dataset: Dataset,
@@ -1347,6 +1358,9 @@ export async function loadFactTables(
       notesCodeColumn,
       factIdentifiers
     );
+    if (notesCodeColumn) {
+      await cleanupNotesCodeColumn(cubeDB, notesCodeColumn);
+    }
   } catch (error) {
     if (error instanceof FactTableValidationException) {
       logger.debug(error, `Throwing Fact Table Validation Exception`);


### PR DESCRIPTION
Add code to set empty note code entries to null instead of just being empty to prevent empty notes in the consumer view.