### PR TITLE
SW-973: allow reverted update drafts to be deleted

### DIFF
--- a/src/repositories/revision.ts
+++ b/src/repositories/revision.ts
@@ -130,16 +130,18 @@ export const RevisionRepository = dataSource.getRepository(Revision).extend({
       throw new BadRequestException('errors.withdraw.already_published');
     }
 
-    revision.approvedAt = null;
-    revision.approvedBy = null;
-    revision.onlineCubeFilename = null;
-    await revision.save();
-
     const dataset = revision.dataset;
 
     if (revision.revisionIndex === 1) {
       dataset.live = null;
+    } else {
+      revision.revisionIndex = 0;
     }
+
+    revision.approvedAt = null;
+    revision.approvedBy = null;
+    revision.onlineCubeFilename = null;
+    await revision.save();
 
     dataset.draftRevisionId = revision.id;
     dataset.publishedRevisionId = revision.previousRevisionId;


### PR DESCRIPTION
Reverted draft updates were not resetting the revision_index back to zero, so the check to prevent deletion of published revisions `(revision.revisionIndex !== 0)` was triggering.

Fix is to set the rev_index back to 0 when withdrawing a draft update.

 