### PR TITLE
SW-971: add validation exception for mismatched fact table headings

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -4,7 +4,6 @@ import { performance } from 'node:perf_hooks';
 import { NextFunction, Request, Response } from 'express';
 import { t } from 'i18next';
 import { isBefore, isValid } from 'date-fns';
-import { format as pgformat } from '@scaleleap/pg-format';
 
 import { User } from '../entities/user/user';
 import { DataTableDto } from '../dtos/data-table-dto';
@@ -21,31 +20,11 @@ import { NotFoundException } from '../exceptions/not-found.exception';
 import { RevisionDTO } from '../dtos/revision-dto';
 import { RevisionRepository } from '../repositories/revision';
 import { DuckdbOutputType } from '../enums/duckdb-outputs';
-import {
-  createAllCubeFiles,
-  createCubeMetadataTable,
-  createDateDimension,
-  createLookupTableDimension,
-  getPostgresCubePreview,
-  loadCorrectReferenceDataIntoReferenceDataTable,
-  loadReferenceDataIntoCube,
-  makeCubeSafeString,
-  outputCube,
-  updateFactTableValidator
-} from '../services/cube-handler';
+import { createAllCubeFiles, getPostgresCubePreview, outputCube } from '../services/cube-handler';
 import { getCSVPreview, validateAndUpload } from '../services/csv-processor';
-import { DataTableDescription } from '../entities/dataset/data-table-description';
-import { FactTableColumn } from '../entities/dataset/fact-table-column';
 import { DataTableAction } from '../enums/data-table-action';
 import { ColumnMatch } from '../interfaces/column-match';
-import { DimensionType } from '../enums/dimension-type';
-import { CubeValidationException } from '../exceptions/cube-error-exception';
-import { DimensionUpdateTask } from '../interfaces/revision-task';
 import { FileValidationException } from '../exceptions/validation-exception';
-import { FactTableColumnType } from '../enums/fact-table-column-type';
-import { checkForReferenceErrors } from '../services/lookup-table-handler';
-import { validateUpdatedDateDimension } from '../services/dimension-processor';
-import { CubeValidationType } from '../enums/cube-validation-type';
 import { FactTableValidationException } from '../exceptions/fact-table-validation-exception';
 import { NotAllowedException } from '../exceptions/not-allowed.exception';
 import { Dataset } from '../entities/dataset/dataset';
@@ -60,7 +39,7 @@ import {
 import { cleanupTmpFile, uploadAvScan } from '../services/virus-scanner';
 import { TempFile } from '../interfaces/temp-file';
 import { DEFAULT_PAGE_SIZE } from '../utils/page-defaults';
-import { dbManager } from '../db/database-manager';
+import { attachUpdateDataTableToRevision } from '../services/revision';
 
 export const getDataTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const revision: Revision = res.locals.revision;
@@ -242,160 +221,6 @@ export const getRevisionInfo = async (req: Request, res: Response): Promise<void
   res.json(RevisionDTO.fromRevision(revision));
 };
 
