### PR TITLE
SW-988 fix connection leak

### DIFF
--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -551,6 +551,7 @@ export const createAndValidateDateDimension = async (
   try {
     await cubeDB.query(pgformat(`SET search_path TO %I;`, revision.id));
   } catch (error) {
+    cubeDB.release();
     logger.error(error, 'Unable to connect to postgres schema for revision.');
     return viewErrorGenerators(500, dataset.id, 'patch', 'errors.dimension_validation.lookup_table_loading_failed', {
       mismatch: false
@@ -679,13 +680,14 @@ export const createAndValidateDateDimension = async (
     return viewGenerator(currentDataset, 1, pageInfo, 10, 1, headers, dataArray);
   } catch (error) {
     logger.error(error, 'Something went wrong trying to get preview of date dimension lookup table.');
-    cubeDB.release();
     return viewErrorGenerators(500, dataset.id, 'patch', 'errors.dimension_validation.unknown_error', {
       extractor,
       totalNonMatching: preview.length,
       nonMatchingValues: [],
       mismatch: false
     });
+  } finally {
+    cubeDB.release();
   }
 };
 
@@ -898,6 +900,7 @@ export const getDimensionPreview = async (
   try {
     await cubeDB.query(pgformat(`SET search_path TO %I;`, dataset.draftRevision!.id));
   } catch (error) {
+    cubeDB.release();
     logger.error(error, 'Unable to connect to postgres schema for revision.');
     return viewErrorGenerators(500, dataset.id, 'patch', 'errors.dimension_validation.lookup_table_loading_failed', {
       mismatch: false


### PR DESCRIPTION
Found a couple of instances where the connection isn't released when there's an error or just not released after the method finishes when doing dimension processing.

Will get this out as a first pass fix and continue looking for other times when we might not release the connection.