### PR TITLE
Provide db pool stats

### DIFF
--- a/src/db/database-manager.ts
+++ b/src/db/database-manager.ts
@@ -62,13 +62,13 @@ export class DatabaseManager {
     return new EntitySubscriber(this.appDataSource);
   }
 
-  async getAppPool(): Promise<Pool> {
+  getAppPool(): Pool {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const postgresDriver = this.getAppDataSource().driver as any;
     return postgresDriver.master as Pool;
   }
 
-  async getCubePool(): Promise<Pool> {
+  getCubePool(): Pool {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const postgresDriver = this.getCubeDataSource().driver as any;
     return postgresDriver.master as Pool;

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -64,44 +64,48 @@ healthcheck.get('/jwt', passport.authenticate('jwt', { session: false }), (req: 
 });
 
 healthcheck.get('/db', async (req: Request, res: Response) => {
-  const appPool = await dbManager.getAppPool();
-  const cubePool = await dbManager.getCubePool();
+  try {
+    const appPool = dbManager.getAppPool();
+    const cubePool = dbManager.getCubePool();
 
-  if (!appPool || !cubePool) {
-    res.status(500).json({ error: 'Database connection pools not found' });
-    return;
-  }
-
-  res.json({
-    appPool: {
-      name: appPool.options.application_name,
-      connectionTimeout: `${appPool.options.connectionTimeoutMillis}ms`,
-      idleTimeout: `${appPool.options.idleTimeoutMillis}ms`,
-      clients: {
-        min: appPool.options.min,
-        max: appPool.options.max,
-        idle: appPool.idleCount,
-        waiting: appPool.waitingCount,
-        expired: appPool.expiredCount,
-        total: appPool.totalCount,
-        isFull: appPool.totalCount >= appPool.options.max
-      }
-    },
-    cubePool: {
-      name: cubePool.options.application_name,
-      connectionTimeout: `${cubePool.options.connectionTimeoutMillis}ms`,
-      idleTimeout: `${cubePool.options.idleTimeoutMillis}ms`,
-      clients: {
-        min: cubePool.options.min,
-        max: cubePool.options.max,
-        idle: cubePool.idleCount,
-        waiting: cubePool.waitingCount,
-        expired: cubePool.expiredCount,
-        total: cubePool.totalCount,
-        isFull: cubePool.totalCount >= cubePool.options.max
-      }
+    if (!appPool || !cubePool) {
+      throw new Error('Database pools are not available');
     }
-  });
+
+    res.json({
+      appPool: {
+        name: appPool.options.application_name,
+        connectionTimeout: `${appPool.options.connectionTimeoutMillis}ms`,
+        idleTimeout: `${appPool.options.idleTimeoutMillis}ms`,
+        clients: {
+          min: appPool.options.min,
+          max: appPool.options.max,
+          idle: appPool.idleCount,
+          waiting: appPool.waitingCount,
+          expired: appPool.expiredCount,
+          total: appPool.totalCount,
+          isFull: appPool.totalCount >= appPool.options.max
+        }
+      },
+      cubePool: {
+        name: cubePool.options.application_name,
+        connectionTimeout: `${cubePool.options.connectionTimeoutMillis}ms`,
+        idleTimeout: `${cubePool.options.idleTimeoutMillis}ms`,
+        clients: {
+          min: cubePool.options.min,
+          max: cubePool.options.max,
+          idle: cubePool.idleCount,
+          waiting: cubePool.waitingCount,
+          expired: cubePool.expiredCount,
+          total: cubePool.totalCount,
+          isFull: cubePool.totalCount >= cubePool.options.max
+        }
+      }
+    });
+  } catch (error) {
+    logger.error(error, 'Error fetching database pool information');
+    res.status(500).json({ error: 'Failed to fetch database pool information' });
+  }
 });
 
 export const healthcheckRouter = healthcheck;


### PR DESCRIPTION
Adds a new `/healthcheck/db` route that returns db pool stats as json:

```
{
  "appPool": {
    "name": "sw3-backend-app",
    "connectionTimeout": "2000ms",
    "idleTimeout": "10000ms",
    "clients": {
      "min": 0,
      "max": 5,
      "idle": 1,
      "waiting": 0,
      "expired": 0,
      "total": 1,
      "isFull": false
    }
  },
  "cubePool": {
    "name": "sw3-backend-cube",
    "connectionTimeout": "2000ms",
    "idleTimeout": "10000ms",
    "clients": {
      "min": 0,
      "max": 5,
      "idle": 1,
      "waiting": 0,
      "expired": 0,
      "total": 1,
      "isFull": false
    }
  }
}
```