### PR TITLE
SW-992 Fix numbers stored as text in Excel

### DIFF
--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -446,7 +446,8 @@ export const createStreamingExcelFilteredView = async (
       while (rows.length > 0) {
         for (const row of rows) {
           if (row === null) break;
-          worksheet.addRow(Object.values(row)).commit();
+          const data = Object.values(row).map((val) => (isNaN(Number(val)) ? val : Number(val)));
+          worksheet.addRow(Object.values(data)).commit();
         }
         totalRows += CURSOR_ROW_LIMIT;
         if (totalRows > EXCEL_ROW_LIMIT) {


### PR DESCRIPTION
Numbers were being stored as text in Excel.  This was happening because postgres was returning strings which were then stored directly in the excel cell.  This fixes the issue by quickly parsing the array and turning any numbers into actual numbers.