### PR TITLE
Don't set name to space if name is missing

### DIFF
--- a/src/migrations/1754479124622-user-name.ts
+++ b/src/migrations/1754479124622-user-name.ts
@@ -7,7 +7,8 @@ export class UserName1754479124622 implements MigrationInterface {
     await queryRunner.query(`ALTER TABLE "user" ADD "name" text`);
 
     await queryRunner.query(
-      `UPDATE "user" SET "name" = COALESCE("given_name", '') || ' ' || COALESCE("family_name", '')`
+      `UPDATE "user" SET "name" = COALESCE("given_name", '') || ' ' || COALESCE("family_name", '')
+      WHERE "given_name" IS NOT NULL OR "family_name" IS NOT NULL`
     );
 
     await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "given_name"`);


### PR DESCRIPTION
The migration in the previous PR did not take into account users who had not logged in yet and therefore didn't have names.

On dev, these users names got set to a single space instead of being left NULL.

I wouldn't normally edit a migration file, but the only place this has run so far is dev and my local machine, and I've fixed dev with:

```
UPDATE "user" SET "name" = NULL WHERE "name" = ' ';
```