### PR TITLE
SW-857: set the correct source_type for each column header in cube view

### DIFF
--- a/src/dtos/view-dto.ts
+++ b/src/dtos/view-dto.ts
@@ -6,7 +6,7 @@ import { Error } from './error';
 import { DatasetDTO } from './dataset-dto';
 import { DataTableDto } from './data-table-dto';
 
-export interface CSVHeader {
+export interface ColumnHeader {
   index: number;
   name: string;
   source_type?: FactTableColumnType;
@@ -23,7 +23,7 @@ export interface ViewErrDTO {
   status: number;
   errors: Error[];
   dataset_id: string | undefined;
-  headers?: CSVHeader[];
+  headers?: ColumnHeader[];
   data?: string[][];
   extension?: object;
 }
@@ -35,7 +35,7 @@ export interface ViewDTO {
   page_info: PageInfo;
   page_size: number;
   total_pages: number;
-  headers: CSVHeader[];
+  headers: ColumnHeader[];
   data: string[][] | unknown[][];
   extension?: object;
 }

--- a/src/dtos/view-dto.ts
+++ b/src/dtos/view-dto.ts
@@ -10,6 +10,7 @@ export interface CSVHeader {
   index: number;
   name: string;
   source_type?: FactTableColumnType;
+  extractor?: Record<string, string>;
 }
 
 export interface PageInfo {

--- a/src/exceptions/fact-table-validation-exception.ts
+++ b/src/exceptions/fact-table-validation-exception.ts
@@ -1,5 +1,5 @@
 import { FactTableValidationExceptionType } from '../enums/fact-table-validation-exception-type';
-import { CSVHeader } from '../dtos/view-dto';
+import { ColumnHeader } from '../dtos/view-dto';
 
 export class FactTableValidationException implements Error {
   constructor(message: string, type: FactTableValidationExceptionType, status?: number) {
@@ -14,5 +14,5 @@ export class FactTableValidationException implements Error {
   tag: string;
   name: string;
   data: string[][];
-  headers: CSVHeader[];
+  headers: ColumnHeader[];
 }

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -303,13 +303,7 @@ export const createFrontendView = async (
     const tableHeaders = Object.keys(preview.rows[0]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = preview.rows.map((row: any) => Object.values(row));
-
-    const currentDataset = await DatasetRepository.getById(dataset.id, {
-      factTable: true,
-      dimensions: { metadata: true },
-      measure: true
-    });
-
+    const currentDataset = await DatasetRepository.getById(dataset.id, { factTable: true, dimensions: true });
     const lastLine = startLine + dataArray.length - 1;
     const headers = getColumnHeaders(currentDataset, tableHeaders, filterTable.rows);
 

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -7,7 +7,7 @@ import { format as pgformat } from '@scaleleap/pg-format';
 import { logger as parentLogger } from '../utils/logger';
 import { DataTable } from '../entities/dataset/data-table';
 import { Dataset } from '../entities/dataset/dataset';
-import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { ColumnHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { DatasetRepository } from '../repositories/dataset';
 import { FileType } from '../enums/file-type';
@@ -311,7 +311,7 @@ export const getCSVPreview = async (
     const dataset = await DatasetRepository.getById(datasetId, { factTable: true });
     const currentImport = await DataTable.findOneByOrFail({ id: dataTable.id });
 
-    const headers: CSVHeader[] = tableHeaders.map((header, idx) => {
+    const headers: ColumnHeader[] = tableHeaders.map((header, idx) => {
       let sourceType: FactTableColumnType;
 
       if (header === 'int_line_number') {
@@ -361,7 +361,7 @@ export const getFactTableColumnPreview = async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = preview.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
-    const headers: CSVHeader[] = [];
+    const headers: ColumnHeader[] = [];
     for (let i = 0; i < tableHeaders.length; i++) {
       let sourceType: FactTableColumnType;
       if (tableHeaders[i] === 'int_line_number') sourceType = FactTableColumnType.LineNumber;

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -14,7 +14,7 @@ import { SUPPORTED_LOCALES } from '../middleware/translation';
 import { DimensionMetadata } from '../entities/dataset/dimension-metadata';
 import { Measure } from '../entities/dataset/measure';
 import { DimensionPatchDto } from '../dtos/dimension-partch-dto';
-import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { ColumnHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { DateExtractor } from '../extractors/date-extractor';
 import { DatasetRepository } from '../repositories/dataset';
 import { LookupTable } from '../entities/dataset/lookup-table';
@@ -669,7 +669,7 @@ export const createAndValidateDateDimension = async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = dimensionTable.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id, { dimensions: { metadata: true } });
-    const headers: CSVHeader[] = [];
+    const headers: ColumnHeader[] = [];
     for (let i = 0; i < tableHeaders.length; i++) {
       let sourceType: FactTableColumnType;
       if (tableHeaders[i] === 'int_line_number') sourceType = FactTableColumnType.LineNumber;
@@ -738,7 +738,7 @@ async function getDatePreviewWithExtractor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dataArray = previewResult.map((row: any) => Object.values(row));
   const currentDataset = await DatasetRepository.getById(dataset.id);
-  const headers: CSVHeader[] = [];
+  const headers: ColumnHeader[] = [];
 
   for (let i = 0; i < tableHeaders.length; i++) {
     headers.push({
@@ -788,7 +788,7 @@ async function getPreviewWithNumberExtractor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dataArray = preview.map((row: any) => Object.values(row));
   const currentDataset = await DatasetRepository.getById(dataset.id);
-  const headers: CSVHeader[] = [];
+  const headers: ColumnHeader[] = [];
   for (let i = 0; i < tableHeaders.length; i++) {
     headers.push({
       index: i,
@@ -828,7 +828,7 @@ async function getPreviewWithoutExtractor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dataArray = preview.map((row: any) => Object.values(row));
   const currentDataset = await DatasetRepository.getById(dataset.id);
-  const headers: CSVHeader[] = [];
+  const headers: ColumnHeader[] = [];
   for (let i = 0; i < tableHeaders.length; i++) {
     headers.push({
       index: i,
@@ -879,7 +879,7 @@ async function getLookupPreviewWithExtractor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dataArray = dimensionTable.map((row: any) => Object.values(row));
   const currentDataset = await DatasetRepository.getById(dataset.id);
-  const headers: CSVHeader[] = [];
+  const headers: ColumnHeader[] = [];
 
   for (let i = 0; i < tableHeaders.length; i++) {
     headers.push({

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/lookup-table-utils';
 import { ColumnDescriptor } from '../extractors/column-descriptor';
 import { Dataset } from '../entities/dataset/dataset';
-import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { ColumnHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { logger } from '../utils/logger';
 import { Dimension } from '../entities/dataset/dimension';
 import { viewErrorGenerators, viewGenerator } from '../utils/view-error-generators';
@@ -366,7 +366,7 @@ export const validateLookupTable = async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = dimensionTable.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
-    const headers: CSVHeader[] = [];
+    const headers: ColumnHeader[] = [];
     for (let i = 0; i < tableHeaders.length; i++) {
       let sourceType: FactTableColumnType;
       if (tableHeaders[i] === 'int_line_number') sourceType = FactTableColumnType.LineNumber;

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -18,7 +18,7 @@ import {
 } from '../utils/lookup-table-utils';
 import { ColumnDescriptor } from '../extractors/column-descriptor';
 import { Dataset } from '../entities/dataset/dataset';
-import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { ColumnHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { viewErrorGenerators, viewGenerator } from '../utils/view-error-generators';
 import { logger } from '../utils/logger';
 import { Measure } from '../entities/dataset/measure';
@@ -550,7 +550,7 @@ export const validateMeasureLookupTable = async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = measureTable.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
-    const headers: CSVHeader[] = [];
+    const headers: ColumnHeader[] = [];
     for (let i = 0; i < tableHeaders.length; i++) {
       let sourceType: FactTableColumnType;
       if (tableHeaders[i] === 'int_line_number') sourceType = FactTableColumnType.LineNumber;
@@ -601,7 +601,7 @@ async function getMeasurePreviewWithoutExtractor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = preview.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
-    const headers: CSVHeader[] = [];
+    const headers: ColumnHeader[] = [];
     for (let i = 0; i < tableHeaders.length; i++) {
       headers.push({
         index: i,
@@ -645,7 +645,7 @@ async function getMeasurePreviewWithExtractor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = measureTable.map((row: any) => Object.values(row));
     const currentDataset = await DatasetRepository.getById(dataset.id);
-    const headers: CSVHeader[] = tableHeaders.map((name, idx) => ({
+    const headers: ColumnHeader[] = tableHeaders.map((name, idx) => ({
       name,
       index: idx,
       source_type: FactTableColumnType.Unknown

--- a/src/utils/column-headers.ts
+++ b/src/utils/column-headers.ts
@@ -1,4 +1,4 @@
-import { CSVHeader } from '../dtos/view-dto';
+import { ColumnHeader } from '../dtos/view-dto';
 import { Dataset } from '../entities/dataset/dataset';
 import { DimensionType } from '../enums/dimension-type';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
@@ -7,7 +7,7 @@ export const getColumnHeaders = (
   dataset: Dataset,
   columns: string[],
   filters: Record<string, string>[]
-): CSVHeader[] => {
+): ColumnHeader[] => {
   return columns.map((columnName, idx) => {
     let source_type = FactTableColumnType.Unknown;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils/column-headers.ts
+++ b/src/utils/column-headers.ts
@@ -2,6 +2,7 @@ import { ColumnHeader } from '../dtos/view-dto';
 import { Dataset } from '../entities/dataset/dataset';
 import { DimensionType } from '../enums/dimension-type';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
+import { t } from '../middleware/translation';
 
 export const getColumnHeaders = (
   dataset: Dataset,
@@ -19,7 +20,9 @@ export const getColumnHeaders = (
     if (filter) {
       const factTableColumn = dataset.factTable?.find((factCol) => factCol.columnName === filter.fact_table_column);
 
-      if (factTableColumn?.columnType === FactTableColumnType.Dimension) {
+      if (factTableColumn?.columnType === FactTableColumnType.Measure) {
+        source_type = FactTableColumnType.Measure;
+      } else if (factTableColumn?.columnType === FactTableColumnType.Dimension) {
         const dimension = dataset.dimensions?.find((dim) => dim.factTableColumn === factTableColumn.columnName);
         if (dimension?.type === DimensionType.Date || dimension?.type === DimensionType.Time) {
           source_type = FactTableColumnType.Time;
@@ -28,14 +31,10 @@ export const getColumnHeaders = (
           source_type = FactTableColumnType.Dimension;
         }
       }
-
-      if (factTableColumn?.columnType === FactTableColumnType.Measure) {
-        source_type = FactTableColumnType.Measure;
-      }
-    } else {
+    } else if (columnName === t('column_headers.data_values')) {
       source_type = FactTableColumnType.DataValues;
     }
 
-    return { index: idx, name: columnName, source_type, extractor };
+    return { index: idx - 1, name: columnName, source_type, extractor };
   });
 };

--- a/src/utils/column-headers.ts
+++ b/src/utils/column-headers.ts
@@ -1,0 +1,41 @@
+import { CSVHeader } from '../dtos/view-dto';
+import { Dataset } from '../entities/dataset/dataset';
+import { DimensionType } from '../enums/dimension-type';
+import { FactTableColumnType } from '../enums/fact-table-column-type';
+
+export const getColumnHeaders = (
+  dataset: Dataset,
+  columns: string[],
+  filters: Record<string, string>[]
+): CSVHeader[] => {
+  return columns.map((columnName, idx) => {
+    let source_type = FactTableColumnType.Unknown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let extractor: any;
+
+    // we can use the filters to map translated dimension name to fact table column
+    const filter = filters.find((filter) => filter.dimension_name === columnName);
+
+    if (filter) {
+      const factTableColumn = dataset.factTable?.find((factCol) => factCol.columnName === filter.fact_table_column);
+
+      if (factTableColumn?.columnType === FactTableColumnType.Dimension) {
+        const dimension = dataset.dimensions?.find((dim) => dim.factTableColumn === factTableColumn.columnName);
+        if (dimension?.type === DimensionType.Date || dimension?.type === DimensionType.Time) {
+          source_type = FactTableColumnType.Time;
+          extractor = dimension.extractor;
+        } else {
+          source_type = FactTableColumnType.Dimension;
+        }
+      }
+
+      if (factTableColumn?.columnType === FactTableColumnType.Measure) {
+        source_type = FactTableColumnType.Measure;
+      }
+    } else {
+      source_type = FactTableColumnType.DataValues;
+    }
+
+    return { index: idx, name: columnName, source_type, extractor };
+  });
+};

--- a/src/utils/table-data-to-view-table.ts
+++ b/src/utils/table-data-to-view-table.ts
@@ -1,9 +1,9 @@
-import { CSVHeader } from '../dtos/view-dto';
+import { ColumnHeader } from '../dtos/view-dto';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { RowData } from 'duckdb-async';
 
 type ViewTable = {
-  headers: CSVHeader[];
+  headers: ColumnHeader[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any[][];
 };
@@ -11,7 +11,7 @@ type ViewTable = {
 export const tableDataToViewTable = (tableData: RowData[]): ViewTable => {
   const tableHeaders = Object.keys(tableData[0]);
   const dataArray = tableData.map((row) => Object.values(row));
-  const headers: CSVHeader[] = tableHeaders.map((header, idx) => ({
+  const headers: ColumnHeader[] = tableHeaders.map((header, idx) => ({
     index: idx,
     name: header,
     sourceType: header === 'line_number' ? FactTableColumnType.LineNumber : FactTableColumnType.Unknown

--- a/src/utils/view-error-generators.ts
+++ b/src/utils/view-error-generators.ts
@@ -1,6 +1,6 @@
 import { t } from 'i18next';
 
-import { CSVHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
+import { ColumnHeader, ViewDTO, ViewErrDTO } from '../dtos/view-dto';
 import { ErrorMessage } from '../dtos/error';
 import { AVAILABLE_LANGUAGES } from '../middleware/translation';
 import { Dataset } from '../entities/dataset/dataset';
@@ -48,7 +48,7 @@ export const viewGenerator = async (
   pageInfo: PageInfo,
   size: number,
   totalPages: number,
-  headers: CSVHeader[],
+  headers: ColumnHeader[],
   data: string[][] | unknown[][],
   dataTable?: DataTable
 ): Promise<ViewDTO> => {

--- a/test/routes/view-dataset-contents.test.ts
+++ b/test/routes/view-dataset-contents.test.ts
@@ -27,7 +27,7 @@ BlobStorage.prototype.loadBuffer = jest.fn();
 const dataset1Id = 'bdc40218-af89-424b-b86e-d21710bc92f1';
 const revision1Id = '85f0e416-8bd1-4946-9e2c-1c958897c6ef';
 const import1Id = 'fa07be9d-3495-432d-8c1f-d0fc6daae359';
-const user: User = getTestUser('test', 'user');
+const user: User = getTestUser();
 let userGroup = getTestUserGroup('Test Group');
 let queryRunner: QueryRunner;
 


### PR DESCRIPTION
The frontend ideally needs to know what type of values each column of the data table contains.

The source type is now determined from the fact table / dimensions and returned accordingly.

If the column type is a date or time, then the extractor & format is also returned.