### PR TITLE
SW-1019 Fix missing quarter format

### DIFF
--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -88,6 +88,8 @@ function quarterFormats(quarterFormat: string, yearFormat: string): DateFormat {
   switch (quarterFormat) {
     case 'QX':
       return { increment, formatStr: `${yearFormat}Q[quarterNo]` };
+    case '-QX':
+      return { increment, formatStr: `${yearFormat}-Q[quarterNo]` };
     case '_QX':
       return { increment, formatStr: `${yearFormat}_Q[quarterNo]` };
     case 'X':


### PR DESCRIPTION
The frontend allows a quarter format of `-Qx` but this ended being ommited from the code resulting in an error for users.  This adds the missing Quarter format to the code.