-async function attachUpdateDataTableToRevision(
-  datasetId: string,
-  revision: Revision,
-  dataTable: DataTable,
-  updateAction: DataTableAction,
-  columnMatcher?: ColumnMatch[]
-): Promise<void> {
-  logger.debug('Attaching update data table to revision and validating cube');
-  const start = performance.now();
-
-  const dataset = await DatasetRepository.getById(datasetId, {
-    factTable: true,
-    measure: { measureTable: true, metadata: true },
-    dimensions: { metadata: true, lookupTable: true },
-    revisions: { dataTable: { dataTableDescriptions: true } }
-  });
-
-  // Validate all the columns against the fact table
-  if (columnMatcher) {
-    const matchedColumns: string[] = [];
-    for (const col of columnMatcher) {
-      const factTableCol: FactTableColumn | undefined = dataset.factTable?.find(
-        (factTableCol: FactTableColumn) =>
-          makeCubeSafeString(factTableCol.columnName) === makeCubeSafeString(col.fact_table_column_name)
-      );
-      const dataTableCol = dataTable.dataTableDescriptions.find(
-        (dataTableCol: DataTableDescription) =>
-          makeCubeSafeString(dataTableCol.columnName) === makeCubeSafeString(col.data_table_column_name)
-      );
-      if (factTableCol && dataTableCol) {
-        matchedColumns.push(factTableCol.columnName);
-        dataTableCol.factTableColumn = factTableCol.columnName;
-      }
-    }
-    if (matchedColumns.length !== dataset.factTable?.length) {
-      logger.error(`Could not match all columns to the fact table.`);
-      throw new UnknownException('errors.failed_to_match_columns');
-    }
-  } else {
-    // validate columns
-    const matchedColumns: string[] = [];
-    const unmatchedColumns: string[] = [];
-    for (const col of dataTable.dataTableDescriptions) {
-      const factTableCol: FactTableColumn | undefined = dataset.factTable?.find(
-        (factTableCol: FactTableColumn) =>
-          makeCubeSafeString(factTableCol.columnName) === makeCubeSafeString(col.columnName)
-      );
-      if (factTableCol) {
-        matchedColumns.push(factTableCol.columnName);
-        col.factTableColumn = factTableCol.columnName;
-      } else {
-        unmatchedColumns.push(col.columnName);
-      }
-    }
-
-    if (matchedColumns.length !== dataset.factTable?.length) {
-      logger.error(
-        `Could not match all columns to the fact table.  The following columns were not matched: ${unmatchedColumns.join(', ')}`
-      );
-      const end = performance.now();
-      const time = Math.round(end - start);
-      logger.info(`Cube update validation took ${time}ms`);
-      throw new UnknownException('errors.failed_to_match_columns');
-    }
-  }
-
-  logger.debug(`Setting the update action to: ${updateAction}`);
-  dataTable.action = updateAction;
-  revision.dataTable = dataTable;
-  const buildId = `build-${crypto.randomUUID()}`;
-  const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
-
-  try {
-    await cubeDB.query(pgformat('CREATE SCHEMA IF NOT EXISTS %I;', buildId));
-    await cubeDB.query(pgformat(`SET search_path TO %I;`, buildId));
-    await updateFactTableValidator(cubeDB, buildId, dataset, revision);
-  } catch (err) {
-    const error = err as CubeValidationException;
-    logger.debug('Closing DuckDB instance');
-    const end = performance.now();
-    const time = Math.round(end - start);
-    logger.info(`Cube update validation took ${time}ms`);
-    await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
-    cubeDB.release();
-    throw error;
-  }
-
-  const dimensionUpdateTasks: DimensionUpdateTask[] = [];
-  if (dataset.dimensions.find((dimension) => dimension.type === DimensionType.ReferenceData)) {
-    await loadReferenceDataIntoCube(buildId);
-  }
-  for (const dimension of dataset.dimensions) {
-    const factTableColumn = dataset.factTable.find(
-      (factTableColumn) =>
-        factTableColumn.columnName === dimension.factTableColumn &&
-        factTableColumn.columnType === FactTableColumnType.Dimension
-    );
-    if (!factTableColumn) {
-      logger.error(`Could not find fact table column for dimension ${dimension.id}`);
-      throw new BadRequestException('errors.data_table_validation_error');
-    }
-    try {
-      await createCubeMetadataTable(cubeDB, revision.id, buildId);
-      switch (dimension.type) {
-        case DimensionType.LookupTable:
-          logger.debug(`Validating lookup table dimension: ${dimension.id}`);
-          await createLookupTableDimension(cubeDB, dataset, dimension, factTableColumn);
-          await checkForReferenceErrors(cubeDB, dataset, dimension, factTableColumn);
-          break;
-        case DimensionType.ReferenceData:
-          logger.debug(`Validating reference data dimension: ${dimension.id}`);
-          await loadCorrectReferenceDataIntoReferenceDataTable(cubeDB, dimension);
-          break;
-        case DimensionType.DatePeriod:
-        case DimensionType.Date:
-          logger.debug(`Validating time dimension: ${dimension.id}`);
-          await createDateDimension(cubeDB, dimension.extractor, factTableColumn);
-          await validateUpdatedDateDimension(cubeDB, dataset, dimension, factTableColumn);
-      }
-    } catch (error) {
-      logger.warn(`An error occurred validating dimension ${dimension.id}: ${error}`);
-      const err = error as CubeValidationException;
-      if (err.type === CubeValidationType.DimensionNonMatchedRows) {
-        dimensionUpdateTasks.push({
-          id: dimension.id,
-          lookupTableUpdated: false
-        });
-      } else {
-        const end = performance.now();
-        const time = Math.round(end - start);
-        logger.info(`Cube update validation took ${time}ms`);
-        await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
-        cubeDB.release();
-        logger.error(`An error occurred trying to validate the file with the following error: ${err}`);
-        throw new BadRequestException('errors.data_table_validation_error');
-      }
-    }
-  }
-
-  // TODO Validate measure.  This requires a rewrite of how measures are created and stored
-
-  revision.tasks = { dimensions: dimensionUpdateTasks };
-
-  await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
-  cubeDB.release();
-  await revision.save();
-  const end = performance.now();
-  const time = Math.round(end - start);
-  logger.info(`Cube update validation took ${time}ms`);
-
-  dataTable.revision = revision;
-  await dataTable.save();
-}
-
 export const updateDataTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const datasetId: string = res.locals.datasetId;
   const revision: Revision = res.locals.revision;
