### PR TITLE
Reduce log noise

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -152,7 +152,6 @@ export const downloadRawFactTable = async (req: Request, res: Response, next: Ne
   const revision = res.locals.revision;
   logger.info('User requested to down files...');
   let readable: Readable;
-  // logger.debug(`${JSON.stringify(revision)}`);
 
   if (!revision.dataTable) {
     logger.error("Revision doesn't have a data table, can't download file");

--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -271,20 +271,7 @@ export class TasklistStateDTO {
     dto.canPublish =
       dataTableComplete && dimensionsComplete && metadataComplete && translationsComplete && publishingComplete;
 
-    logger.debug(
-      `\nTasklistState: ${JSON.stringify(
-        {
-          dataTableComplete,
-          dimensionsComplete,
-          metadataComplete,
-          translationsComplete,
-          publishingComplete,
-          canPublish: dto.canPublish
-        },
-        null,
-        2
-      )}`
-    );
+    logger.info(`Dataset ready for publishing: ${dto.canPublish ? 'true' : 'false'}`);
 
     return dto;
   }

--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -273,6 +273,21 @@ export class TasklistStateDTO {
 
     logger.info(`Dataset ${dataset.id} ready for publishing: ${dto.canPublish ? 'true' : 'false'}`);
 
+    logger.trace(
+      `\nTasklistState: ${JSON.stringify(
+        {
+          dataTableComplete,
+          dimensionsComplete,
+          metadataComplete,
+          translationsComplete,
+          publishingComplete,
+          canPublish: dto.canPublish
+        },
+        null,
+        2
+      )}`
+    );
+
     return dto;
   }
 }

--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -271,7 +271,7 @@ export class TasklistStateDTO {
     dto.canPublish =
       dataTableComplete && dimensionsComplete && metadataComplete && translationsComplete && publishingComplete;
 
-    logger.info(`Dataset ready for publishing: ${dto.canPublish ? 'true' : 'false'}`);
+    logger.info(`Dataset ${dataset.id} ready for publishing: ${dto.canPublish ? 'true' : 'false'}`);
 
     return dto;
   }

--- a/src/services/csv-processor.ts
+++ b/src/services/csv-processor.ts
@@ -274,7 +274,6 @@ export const getCSVPreview = async (
 
   try {
     await cubeDB.query(pgformat(`SET search_path TO %I;`, 'data_tables'));
-    logger.debug('Getting table query from postgres');
     tableName = dataTable.id;
     const totalsQuery = pgformat(`SELECT count(*) AS total_lines FROM %I;`, tableName);
     const totals: { total_lines: number }[] = await cubeDB.query(totalsQuery);

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -281,7 +281,7 @@ export const loadFileDataTableIntoTable = async (
       );
   }
   try {
-    logger.debug(`Loading file data table into table ${tableName} with query: ${insertQuery}`);
+    logger.debug(`Loading file data table into table ${tableName}`);
     await quack.exec(insertQuery);
     await loadTableDataIntoFactTable(quack, factTableDef, tableName, tempTableName);
     await quack.exec(pgformat('DROP TABLE %I', tempTableName));
@@ -547,8 +547,6 @@ export async function loadFileIntoLookupTablesSchema(
       );
     }
     const builtInsertQuery = pgformat(`INSERT INTO %I %s;`, dimTable, dataExtractorParts.join(' UNION '));
-    // const builtInsertQuery = `INSERT INTO ${makeCubeSafeString(dimension.factTableColumn)}_lookup (${dataExtractorParts.join(' UNION ')});`;
-    // logger.debug(`Built insert query: ${builtInsertQuery}`);
     await quack.exec(builtInsertQuery);
   } else {
     const languageMatcher = languageMatcherCaseStatement(extractor.languageColumn);
@@ -808,7 +806,6 @@ async function copyUpdateTableToFactTable(
     dataTableSelect,
     updateTableName
   );
-  logger.debug(copyQuery);
   await cubeDB.query(copyQuery);
 }
 
@@ -2113,7 +2110,6 @@ export async function createEmptyFactTableInCube(
       FACT_TABLE_NAME,
       factTableCreationDef.join(', ')
     );
-    // logger.debug(`Creating fact table with query: '${createQuery}'`);
     await cubeDB.query(factTableCreationQuery);
   } catch (err) {
     logger.error(err, `Failed to create fact table in cube`);
@@ -2153,7 +2149,6 @@ async function createPrimaryKeyOnFactTable(
   logger.debug('Creating primary key on fact table');
   try {
     const alterTableQuery = pgformat('ALTER TABLE %I.%I ADD PRIMARY KEY (%I)', schema, FACT_TABLE_NAME, compositeKey);
-    logger.debug(`Alter Table query = ${alterTableQuery}`);
     await cubeDB.query(alterTableQuery);
   } catch (error) {
     logger.warn(error, `Failed to add primary key to the fact table`);
@@ -2367,7 +2362,6 @@ export const createBasePostgresCube = async (
         joinStatements.join('\n').replace(/#LANG#/g, pgformat('%L', locale.toLowerCase())),
         orderByStatements.length > 0 ? `ORDER BY ${orderByStatements.join(', ')}` : ''
       );
-      logger.debug(coreCubeViewSQL);
       await cubeDB.query(pgformat('CREATE VIEW %I AS %s', `${CORE_VIEW_NAME}_${lang}`, coreCubeViewSQL));
       await cubeDB.query(pgformat(`INSERT INTO metadata VALUES (%L, %L)`, coreViewName, coreCubeViewSQL));
 
@@ -2424,7 +2418,6 @@ async function createViewsFromConfig(
       cols = factTable.map((col) => pgformat('%I', col.columnName)) || ['*'];
     }
     const SQL = pgformat('SELECT %s FROM %I', cols.join(', '), baseViewName);
-    logger.debug(`SQL for view ${viewName}: ${SQL}`);
     await cubeDB.query(pgformat('DELETE FROM metadata WHERE key = %L', viewName));
     await cubeDB.query(pgformat('INSERT INTO metadata VALUES (%L, %L)', viewName, SQL));
     await cubeDB.query(pgformat('DELETE FROM metadata WHERE key = %L', `${viewName}_columns`));

--- a/src/services/cube-handler.ts
+++ b/src/services/cube-handler.ts
@@ -282,6 +282,7 @@ export const loadFileDataTableIntoTable = async (
   }
   try {
     logger.debug(`Loading file data table into table ${tableName}`);
+    logger.trace(`insert query: ${insertQuery}`);
     await quack.exec(insertQuery);
     await loadTableDataIntoFactTable(quack, factTableDef, tableName, tempTableName);
     await quack.exec(pgformat('DROP TABLE %I', tempTableName));
@@ -806,6 +807,7 @@ async function copyUpdateTableToFactTable(
     dataTableSelect,
     updateTableName
   );
+  logger.trace(`copy query: ${copyQuery}`);
   await cubeDB.query(copyQuery);
 }
 
@@ -2149,6 +2151,7 @@ async function createPrimaryKeyOnFactTable(
   logger.debug('Creating primary key on fact table');
   try {
     const alterTableQuery = pgformat('ALTER TABLE %I.%I ADD PRIMARY KEY (%I)', schema, FACT_TABLE_NAME, compositeKey);
+    logger.trace(`add primary key query: ${alterTableQuery}`);
     await cubeDB.query(alterTableQuery);
   } catch (error) {
     logger.warn(error, `Failed to add primary key to the fact table`);
@@ -2362,6 +2365,8 @@ export const createBasePostgresCube = async (
         joinStatements.join('\n').replace(/#LANG#/g, pgformat('%L', locale.toLowerCase())),
         orderByStatements.length > 0 ? `ORDER BY ${orderByStatements.join(', ')}` : ''
       );
+
+      logger.trace(`core cube view SQL: ${coreCubeViewSQL}`);
       await cubeDB.query(pgformat('CREATE VIEW %I AS %s', `${CORE_VIEW_NAME}_${lang}`, coreCubeViewSQL));
       await cubeDB.query(pgformat(`INSERT INTO metadata VALUES (%L, %L)`, coreViewName, coreCubeViewSQL));
 

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -492,7 +492,6 @@ export const validateDateDimension = async (
       LEFT JOIN "${lookupTableName}"
       ON fact_table.fact_table_date="${lookupTableName}"."${factTableColumn.columnName}"
       WHERE "${factTableColumn.columnName}" IS NULL;`;
-    // logger.debug(`Matching query is:\n${matchingQuery}`);
 
     const nonMatchedRows = await cubeDB.query(matchingQuery);
 
@@ -589,14 +588,9 @@ export const createAndValidateDateDimension = async (
     tableName
   );
 
-  // logger.debug(`Preview query is: ${previewQuery}`);
   const preview: { data_data: string }[] = await cubeDB.query(previewQuery);
   try {
-    // logger.debug(`Preview is: ${JSON.stringify(preview)}`);
     dateDimensionTable = dateDimensionReferenceTableCreator(extractor, preview);
-    // logger.debug(
-    //   `Date dimension table created with the following JSON: ${JSON.stringify(dateDimensionTable, null, 2)}`
-    // );
   } catch (error) {
     logger.error(error, `Something went wrong trying to create the date reference table`);
     cubeDB.release();
@@ -872,7 +866,7 @@ async function getLookupPreviewWithExtractor(
     sampleSize
   );
 
-  logger.debug(`Querying the cube to get the preview using query ${query}`);
+  logger.debug(`Querying the cube to get the lookup preview`);
   const dimensionTable = await cubeDB.query(query);
   const tableHeaders = Object.keys(dimensionTable[0]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -867,6 +867,7 @@ async function getLookupPreviewWithExtractor(
   );
 
   logger.debug(`Querying the cube to get the lookup preview`);
+  logger.trace(`lookup preview query: ${query}`);
   const dimensionTable = await cubeDB.query(query);
   const tableHeaders = Object.keys(dimensionTable[0]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -281,7 +281,7 @@ async function identifyDuplicateFacts(
   );
 
   try {
-    logger.debug(`Running query to find duplicates:\n${duplicateFactQuery}`);
+    logger.debug(`Running query to find duplicate facts...`);
     const brokenFacts = await cubeDB.query(duplicateFactQuery);
     if (brokenFacts.length > 0) {
       const { headers, data } = tableDataToViewTable(brokenFacts);

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -282,6 +282,7 @@ async function identifyDuplicateFacts(
 
   try {
     logger.debug(`Running query to find duplicate facts...`);
+    logger.trace(`duplicate fact query: ${duplicateFactQuery}`);
     const brokenFacts = await cubeDB.query(duplicateFactQuery);
     if (brokenFacts.length > 0) {
       const { headers, data } = tableDataToViewTable(brokenFacts);

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -169,8 +169,6 @@ export const createLookupTableInCube = async (
     const builtInsertQuery = `
       INSERT INTO ${makeCubeSafeString(dimension.factTableColumn)}_lookup (${dataExtractorParts.join(' UNION ')});
     `;
-
-    // logger.debug(`Built insert query: ${builtInsertQuery}`);
     await quack.exec(builtInsertQuery);
   } else {
     const languageMatcher = languageMatcherCaseStatement(extractor.languageColumn);

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -238,9 +238,7 @@ async function createMeasureTable(
       );
     }
     buildMeasureViewQuery = `${viewComponents.join('\nUNION\n')}`;
-    // logger.debug(`Extracting SW2 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
   } else {
-    // logger.debug(`Extractor = ${JSON.stringify(extractor, null, 2)}`);
     if (extractor.notesColumns && extractor.notesColumns.length > 0) {
       notesColumnDef = `"${extractor.notesColumns[0].name}"`;
     } else {
@@ -262,7 +260,6 @@ async function createMeasureTable(
         ${hierarchyDef} AS hierarchy
       FROM ${lookupTableName}
     `;
-    // logger.debug(`Extracting SW3 measure lookup table to measure table using query ${buildMeasureViewQuery}`);
   }
   try {
     const insertQuery = `INSERT INTO measure (${buildMeasureViewQuery});`;
@@ -543,9 +540,6 @@ export const validateMeasureLookupTable = async (
       lang
     );
     const measureTable = await cubeDB.query(previewQuery);
-    // logger.debug(`Measure preview query result: ${JSON.stringify(dimensionTable, null, 2)}`);
-    // this is throwing "TypeError: Converting circular structure to JSON"
-
     const tableHeaders = Object.keys(measureTable[0]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataArray = measureTable.map((row: any) => Object.values(row));
@@ -639,7 +633,6 @@ async function getMeasurePreviewWithExtractor(
       'measure',
       lang
     );
-    // logger.debug(`Querying the cube to get the preview using query: ${query}`);
     const measureTable = await cubeDB.query(previewQuery);
     const tableHeaders = Object.keys(measureTable[0]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -167,9 +167,8 @@ export const validateLookupTableLanguages = async (
       lookupTableName,
       joinColumn
     );
-    logger.debug(
-      `Checking language counts match total number of supported languages using query:\n${missingLanguageRowsQuery}\n`
-    );
+    logger.debug(`Checking language counts match total number of supported languages`);
+    logger.trace(`missing language rows query: ${missingLanguageRowsQuery}`);
     const missingLanguageRows: { join_column: string; lang_count: number; languages: string }[] =
       await cubeDB.query(missingLanguageRowsQuery);
     if (missingLanguageRows.length > 0) {
@@ -238,7 +237,7 @@ export const validateLookupTableReferenceValues = async (
 ): Promise<ViewErrDTO | undefined> => {
   try {
     logger.debug(`Validating the lookup table`);
-    const nonmatchedRowsQuery = pgformat(
+    const nonMatchedRowsQuery = pgformat(
       `SELECT line_number, fact_table_column, %I.%I as lookup_table_column
             FROM (SELECT row_number() OVER () as line_number, %I as fact_table_column FROM
             %I) as fact_table LEFT JOIN %I ON
@@ -254,7 +253,8 @@ export const validateLookupTableReferenceValues = async (
       lookupTableName,
       joinColumn
     );
-    const nonMatchedRows = await cubeDB.query(nonmatchedRowsQuery);
+    logger.trace(`non matched rows query: ${nonMatchedRowsQuery}`);
+    const nonMatchedRows = await cubeDB.query(nonMatchedRowsQuery);
     logger.debug(`Number of non matched rows: ${nonMatchedRows.length}`);
     const totals: { total_rows: number }[] = await cubeDB.query(`SELECT COUNT(*) as total_rows FROM ${factTableName}`);
     if (nonMatchedRows.length === totals[0].total_rows) {

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -254,9 +254,8 @@ export const validateLookupTableReferenceValues = async (
       lookupTableName,
       joinColumn
     );
-    logger.debug(`Running non-matched query ${nonmatchedRowsQuery}`);
     const nonMatchedRows = await cubeDB.query(nonmatchedRowsQuery);
-    logger.debug(`Number of rows from non matched rows query: ${nonMatchedRows.length}`);
+    logger.debug(`Number of non matched rows: ${nonMatchedRows.length}`);
     const totals: { total_rows: number }[] = await cubeDB.query(`SELECT COUNT(*) as total_rows FROM ${factTableName}`);
     if (nonMatchedRows.length === totals[0].total_rows) {
       logger.error(`The user supplied an incorrect lookup table and none of the rows matched`);


### PR DESCRIPTION
Reduces the wall of text that the backend debug logs have become.

Query logging is now at `trace` level so set `LOG_LEVEL=trace` to enable.