### PR TITLE
SW-774: fix current topic being returned in parent list

### DIFF
--- a/src/repositories/topic.ts
+++ b/src/repositories/topic.ts
@@ -9,6 +9,7 @@ export const TopicRepository = dataSource.getRepository(Topic).extend({
 
   async getParents(path: string): Promise<Topic[]> {
     const parentIds = path.split('.');
+    parentIds.pop(); // the last element is the child, remove it
 
     return this.find({
       where: { id: In(parentIds) }


### PR DESCRIPTION
Fix: The get parent topics function was returning the current topic in the list of parents.