@@ -464,6 +289,7 @@ export const updateDataTable = async (req: Request, res: Response, next: NextFun
   } catch (err) {
     logger.error(err, `An error occurred trying to update the dataset`);
     const error = err as FactTableValidationException;
+
     if (error.type) {
       res.status(error.status);
       const viewErr: ViewErrDTO = {

--- a/src/enums/fact-table-validation-exception-type.ts
+++ b/src/enums/fact-table-validation-exception-type.ts
@@ -9,5 +9,6 @@ export enum FactTableValidationExceptionType {
   DuplicateFact = 'duplicate_fact',
   IncompleteFact = 'incomplete_fact',
   UnknownError = 'unknown_error',
-  UnknownFileType = 'unknown_file_type'
+  UnknownFileType = 'unknown_file_type',
+  UnmatchedColumns = 'unmatched_columns'
 }

--- a/src/services/revision.ts
+++ b/src/services/revision.ts
@@ -1,0 +1,189 @@
+import { format as pgformat } from '@scaleleap/pg-format';
+
+import { logger } from '../utils/logger';
+import { dbManager } from '../db/database-manager';
+import { DataTable } from '../entities/dataset/data-table';
+import { DataTableDescription } from '../entities/dataset/data-table-description';
+import { FactTableColumn } from '../entities/dataset/fact-table-column';
+import { Revision } from '../entities/dataset/revision';
+import { CubeValidationType } from '../enums/cube-validation-type';
+import { DataTableAction } from '../enums/data-table-action';
+import { DimensionType } from '../enums/dimension-type';
+import { FactTableColumnType } from '../enums/fact-table-column-type';
+import { BadRequestException } from '../exceptions/bad-request.exception';
+import { CubeValidationException } from '../exceptions/cube-error-exception';
+import { UnknownException } from '../exceptions/unknown.exception';
+import { ColumnMatch } from '../interfaces/column-match';
+import { DimensionUpdateTask } from '../interfaces/revision-task';
+import { DatasetRepository } from '../repositories/dataset';
+import {
+  makeCubeSafeString,
+  updateFactTableValidator,
+  loadReferenceDataIntoCube,
+  createCubeMetadataTable,
+  createLookupTableDimension,
+  loadCorrectReferenceDataIntoReferenceDataTable,
+  createDateDimension
+} from './cube-handler';
+import { validateUpdatedDateDimension } from './dimension-processor';
+import { checkForReferenceErrors } from './lookup-table-handler';
+import { FactTableValidationExceptionType } from '../enums/fact-table-validation-exception-type';
+import { FactTableValidationException } from '../exceptions/fact-table-validation-exception';
+
+export async function attachUpdateDataTableToRevision(
+  datasetId: string,
+  revision: Revision,
+  dataTable: DataTable,
+  updateAction: DataTableAction,
+  columnMatcher?: ColumnMatch[]
+): Promise<void> {
+  logger.debug('Attaching update data table to revision and validating cube');
+  const start = performance.now();
+
+  const dataset = await DatasetRepository.getById(datasetId, {
+    factTable: true,
+    measure: { measureTable: true, metadata: true },
+    dimensions: { metadata: true, lookupTable: true },
+    revisions: { dataTable: { dataTableDescriptions: true } }
+  });
+
+  // Validate all the columns against the fact table
+  if (columnMatcher) {
+    const matchedColumns: string[] = [];
+    for (const col of columnMatcher) {
+      const factTableCol: FactTableColumn | undefined = dataset.factTable?.find(
+        (factTableCol: FactTableColumn) =>
+          makeCubeSafeString(factTableCol.columnName) === makeCubeSafeString(col.fact_table_column_name)
+      );
+      const dataTableCol = dataTable.dataTableDescriptions.find(
+        (dataTableCol: DataTableDescription) =>
+          makeCubeSafeString(dataTableCol.columnName) === makeCubeSafeString(col.data_table_column_name)
+      );
+      if (factTableCol && dataTableCol) {
+        matchedColumns.push(factTableCol.columnName);
+        dataTableCol.factTableColumn = factTableCol.columnName;
+      }
+    }
+    if (matchedColumns.length !== dataset.factTable?.length) {
+      logger.error(`Could not match all columns to the fact table.`);
+      throw new UnknownException('errors.failed_to_match_columns');
+    }
+  } else {
+    // validate columns
+    const matchedColumns: string[] = [];
+    const unmatchedColumns: string[] = [];
+    for (const col of dataTable.dataTableDescriptions) {
+      const factTableCol: FactTableColumn | undefined = dataset.factTable?.find(
+        (factTableCol: FactTableColumn) =>
+          makeCubeSafeString(factTableCol.columnName) === makeCubeSafeString(col.columnName)
+      );
+      if (factTableCol) {
+        matchedColumns.push(factTableCol.columnName);
+        col.factTableColumn = factTableCol.columnName;
+      } else {
+        unmatchedColumns.push(col.columnName);
+      }
+    }
+
+    if (matchedColumns.length !== dataset.factTable?.length) {
+      logger.error(
+        `Could not match all columns to the fact table. The following columns were not matched: ${unmatchedColumns.join(', ')}`
+      );
+      const end = performance.now();
+      const time = Math.round(end - start);
+      logger.info(`Cube update validation took ${time}ms`);
+      throw new FactTableValidationException(
+        'Could not match all columns to the fact table.',
+        FactTableValidationExceptionType.UnmatchedColumns,
+        400
+      );
+    }
+  }
+
+  logger.debug(`Setting the update action to: ${updateAction}`);
+  dataTable.action = updateAction;
+  revision.dataTable = dataTable;
+  const buildId = `build-${crypto.randomUUID()}`;
+  const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
+
+  try {
+    await cubeDB.query(pgformat('CREATE SCHEMA IF NOT EXISTS %I;', buildId));
+    await cubeDB.query(pgformat(`SET search_path TO %I;`, buildId));
+    await updateFactTableValidator(cubeDB, buildId, dataset, revision);
+  } catch (err) {
+    const error = err as CubeValidationException;
+    logger.debug('Closing DuckDB instance');
+    const end = performance.now();
+    const time = Math.round(end - start);
+    logger.info(`Cube update validation took ${time}ms`);
+    await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
+    cubeDB.release();
+    throw error;
+  }
+
+  const dimensionUpdateTasks: DimensionUpdateTask[] = [];
+  if (dataset.dimensions.find((dimension) => dimension.type === DimensionType.ReferenceData)) {
+    await loadReferenceDataIntoCube(buildId);
+  }
+  for (const dimension of dataset.dimensions) {
+    const factTableColumn = dataset.factTable.find(
+      (factTableColumn) =>
+        factTableColumn.columnName === dimension.factTableColumn &&
+        factTableColumn.columnType === FactTableColumnType.Dimension
+    );
+    if (!factTableColumn) {
+      logger.error(`Could not find fact table column for dimension ${dimension.id}`);
+      throw new BadRequestException('errors.data_table_validation_error');
+    }
+    try {
+      await createCubeMetadataTable(cubeDB, revision.id, buildId);
+      switch (dimension.type) {
+        case DimensionType.LookupTable:
+          logger.debug(`Validating lookup table dimension: ${dimension.id}`);
+          await createLookupTableDimension(cubeDB, dataset, dimension, factTableColumn);
+          await checkForReferenceErrors(cubeDB, dataset, dimension, factTableColumn);
+          break;
+        case DimensionType.ReferenceData:
+          logger.debug(`Validating reference data dimension: ${dimension.id}`);
+          await loadCorrectReferenceDataIntoReferenceDataTable(cubeDB, dimension);
+          break;
+        case DimensionType.DatePeriod:
+        case DimensionType.Date:
+          logger.debug(`Validating time dimension: ${dimension.id}`);
+          await createDateDimension(cubeDB, dimension.extractor, factTableColumn);
+          await validateUpdatedDateDimension(cubeDB, dataset, dimension, factTableColumn);
+      }
+    } catch (error) {
+      logger.warn(`An error occurred validating dimension ${dimension.id}: ${error}`);
+      const err = error as CubeValidationException;
+      if (err.type === CubeValidationType.DimensionNonMatchedRows) {
+        dimensionUpdateTasks.push({
+          id: dimension.id,
+          lookupTableUpdated: false
+        });
+      } else {
+        const end = performance.now();
+        const time = Math.round(end - start);
+        logger.info(`Cube update validation took ${time}ms`);
+        await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
+        cubeDB.release();
+        logger.error(err, `An error occurred trying to validate the file`);
+        throw new BadRequestException('errors.data_table_validation_error');
+      }
+    }
+  }
+
+  // TODO Validate measure.  This requires a rewrite of how measures are created and stored
+
+  revision.tasks = { dimensions: dimensionUpdateTasks };
+
+  await cubeDB.query(pgformat('DROP SCHEMA %I CASCADE', buildId));
+  cubeDB.release();
+  await revision.save();
+  const end = performance.now();
+  const time = Math.round(end - start);
+  logger.info(`Cube update validation took ${time}ms`);
+
+  dataTable.revision = revision;
+  await dataTable.save();
+}


### PR DESCRIPTION
Adds a new `FactTableValidationExceptionType.UnmatchedColumns` which is returned when a fact table upload has columns that don't match the existing fact table.

Also moved `attachUpdateDataTableToRevision` out of `controllers` as it's not a request handler.