### PR TITLE
SW-916 Make date matching BST aware

### DIFF
--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -185,16 +185,9 @@ function periodTableCreator(
   const type = yearType(dateFormat.type, dateFormat.startDay, dateFormat.startMonth);
 
   let year = parseISO(`${startYear}-${type.start}`);
-  const stdTimezoneOfferset = (): number => {
-    const jan = new Date(year.getFullYear(), 0, 1);
-    const jul = new Date(year.getFullYear(), 6, 1);
-    return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
-  };
-
-  const isBSTObserved = (): boolean => {
   const stdTimezoneOffset = (): number => {
     const jan = new Date(year.getFullYear(), 0, 1);
-    const jul = new Date(year.getFullYear(), 6, 0);
+    const jul = new Date(year.getFullYear(), 6, 1);
     return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
   };
 

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -187,7 +187,7 @@ function periodTableCreator(
   let year = parseISO(`${startYear}-${type.start}`);
   const stdTimezoneOfferset = (): number => {
     const jan = new Date(year.getFullYear(), 0, 1);
-    const jul = new Date(year.getFullYear(), 6, 0);
+    const jul = new Date(year.getFullYear(), 6, 1);
     return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
   };
 

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -192,7 +192,14 @@ function periodTableCreator(
   };
 
   const isBSTObserved = (): boolean => {
-    return year.getTimezoneOffset() < stdTimezoneOfferset();
+  const stdTimezoneOffset = (): number => {
+    const jan = new Date(year.getFullYear(), 0, 1);
+    const jul = new Date(year.getFullYear(), 6, 0);
+    return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+  };
+
+  const isBSTObserved = (): boolean => {
+    return year.getTimezoneOffset() < stdTimezoneOffset();
   };
 
   if (isBSTObserved()) {


### PR DESCRIPTION
Date matching had largely assumed all dates were UTC/GMT but with the introduction of rolling years this stopped being the case.  So I've added the code to make the date matcher BST aware.  When it puts the date in the database its in UTC with the appropriate hour added if the date is in BST.