### PR TITLE
SW-482: Return set of note codes used by dataset with preview

### DIFF
--- a/src/dtos/view-dto.ts
+++ b/src/dtos/view-dto.ts
@@ -38,6 +38,7 @@ export interface ViewDTO {
   headers: ColumnHeader[];
   data: string[][] | unknown[][];
   extension?: object;
+  note_codes?: string[];
 }
 
 export interface ViewStream {


### PR DESCRIPTION
Fetches the set of notecodes used by the dataset and returns them with the cube preview/consumer view response.