### PR TITLE
SW-465: Temporarily unpublish / archive / unarchive a dataset

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -60,6 +60,8 @@ import { PublisherDTO } from '../dtos/publisher-dto';
 import { UserGroupRepository } from '../repositories/user-group';
 import { dbManager } from '../db/database-manager';
 import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
+import { TaskAction } from '../enums/task-action';
+import { TaskService } from '../services/task';
 
 export const listUserDatasets = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -562,4 +564,35 @@ export const getHistory = async (req: Request, res: Response, next: NextFunction
     logger.error(err, `There was a problem fetching the history for dataset ${datasetId}`);
     next(new UnknownException('errors.dataset_history'));
   }
+};
+
+export const datasetActionRequest = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const action = req.params.action as TaskAction;
+
+  if (!Object.values(TaskAction).includes(action)) {
+    next();
+    return;
+  }
+
+  const datasetId = res.locals.datasetId;
+  const user = req.user as User;
+  const { reason } = req.body;
+  const taskService = new TaskService();
+
+  switch (action) {
+    // case TaskAction.Publish:
+    //   await taskService.requestPublish(datasetId, user, reason);
+    //   break;
+    case TaskAction.Unpublish:
+      await taskService.requestUnpublish(datasetId, user, reason);
+      break;
+    case TaskAction.Archive:
+      await taskService.requestArchive(datasetId, user, reason);
+      break;
+    case TaskAction.Unarchive:
+      await taskService.requestUnarchive(datasetId, user, reason);
+      break;
+  }
+
+  res.status(204).end();
 };

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -580,9 +580,8 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
   const taskService = new TaskService();
 
   switch (action) {
-    // case TaskAction.Publish:
-    //   await taskService.requestPublish(datasetId, user, reason);
-    //   break;
+    case TaskAction.Publish:
+      throw new BadRequestException('Publish request is handled via the revision endpoint');
     case TaskAction.Unpublish:
       await taskService.requestUnpublish(datasetId, user, reason);
       break;

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -57,7 +57,8 @@ export const taskDecision = async (req: Request, res: Response, next: NextFuncti
 
       case TaskAction.Unpublish:
         if (dto.decision === 'approve') {
-          task = await taskService.approveUnpublish(task.id, user);
+          await req.datasetService.approveUnpublish(dataset.id, user);
+          task = await taskService.update(task.id, TaskStatus.Approved, false, user, null);
         }
         if (dto.decision === 'reject') {
           task = await taskService.rejectUnpublish(task.id, user, dto.reason);

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -11,7 +11,7 @@ import { PublisherDTO } from './publisher-dto';
 // WARNING: Make sure to filter any props the consumer side should not have access to
 export class ConsumerDatasetDTO {
   id: string;
-  live?: string | null;
+  first_published_at?: string | null;
   dimensions?: DimensionDTO[];
   revisions: ConsumerRevisionDTO[];
   published_revision?: ConsumerRevisionDTO;
@@ -22,7 +22,7 @@ export class ConsumerDatasetDTO {
   static fromDataset(dataset: Dataset): ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();
     dto.id = dataset.id;
-    dto.live = dataset.live?.toISOString();
+    dto.first_published_at = dataset.firstPublishedAt?.toISOString();
 
     // only return published revisions
     dto.revisions = dataset.revisions

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -12,6 +12,7 @@ import { PublisherDTO } from './publisher-dto';
 export class ConsumerDatasetDTO {
   id: string;
   first_published_at?: string | null;
+  archived_at?: string;
   dimensions?: DimensionDTO[];
   revisions: ConsumerRevisionDTO[];
   published_revision?: ConsumerRevisionDTO;
@@ -23,6 +24,7 @@ export class ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();
     dto.id = dataset.id;
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
+    dto.archived_at = dataset.archivedAt?.toISOString();
 
     // only return published revisions
     dto.revisions = dataset.revisions

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -12,7 +12,6 @@ import { PublisherDTO } from './publisher-dto';
 export class ConsumerDatasetDTO {
   id: string;
   first_published_at?: string | null;
-  unpublished_at?: string;
   archived_at?: string;
   dimensions?: DimensionDTO[];
   revisions: ConsumerRevisionDTO[];
@@ -25,7 +24,6 @@ export class ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();
     dto.id = dataset.id;
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
-    dto.unpublished_at = dataset.unpublishedAt?.toISOString();
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     // only return published revisions

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -12,6 +12,7 @@ import { PublisherDTO } from './publisher-dto';
 export class ConsumerDatasetDTO {
   id: string;
   first_published_at?: string | null;
+  unpublished_at?: string;
   archived_at?: string;
   dimensions?: DimensionDTO[];
   revisions: ConsumerRevisionDTO[];
@@ -24,6 +25,7 @@ export class ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();
     dto.id = dataset.id;
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
+    dto.unpublished_at = dataset.unpublishedAt?.toISOString();
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     // only return published revisions

--- a/src/dtos/consumer-revision-dto.ts
+++ b/src/dtos/consumer-revision-dto.ts
@@ -17,6 +17,7 @@ export class ConsumerRevisionDTO {
   updated_at: string;
   approved_at?: string;
   publish_at?: string;
+  unpublished_at?: string;
   metadata?: RevisionMetadataDTO[];
   rounding_applied?: boolean;
   update_frequency?: UpdateFrequencyDTO;
@@ -34,6 +35,7 @@ export class ConsumerRevisionDTO {
     revDto.updated_at = revision.updatedAt.toISOString();
     revDto.previous_revision_id = revision.previousRevisionId;
     revDto.publish_at = revision.publishAt?.toISOString();
+    revDto.unpublished_at = revision.unpublishedAt?.toISOString();
     revDto.approved_at = revision.approvedAt?.toISOString();
 
     revDto.rounding_applied = revision.roundingApplied;

--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -15,7 +15,6 @@ export class DatasetDTO {
   created_at: string;
   created_by_id: string;
   first_published_at?: string | null;
-  unpublished_at?: string;
   archived_at?: string;
   fact_table?: FactTableColumnDto[];
   dimensions?: DimensionDTO[];
@@ -26,6 +25,8 @@ export class DatasetDTO {
   end_revision_id?: string;
   draft_revision?: RevisionDTO;
   draft_revision_id?: string;
+  published_revision?: RevisionDTO;
+  published_revision_id?: string;
   measure?: MeasureDTO;
   start_date?: Date | null;
   end_date?: Date | null;
@@ -40,7 +41,6 @@ export class DatasetDTO {
     dto.created_by_id = dataset.createdById;
 
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
-    dto.unpublished_at = dataset.unpublishedAt?.toISOString();
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     dto.dimensions = dataset.dimensions?.map((dimension: Dimension) => DimensionDTO.fromDimension(dimension));
@@ -49,10 +49,14 @@ export class DatasetDTO {
     dto.draft_revision_id = dataset.draftRevisionId;
     dto.start_revision_id = dataset.startRevisionId;
     dto.end_revision_id = dataset.endRevisionId;
+    dto.published_revision_id = dataset.publishedRevisionId;
 
     dto.draft_revision = dataset.draftRevision ? RevisionDTO.fromRevision(dataset.draftRevision) : undefined;
     dto.start_revision = dataset.startRevision ? RevisionDTO.fromRevision(dataset.startRevision) : undefined;
     dto.end_revision = dataset.endRevision ? RevisionDTO.fromRevision(dataset.endRevision) : undefined;
+    dto.published_revision = dataset.publishedRevision
+      ? RevisionDTO.fromRevision(dataset.publishedRevision)
+      : undefined;
 
     dto.measure = dataset.measure ? MeasureDTO.fromMeasure(dataset.measure) : undefined;
 

--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -15,6 +15,7 @@ export class DatasetDTO {
   created_at: string;
   created_by_id: string;
   first_published_at?: string | null;
+  unpublished_at?: string;
   archived_at?: string;
   fact_table?: FactTableColumnDto[];
   dimensions?: DimensionDTO[];
@@ -39,6 +40,7 @@ export class DatasetDTO {
     dto.created_by_id = dataset.createdById;
 
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
+    dto.unpublished_at = dataset.unpublishedAt?.toISOString();
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     dto.dimensions = dataset.dimensions?.map((dimension: Dimension) => DimensionDTO.fromDimension(dimension));

--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -14,8 +14,8 @@ export class DatasetDTO {
   id: string;
   created_at: string;
   created_by_id: string;
-  live?: string | null;
-  archive?: string;
+  first_published_at?: string | null;
+  archived_at?: string;
   fact_table?: FactTableColumnDto[];
   dimensions?: DimensionDTO[];
   revisions: RevisionDTO[];
@@ -38,8 +38,8 @@ export class DatasetDTO {
     dto.created_at = dataset.createdAt.toISOString();
     dto.created_by_id = dataset.createdById;
 
-    dto.live = dataset.live?.toISOString();
-    dto.archive = dataset.archive?.toISOString();
+    dto.first_published_at = dataset.firstPublishedAt?.toISOString();
+    dto.archived_at = dataset.archivedAt?.toISOString();
 
     dto.dimensions = dataset.dimensions?.map((dimension: Dimension) => DimensionDTO.fromDimension(dimension));
     dto.revisions = dataset.revisions?.map((revision: Revision) => RevisionDTO.fromRevision(revision));

--- a/src/dtos/dataset-list-item-dto.ts
+++ b/src/dtos/dataset-list-item-dto.ts
@@ -7,8 +7,9 @@ export interface DatasetListItemDTO {
   group_name?: string;
   code?: string;
   revision_by?: string;
-  last_updated?: string;
   status?: DatasetStatus;
   publishing_status?: PublishingStatus;
   first_published_at?: string;
+  last_updated_at?: string;
+  archived_at?: string;
 }

--- a/src/dtos/dataset-list-item-dto.ts
+++ b/src/dtos/dataset-list-item-dto.ts
@@ -10,5 +10,5 @@ export interface DatasetListItemDTO {
   last_updated?: string;
   status?: DatasetStatus;
   publishing_status?: PublishingStatus;
-  published_date?: string;
+  first_published_at?: string;
 }

--- a/src/dtos/dataset-list-item-dto.ts
+++ b/src/dtos/dataset-list-item-dto.ts
@@ -10,6 +10,7 @@ export interface DatasetListItemDTO {
   status?: DatasetStatus;
   publishing_status?: PublishingStatus;
   first_published_at?: string;
+  unpublished_at?: string;
   last_updated_at?: string;
   archived_at?: string;
 }

--- a/src/dtos/revision-dto.ts
+++ b/src/dtos/revision-dto.ts
@@ -25,6 +25,7 @@ export class RevisionDTO {
   approved_at?: string;
   approved_by?: string;
   publish_at?: string;
+  unpublished_at?: string;
   metadata?: RevisionMetadataDTO[];
   rounding_applied?: boolean;
   update_frequency?: UpdateFrequencyDTO;
@@ -46,6 +47,7 @@ export class RevisionDTO {
     revDto.previous_revision_id = revision.previousRevisionId;
     revDto.online_cube_filename = revision.onlineCubeFilename || undefined;
     revDto.publish_at = revision.publishAt?.toISOString();
+    revDto.unpublished_at = revision.unpublishedAt?.toISOString();
     revDto.approved_at = revision.approvedAt?.toISOString();
     revDto.approved_by = revision.approvedBy?.name;
     revDto.created_by = revision.createdBy?.name;

--- a/src/dtos/task-dto.ts
+++ b/src/dtos/task-dto.ts
@@ -1,9 +1,11 @@
 import { Task, TaskMetadata } from '../entities/task/task';
+import { TaskAction } from '../enums/task-action';
+import { TaskStatus } from '../enums/task-status';
 
 export class TaskDTO {
   id: string;
-  action: string;
-  status: string;
+  action: TaskAction;
+  status: TaskStatus;
   open: boolean;
   dataset_id?: string;
   comment?: string;

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -39,6 +39,9 @@ export class Dataset extends BaseEntity {
   @Column({ name: 'first_published_at', type: 'timestamptz', nullable: true })
   firstPublishedAt: Date | null;
 
+  @Column({ name: 'unpublished_at', type: 'timestamptz', nullable: true })
+  unpublishedAt: Date | null;
+
   @Column({ name: 'archived_at', type: 'timestamptz', nullable: true })
   archivedAt: Date | null;
 

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -39,9 +39,6 @@ export class Dataset extends BaseEntity {
   @Column({ name: 'first_published_at', type: 'timestamptz', nullable: true })
   firstPublishedAt: Date | null;
 
-  @Column({ name: 'unpublished_at', type: 'timestamptz', nullable: true })
-  unpublishedAt: Date | null;
-
   @Column({ name: 'archived_at', type: 'timestamptz', nullable: true })
   archivedAt: Date | null;
 

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -36,11 +36,11 @@ export class Dataset extends BaseEntity {
   @Column({ type: 'uuid', name: 'created_by' })
   createdById: string;
 
-  @Column({ type: 'timestamptz', nullable: true })
-  live: Date | null;
+  @Column({ name: 'first_published_at', type: 'timestamptz', nullable: true })
+  firstPublishedAt: Date | null;
 
-  @Column({ type: 'timestamptz', nullable: true })
-  archive: Date;
+  @Column({ name: 'archived_at', type: 'timestamptz', nullable: true })
+  archivedAt: Date | null;
 
   @Column({ name: 'start_date', type: 'date', nullable: true })
   startDate: Date | null;

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -80,7 +80,7 @@ export class Revision extends BaseEntity {
   approvedBy: User | null;
 
   @Column({ name: 'publish_at', type: 'timestamptz', nullable: true })
-  publishAt: Date;
+  publishAt: Date | null;
 
   @Column({ name: 'tasks', type: 'jsonb', nullable: true })
   tasks: RevisionTask;

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -82,6 +82,9 @@ export class Revision extends BaseEntity {
   @Column({ name: 'publish_at', type: 'timestamptz', nullable: true })
   publishAt: Date | null;
 
+  @Column({ name: 'unpublished_at', type: 'timestamptz', nullable: true })
+  unpublishedAt: Date | null;
+
   @Column({ name: 'tasks', type: 'jsonb', nullable: true })
   tasks: RevisionTask;
 

--- a/src/entities/task/task.ts
+++ b/src/entities/task/task.ts
@@ -40,7 +40,7 @@ export class Task extends BaseEntity {
   @Column({ name: 'dataset_id', type: 'text', nullable: true })
   datasetId?: string;
 
-  @ManyToOne(() => Dataset, (dataset) => dataset.tasks, { nullable: true })
+  @ManyToOne(() => Dataset, (dataset) => dataset.tasks, { nullable: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'dataset_id', foreignKeyConstraintName: 'FK_task_dataset_id' })
   dataset?: Dataset;
 

--- a/src/enums/dataset-status.ts
+++ b/src/enums/dataset-status.ts
@@ -1,5 +1,6 @@
 export enum DatasetStatus {
   New = 'new',
   Live = 'live',
+  Offline = 'offline',
   Archived = 'archived'
 }

--- a/src/enums/dataset-status.ts
+++ b/src/enums/dataset-status.ts
@@ -1,5 +1,5 @@
 export enum DatasetStatus {
   New = 'new',
   Live = 'live',
-  Migrated = 'migrated'
+  Archived = 'archived'
 }

--- a/src/enums/publishing-status.ts
+++ b/src/enums/publishing-status.ts
@@ -7,6 +7,7 @@ export enum PublishingStatus {
   Scheduled = 'scheduled',
   UpdateScheduled = 'update_scheduled',
   Published = 'published',
+  Unpublished = 'unpublished',
   UnpublishRequested = 'unpublish_requested',
   ArchiveRequested = 'archive_requested',
   UnarchiveRequested = 'unarchive_requested'

--- a/src/enums/publishing-status.ts
+++ b/src/enums/publishing-status.ts
@@ -6,5 +6,8 @@ export enum PublishingStatus {
   ChangesRequested = 'changes_requested',
   Scheduled = 'scheduled',
   UpdateScheduled = 'update_scheduled',
-  Published = 'published'
+  Published = 'published',
+  UnpublishRequested = 'unpublish_requested',
+  ArchiveRequested = 'archive_requested',
+  UnarchiveRequested = 'unarchive_requested'
 }

--- a/src/migrations/1757407828605-archived.ts
+++ b/src/migrations/1757407828605-archived.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Archived1757407828605 implements MigrationInterface {
+  name = 'Archived1757407828605';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "live" TO "first_published_at"`);
+    await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archive" TO "archived_at"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archived_at" TO "archive"`);
+    await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "first_published_at" TO "live"`);
+  }
+}

--- a/src/migrations/1757407828605-unpublish-archive.ts
+++ b/src/migrations/1757407828605-unpublish-archive.ts
@@ -6,11 +6,23 @@ export class UnpublishArchive1757407828605 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "live" TO "first_published_at"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archive" TO "archived_at"`);
+
     await queryRunner.query(`ALTER TABLE "revision" ADD COLUMN "unpublished_at" TIMESTAMP WITH TIME ZONE`);
+
+    await queryRunner.query(`ALTER TABLE "task" DROP CONSTRAINT "FK_task_dataset_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "task" ADD CONSTRAINT "FK_task_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "task" DROP CONSTRAINT "FK_task_dataset_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "task" ADD CONSTRAINT "FK_task_dataset_id" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+
     await queryRunner.query(`ALTER TABLE "revision" DROP COLUMN "unpublished_at"`);
+
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archived_at" TO "archive"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "first_published_at" TO "live"`);
   }

--- a/src/migrations/1757407828605-unpublish-archive.ts
+++ b/src/migrations/1757407828605-unpublish-archive.ts
@@ -1,14 +1,16 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class Archived1757407828605 implements MigrationInterface {
-  name = 'Archived1757407828605';
+export class UnpublishArchive1757407828605 implements MigrationInterface {
+  name = 'UnpublishArchive1757407828605';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "live" TO "first_published_at"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archive" TO "archived_at"`);
+    await queryRunner.query(`ALTER TABLE "dataset" ADD COLUMN "unpublished_at" TIMESTAMP WITH TIME ZONE`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "dataset" DROP COLUMN "unpublished_at"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archived_at" TO "archive"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "first_published_at" TO "live"`);
   }

--- a/src/migrations/1757407828605-unpublish-archive.ts
+++ b/src/migrations/1757407828605-unpublish-archive.ts
@@ -6,11 +6,11 @@ export class UnpublishArchive1757407828605 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "live" TO "first_published_at"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archive" TO "archived_at"`);
-    await queryRunner.query(`ALTER TABLE "dataset" ADD COLUMN "unpublished_at" TIMESTAMP WITH TIME ZONE`);
+    await queryRunner.query(`ALTER TABLE "revision" ADD COLUMN "unpublished_at" TIMESTAMP WITH TIME ZONE`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "dataset" DROP COLUMN "unpublished_at"`);
+    await queryRunner.query(`ALTER TABLE "revision" DROP COLUMN "unpublished_at"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "archived_at" TO "archive"`);
     await queryRunner.query(`ALTER TABLE "dataset" RENAME COLUMN "first_published_at" TO "live"`);
   }

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -88,7 +88,8 @@ const listAllQuery = (qb: QueryBuilder<Dataset>, lang: Locale): SelectQueryBuild
     .addSelect(
       `
         CASE
-          WHEN d.live IS NOT NULL AND d.live < NOW() THEN 'live'
+          WHEN d.archived_at IS NOT NULL AND d.archived_at < NOW() THEN 'archived'
+          WHEN d.first_published_at IS NOT NULL AND d.first_published_at < NOW() THEN 'live'
           ELSE 'new'
         END`,
       'status'
@@ -96,14 +97,17 @@ const listAllQuery = (qb: QueryBuilder<Dataset>, lang: Locale): SelectQueryBuild
     .addSelect(
       `
         CASE
-          WHEN d.live IS NOT NULL AND t.action = 'publish' AND t.status = 'requested' THEN 'update_pending_approval'
+          WHEN d.first_published_at IS NOT NULL AND t.action = 'publish' AND t.status = 'requested' THEN 'update_pending_approval'
           WHEN t.action = 'publish' AND t.status = 'requested' THEN 'pending_approval'
           WHEN t.action = 'publish' AND t.status = 'rejected' THEN 'changes_requested'
-          WHEN d.live IS NOT NULL AND d.live < NOW() AND r.approved_at IS NOT NULL AND r.publish_at < NOW() THEN 'published'
-          WHEN d.live IS NOT NULL AND d.live < NOW() AND r.approved_at IS NOT NULL AND r.publish_at > NOW() THEN 'update_scheduled'
-          WHEN d.live IS NOT NULL AND d.live > NOW() AND r.approved_at IS NOT NULL AND r.publish_at > NOW() THEN 'scheduled'
-          WHEN d.live IS NOT NULL AND d.live < NOW() AND r.approved_at IS NULL THEN 'update_incomplete'
-          WHEN d.live IS NULL AND r.approved_at IS NULL THEN 'incomplete'
+          WHEN t.action = 'unpublish' AND t.status = 'requested' THEN 'unpublish_requested'
+          WHEN t.action = 'archive' AND t.status = 'requested' THEN 'archive_requested'
+          WHEN t.action = 'unarchive' AND t.status = 'requested' THEN 'unarchive_requested'
+          WHEN d.first_published_at IS NOT NULL AND d.first_published_at < NOW() AND r.approved_at IS NOT NULL AND r.publish_at < NOW() THEN 'published'
+          WHEN d.first_published_at IS NOT NULL AND d.first_published_at < NOW() AND r.approved_at IS NOT NULL AND r.publish_at > NOW() THEN 'update_scheduled'
+          WHEN d.first_published_at IS NOT NULL AND d.first_published_at > NOW() AND r.approved_at IS NOT NULL AND r.publish_at > NOW() THEN 'scheduled'
+          WHEN d.first_published_at IS NOT NULL AND d.first_published_at < NOW() AND r.approved_at IS NULL THEN 'update_incomplete'
+          WHEN d.first_published_at IS NULL AND r.approved_at IS NULL THEN 'incomplete'
           ELSE 'incomplete'
         END
         `,
@@ -256,17 +260,59 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
   },
 
   async publish(revision: Revision, period: PeriodCovered): Promise<Dataset> {
-    const dataset = revision.dataset;
+    const dataset = await this.getById(revision.datasetId, { startRevision: true });
+
+    if (!dataset.startRevision) {
+      throw new Error(`Dataset ${dataset.id} does not have a start revision`);
+    }
 
     dataset.startDate = period.start_date;
     dataset.endDate = period.end_date;
     dataset.draftRevision = null;
     dataset.publishedRevision = revision;
+    dataset.firstPublishedAt = dataset.startRevision!.publishAt;
 
-    if (revision.revisionIndex === 1) {
-      dataset.live = revision.publishAt; // set the first published date if this is the first rev
+    return this.save(dataset);
+  },
+
+  async unpublish(datasetId: string): Promise<Dataset> {
+    logger.info(`Unpublishing dataset ${datasetId}`);
+
+    const dataset = await this.getById(datasetId, { publishedRevision: true });
+    const publishedRevision = dataset.publishedRevision;
+
+    if (!publishedRevision) {
+      throw new Error(`Dataset ${datasetId} does not have a published revision`);
     }
 
-    return DatasetRepository.save(dataset);
+    publishedRevision.approvedAt = null;
+    publishedRevision.publishAt = null;
+
+    if (publishedRevision.revisionIndex !== 1) {
+      // reset rev index to draft state if it's not the initial revision
+      publishedRevision.revisionIndex = 0;
+    }
+
+    await publishedRevision.save();
+
+    dataset.draftRevision = publishedRevision;
+    dataset.publishedRevision = null;
+    dataset.firstPublishedAt = null;
+
+    return this.save(dataset);
+  },
+
+  async archive(datasetId: string): Promise<Dataset> {
+    logger.info(`Archiving dataset ${datasetId}`);
+    const dataset = await this.getById(datasetId);
+    dataset.archivedAt = new Date();
+    return await this.save(dataset);
+  },
+
+  async unarchive(datasetId: string): Promise<Dataset> {
+    logger.info(`Unarchiving dataset ${datasetId}`);
+    const dataset = await this.getById(datasetId);
+    dataset.archivedAt = null;
+    return await this.save(dataset);
   }
 });

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -83,7 +83,7 @@ export const withDraftForCube: FindOptionsRelations<Dataset> = {
 
 const listAllQuery = (qb: QueryBuilder<Dataset>, lang: Locale): SelectQueryBuilder<Dataset> => {
   return qb
-    .select(['d.id AS id', 'r.title AS title', 'r.title_alt AS title_alt', 'r.updated_at AS last_updated'])
+    .select(['d.id AS id', 'r.title AS title', 'r.title_alt AS title_alt', 'r.updated_at AS last_updated_at'])
     .addSelect(`ugm.name AS group_name`)
     .addSelect(
       `

--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -78,13 +78,19 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     limit: number
   ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
     const qb = this.createQueryBuilder('d')
-      .select(['d.id as id', 'rm.title as title', 'd.first_published_at as published_date'])
+      .select([
+        'd.id AS id',
+        'rm.title AS title',
+        'd.first_published_at AS first_published_at',
+        'r.publish_at AS last_updated_at',
+        'd.archived_at AS archived_at'
+      ])
       .innerJoin('d.publishedRevision', 'r')
       .innerJoin('r.metadata', 'rm')
       .where('rm.language LIKE :lang', { lang: `${lang}%` })
       .andWhere('d.first_published_at IS NOT NULL')
       .andWhere('d.first_published_at < NOW()')
-      .groupBy('d.id, rm.title, d.first_published_at')
+      .groupBy('d.id, rm.title, d.first_published_at, r.publish_at, d.archived_at')
       .orderBy('d.first_published_at', 'DESC');
 
     const offset = (page - 1) * limit;
@@ -126,7 +132,13 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     limit: number
   ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
     const qb = this.createQueryBuilder('d')
-      .select(['d.id as id', 'rm.title as title', 'd.first_published_at as published_date'])
+      .select([
+        'd.id AS id',
+        'rm.title AS title',
+        'd.first_published_at AS first_published_at',
+        'r.publish_at AS last_updated_at',
+        'd.archived_at AS archived_at'
+      ])
       .innerJoin('d.publishedRevision', 'r')
       .innerJoin('r.metadata', 'rm')
       .innerJoin('r.revisionTopics', 'rt')
@@ -134,7 +146,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       .andWhere('d.first_published_at IS NOT NULL')
       .andWhere('d.first_published_at < NOW()')
       .andWhere('rt.topicId = :topicId', { topicId })
-      .groupBy('d.id, rm.title, d.first_published_at')
+      .groupBy('d.id, rm.title, d.first_published_at, r.publish_at, d.archived_at')
       .orderBy('d.first_published_at', 'DESC');
 
     const offset = (page - 1) * limit;

--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -44,7 +44,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       relations,
       where: {
         id,
-        live: And(Not(IsNull()), LessThan(now)),
+        firstPublishedAt: And(Not(IsNull()), LessThan(now)),
         revisions: {
           approvedAt: LessThan(now),
           publishAt: LessThan(now)
@@ -78,18 +78,18 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     limit: number
   ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
     const qb = this.createQueryBuilder('d')
-      .select(['d.id as id', 'rm.title as title', 'd.live as published_date'])
+      .select(['d.id as id', 'rm.title as title', 'd.first_published_at as published_date'])
       .innerJoin('d.publishedRevision', 'r')
       .innerJoin('r.metadata', 'rm')
       .where('rm.language LIKE :lang', { lang: `${lang}%` })
-      .andWhere('d.live IS NOT NULL')
-      .andWhere('d.live < NOW()')
-      .groupBy('d.id, rm.title, d.live')
-      .orderBy('d.live', 'DESC');
+      .andWhere('d.first_published_at IS NOT NULL')
+      .andWhere('d.first_published_at < NOW()')
+      .groupBy('d.id, rm.title, d.first_published_at')
+      .orderBy('d.first_published_at', 'DESC');
 
     const offset = (page - 1) * limit;
     const countQuery = qb.clone();
-    const resultQuery = qb.orderBy('d.live', 'DESC').offset(offset).limit(limit);
+    const resultQuery = qb.orderBy('d.first_published_at', 'DESC').offset(offset).limit(limit);
     const [data, count] = await Promise.all([resultQuery.getRawMany(), countQuery.getCount()]);
 
     return { data, count };
@@ -98,8 +98,8 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
   async listPublishedTopics(lang: Locale, topicId?: string): Promise<Topic[]> {
     const latestPublishedRevisions = await this.createQueryBuilder('d')
       .select('d.published_revision_id')
-      .where('d.live IS NOT NULL')
-      .andWhere('d.live < NOW()')
+      .where('d.first_published_at IS NOT NULL')
+      .andWhere('d.first_published_at < NOW()')
       .andWhere('d.published_revision_id IS NOT NULL')
       .getRawMany();
 
@@ -126,20 +126,20 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     limit: number
   ): Promise<ResultsetWithCount<DatasetListItemDTO>> {
     const qb = this.createQueryBuilder('d')
-      .select(['d.id as id', 'rm.title as title', 'd.live as published_date'])
+      .select(['d.id as id', 'rm.title as title', 'd.first_published_at as published_date'])
       .innerJoin('d.publishedRevision', 'r')
       .innerJoin('r.metadata', 'rm')
       .innerJoin('r.revisionTopics', 'rt')
       .where('rm.language LIKE :lang', { lang: `${lang}%` })
-      .andWhere('d.live IS NOT NULL')
-      .andWhere('d.live < NOW()')
+      .andWhere('d.first_published_at IS NOT NULL')
+      .andWhere('d.first_published_at < NOW()')
       .andWhere('rt.topicId = :topicId', { topicId })
-      .groupBy('d.id, rm.title, d.live')
-      .orderBy('d.live', 'DESC');
+      .groupBy('d.id, rm.title, d.first_published_at')
+      .orderBy('d.first_published_at', 'DESC');
 
     const offset = (page - 1) * limit;
     const countQuery = qb.clone();
-    const resultQuery = qb.orderBy('d.live', 'DESC').offset(offset).limit(limit);
+    const resultQuery = qb.orderBy('d.first_published_at', 'DESC').offset(offset).limit(limit);
     const [data, count] = await Promise.all([resultQuery.getRawMany(), countQuery.getCount()]);
 
     return { data, count };

--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -44,11 +44,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       relations,
       where: {
         id,
-        firstPublishedAt: And(Not(IsNull()), LessThan(now)),
-        revisions: {
-          approvedAt: LessThan(now),
-          publishAt: LessThan(now)
-        }
+        firstPublishedAt: And(Not(IsNull()), LessThan(now))
       }
     };
 

--- a/src/repositories/revision.ts
+++ b/src/repositories/revision.ts
@@ -133,7 +133,7 @@ export const RevisionRepository = dataSource.getRepository(Revision).extend({
     const dataset = revision.dataset;
 
     if (revision.revisionIndex === 1) {
-      dataset.live = null;
+      dataset.firstPublishedAt = null;
     } else {
       revision.revisionIndex = 0;
     }

--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -584,10 +584,20 @@
             "type": "string",
             "description": "Title of the dataset (in the language requested via accept-language header)"
           },
-          "published_date": {
+          "first_published_at": {
             "type": "string",
             "format": "date-time",
             "description": "First publication date of the dataset in ISO 8601 format"
+          },
+          "last_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date of the most recent update to the dataset in ISO 8601 format"
+          },
+          "archived_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the dataset was archived in ISO 8601 format, if applicable"
           }
         }
       },
@@ -610,12 +620,12 @@
             {
               "id": "141baa8a-2ed0-45cb-ad4a-83de8c2333b5",
               "title": "Population Estimates",
-              "published_date": "2023-01-01T00:00:00Z"
+              "first_published_at": "2023-01-01T00:00:00Z"
             },
             {
               "id": "0ff18b56-0a4f-4ac3-a198-197aa48cc9e1",
               "title": "Economic Indicators",
-              "published_date": "2023-02-01T00:00:00Z"
+              "first_published_at": "2023-02-01T00:00:00Z"
             }
           ],
           "count": 57

--- a/src/routes/consumer/v1/schema.ts
+++ b/src/routes/consumer/v1/schema.ts
@@ -268,10 +268,20 @@ export const schema = {
             type: 'string',
             description: 'Title of the dataset (in the language requested via accept-language header)'
           },
-          published_date: {
+          first_published_at: {
             type: 'string',
             format: 'date-time',
             description: 'First publication date of the dataset in ISO 8601 format'
+          },
+          last_updated_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date of the most recent update to the dataset in ISO 8601 format'
+          },
+          archived_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date the dataset was archived in ISO 8601 format, if applicable'
           }
         }
       },
@@ -286,12 +296,12 @@ export const schema = {
             {
               id: '141baa8a-2ed0-45cb-ad4a-83de8c2333b5',
               title: 'Population Estimates',
-              published_date: '2023-01-01T00:00:00Z'
+              first_published_at: '2023-01-01T00:00:00Z'
             },
             {
               id: '0ff18b56-0a4f-4ac3-a198-197aa48cc9e1',
               title: 'Economic Indicators',
-              published_date: '2023-02-01T00:00:00Z'
+              first_published_at: '2023-02-01T00:00:00Z'
             }
           ],
           count: 57

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -27,7 +27,8 @@ import {
   listAllFilesInDataset,
   getAllFilesForDataset,
   updateDatasetGroup,
-  getHistory
+  getHistory,
+  datasetActionRequest
 } from '../controllers/dataset';
 import { datasetAuth } from '../middleware/dataset-auth';
 import { fileStreaming } from '../middleware/file-streaming';
@@ -152,6 +153,10 @@ datasetRouter.patch('/:dataset_id/group', jsonParser, updateDatasetGroup);
 // GET /dataset/:dataset_id/history
 // List the event history for this dataset
 datasetRouter.get('/:dataset_id/history', getHistory);
+
+// POST /dataset/:dataset_id/:action
+// Request an action (publish, unpublish, archive, unarchive, withdraw) for this dataset
+datasetRouter.post('/:dataset_id/:action', jsonParser, datasetActionRequest);
 
 // apply revision child routes
 datasetRouter.use('/:dataset_id/revision', revisionRouter);

--- a/src/routes/task.ts
+++ b/src/routes/task.ts
@@ -14,6 +14,7 @@ const jsonParser = express.json();
 
 const taskAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const taskIdError = await hasError(uuidValidator('task_id'), req);
+
   if (taskIdError) {
     logger.error(taskIdError);
     next(new NotFoundException('errors.dataset_id_invalid'));
@@ -23,6 +24,7 @@ const taskAuth = async (req: Request, res: Response, next: NextFunction): Promis
   try {
     const taskService = new TaskService();
     const task = await taskService.getById(req.params.task_id, { dataset: true, createdBy: true, updatedBy: true });
+
     const dataset = task.dataset;
     const userGroupIds = getUserGroupIdsForUser(req.user!);
 

--- a/src/seeders/dataset.ts
+++ b/src/seeders/dataset.ts
@@ -39,7 +39,7 @@ const approvedDataset: DeepPartial<Dataset> = {
   id: 'f12bed26-18ac-4cb9-bcdb-24ed155f29a1',
   createdBy: user,
   createdAt: '2025-05-01 13:10:40.176625+00',
-  live: '2025-05-01 13:20:00+00',
+  firstPublishedAt: '2025-05-01 13:20:00+00',
   startDate: '2013-04-01',
   endDate: '2024-03-31',
   factTable: [
@@ -263,8 +263,8 @@ export default class DatasetSeeder extends Seeder {
           return { ...r, providerId: provider!.id };
         }),
         approvedBy: dataset.createdBy,
-        approvedAt: dataset.live || undefined,
-        publishAt: dataset.live || undefined
+        approvedAt: dataset.firstPublishedAt || undefined,
+        publishAt: dataset.firstPublishedAt || undefined
       });
 
       const duckdbFiles = [
@@ -297,8 +297,8 @@ export default class DatasetSeeder extends Seeder {
         },
         startRevision: revision,
         endRevision: revision,
-        draftRevision: dataset.live ? undefined : revision,
-        publishedRevision: dataset.live ? revision : undefined
+        draftRevision: dataset.firstPublishedAt ? undefined : revision,
+        publishedRevision: dataset.firstPublishedAt ? revision : undefined
       });
     } catch (err) {
       console.error(err, `Error seeding dataset ${approvedDataset.id}`);

--- a/src/seeders/tests/seed.ts
+++ b/src/seeders/tests/seed.ts
@@ -70,16 +70,16 @@ export default class SeedTestFixtures extends Seeder {
             dataset,
             dataTable,
             approvedBy: dataset.createdBy,
-            approvedAt: dataset.live || undefined,
-            publishAt: dataset.live || undefined
+            approvedAt: dataset.firstPublishedAt || undefined,
+            publishAt: dataset.firstPublishedAt || undefined
           });
 
           await entityManager.getRepository(Dataset).save({
             ...dataset,
             startRevision: revision,
             endRevision: revision,
-            draftRevision: dataset.live ? undefined : revision,
-            publishedRevision: dataset.live ? revision : undefined
+            draftRevision: dataset.firstPublishedAt ? undefined : revision,
+            publishedRevision: dataset.firstPublishedAt ? revision : undefined
           });
         }
       } catch (err) {

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -295,13 +295,10 @@ export class DatasetService {
     const start = performance.now();
     await createAllCubeFiles(datasetId, revisionId);
     const periodCoverage = await getCubeTimePeriods(revisionId);
-
-    const end = performance.now();
-    const time = Math.round(end - start);
-    logger.info(`Cube and parquet file creation took ${time}ms (including uploading to data lake)`);
-
     const scheduledRevision = await RevisionRepository.approvePublication(revisionId, `${revisionId}.duckdb`, user);
     const approvedDataset = await DatasetRepository.publish(scheduledRevision, periodCoverage);
+    const time = Math.round(performance.now() - start);
+    logger.info(`Publication approved, time: ${time}ms`);
 
     return approvedDataset;
   }

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -79,6 +79,7 @@ export class DatasetService {
 
   async getDatasetOverview(datasetId: string): Promise<Dataset> {
     return DatasetRepository.getById(datasetId, {
+      publishedRevision: { metadata: true },
       endRevision: { metadata: true },
       tasks: { createdBy: true, updatedBy: true }
     });
@@ -319,13 +320,11 @@ export class DatasetService {
       relations: { publishedRevision: true, revisions: true }
     });
 
-    const publishedRevision = dataset.publishedRevision!;
-    const unPublishedRevisions = dataset.revisions.filter((rev) => !isPublished(rev));
-
-    if (unPublishedRevisions.length > 0) {
-      throw new BadRequestException('errors.create_revision.existing_unpublished_revisions');
+    if (dataset.revisions.some((rev) => !isPublished(rev))) {
+      throw new BadRequestException('errors.create_revision.existing_draft_revision');
     }
 
+    const publishedRevision = dataset.publishedRevision!;
     const newRevision = await RevisionRepository.deepCloneRevision(publishedRevision.id, createdBy);
     logger.info(`New draft revision created: ${newRevision.id}`);
 
@@ -460,5 +459,24 @@ export class DatasetService {
       .filter(omitDatasetUpdates)
       .filter(omitRevisionUpdates)
       .map((event) => flagUpdateTask(dataset, event));
+  }
+
+  async approveUnpublish(datasetId: string, user: User): Promise<void> {
+    logger.info(`Unpublishing dataset ${datasetId}`);
+
+    let dataset = await DatasetRepository.getById(datasetId, { publishedRevision: true });
+
+    if (!dataset.publishedRevision) {
+      throw new Error(`Dataset ${datasetId} does not have a published revision`);
+    }
+
+    // mark the current published revision as unpublished
+    dataset.publishedRevision.unpublishedAt = new Date();
+    await dataset.publishedRevision.save();
+    logger.info(`Revision ${dataset.publishedRevision.id} marked as unpublished`);
+
+    // create a new draft revision based on the now unpublished revision
+    dataset = await this.createRevision(datasetId, user);
+    await createAllCubeFiles(dataset.id, dataset.draftRevision!.id);
   }
 }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -82,7 +82,7 @@ export class TaskService {
     logger.info(`Approving unpublish for dataset ${dataset.id}`);
 
     await DatasetRepository.unpublish(dataset.id);
-    return this.update(task.id, TaskStatus.Approved, false, user);
+    return this.update(task.id, TaskStatus.Approved, false, user, null);
   }
 
   async rejectUnpublish(taskId: string, user: User, reason: string): Promise<Task> {
@@ -109,7 +109,7 @@ export class TaskService {
     logger.info(`Approving archive for dataset ${dataset.id}`);
 
     await DatasetRepository.archive(dataset.id);
-    return this.update(task.id, TaskStatus.Approved, false, user);
+    return this.update(task.id, TaskStatus.Approved, false, user, null);
   }
 
   async rejectArchive(taskId: string, user: User, reason: string): Promise<Task> {
@@ -135,7 +135,7 @@ export class TaskService {
     logger.info(`Approving unarchive for dataset ${dataset.id}`);
 
     await DatasetRepository.unarchive(dataset.id);
-    return this.update(task.id, TaskStatus.Approved, false, user);
+    return this.update(task.id, TaskStatus.Approved, false, user, null);
   }
 
   async rejectUnarchive(taskId: string, user: User, reason: string): Promise<Task> {

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -76,15 +76,6 @@ export class TaskService {
     return await this.create(datasetId, TaskAction.Unpublish, user, reason, { revisionId: dataset.endRevisionId });
   }
 
-  async approveUnpublish(taskId: string, user: User): Promise<Task> {
-    const task = await this.getById(taskId, { dataset: true });
-    const dataset = task.dataset!;
-    logger.info(`Approving unpublish for dataset ${dataset.id}`);
-
-    await DatasetRepository.unpublish(dataset.id);
-    return this.update(task.id, TaskStatus.Approved, false, user, null);
-  }
-
   async rejectUnpublish(taskId: string, user: User, reason: string): Promise<Task> {
     const task = await this.getById(taskId, { dataset: true });
     logger.info(`Rejecting unpublish for dataset ${task.dataset?.id}`);

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -5,7 +5,10 @@ import { Task, TaskMetadata } from '../entities/task/task';
 import { TaskAction } from '../enums/task-action';
 import { TaskStatus } from '../enums/task-status';
 import { User } from '../entities/user/user';
-import { TaskDecisionDTO } from '../dtos/task-decision-dto';
+import { DatasetRepository } from '../repositories/dataset';
+import { getPublishingStatus } from '../utils/dataset-status';
+import { PublishingStatus } from '../enums/publishing-status';
+import { BadRequestException } from '../exceptions/bad-request.exception';
 
 export class TaskService {
   async create(
@@ -54,24 +57,95 @@ export class TaskService {
     return task.save();
   }
 
-  async decision(taskId: string, decision: TaskDecisionDTO, user: User): Promise<Task> {
-    logger.info(`Decision received for task ${taskId}: ${decision.decision}`);
+  async requestUnpublish(datasetId: string, user: User, reason: string): Promise<Task> {
+    logger.info(`Requesting unpublish for dataset ${datasetId}`);
+    const dataset = await DatasetRepository.getById(datasetId, { endRevision: true, tasks: true });
 
-    if (decision.decision === 'approve') {
-      // task is resolved and closed
-      return await this.update(taskId, TaskStatus.Approved, false, user);
+    if (dataset.tasks?.some((task) => task.open)) {
+      logger.warn(`Cannot request unpublish dataset ${datasetId} because it has open tasks`);
+      throw new BadRequestException('errors.request_unpublish.open_tasks');
     }
 
-    if (decision.decision === 'reject') {
-      // leave task open so it can be re-submitted
-      return await this.update(taskId, TaskStatus.Rejected, true, user, decision.reason);
+    const publishingStatus = getPublishingStatus(dataset, dataset.endRevision!);
+
+    if (publishingStatus !== PublishingStatus.Published) {
+      logger.warn(`Cannot unpublish dataset ${datasetId} because it is not in a published state: ${publishingStatus}`);
+      throw new BadRequestException('errors.submit_for_unpublish.invalid_status');
     }
 
-    return this.getById(taskId);
+    return await this.create(datasetId, TaskAction.Unpublish, user, reason, { revisionId: dataset.endRevisionId });
+  }
+
+  async approveUnpublish(taskId: string, user: User): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    const dataset = task.dataset!;
+    logger.info(`Approving unpublish for dataset ${dataset.id}`);
+
+    await DatasetRepository.unpublish(dataset.id);
+    return this.update(task.id, TaskStatus.Approved, false, user);
+  }
+
+  async rejectUnpublish(taskId: string, user: User, reason: string): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    logger.info(`Rejecting unpublish for dataset ${task.dataset?.id}`);
+    return this.update(task.id, TaskStatus.Rejected, false, user, reason);
+  }
+
+  async requestArchive(datasetId: string, user: User, reason: string): Promise<void> {
+    logger.info(`Requesting archive for dataset ${datasetId}`);
+    const dataset = await DatasetRepository.getById(datasetId, { tasks: true });
+
+    if (dataset.tasks?.some((task) => task.open)) {
+      logger.warn(`Cannot request archive dataset ${datasetId} because it has open tasks`);
+      throw new BadRequestException('errors.request_archive.open_tasks');
+    }
+
+    await this.create(datasetId, TaskAction.Archive, user, reason, { revisionId: dataset.endRevisionId });
+  }
+
+  async approveArchive(taskId: string, user: User): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    const dataset = task.dataset!;
+    logger.info(`Approving archive for dataset ${dataset.id}`);
+
+    await DatasetRepository.archive(dataset.id);
+    return this.update(task.id, TaskStatus.Approved, false, user);
+  }
+
+  async rejectArchive(taskId: string, user: User, reason: string): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    logger.info(`Rejecting archive for dataset ${task.dataset?.id}`);
+    return this.update(task.id, TaskStatus.Rejected, false, user, reason);
+  }
+
+  async requestUnarchive(datasetId: string, user: User, reason: string): Promise<void> {
+    const dataset = await DatasetRepository.getById(datasetId, { tasks: true });
+
+    if (dataset.tasks?.some((task) => task.open)) {
+      logger.warn(`Cannot request unarchive dataset ${datasetId} because it has open tasks`);
+      throw new BadRequestException('errors.request_unarchive.open_tasks');
+    }
+
+    await this.create(datasetId, TaskAction.Unarchive, user, reason, { revisionId: dataset.endRevisionId });
+  }
+
+  async approveUnarchive(taskId: string, user: User): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    const dataset = task.dataset!;
+    logger.info(`Approving unarchive for dataset ${dataset.id}`);
+
+    await DatasetRepository.unarchive(dataset.id);
+    return this.update(task.id, TaskStatus.Approved, false, user);
+  }
+
+  async rejectUnarchive(taskId: string, user: User, reason: string): Promise<Task> {
+    const task = await this.getById(taskId, { dataset: true });
+    logger.info(`Rejecting unarchive for dataset ${task.dataset?.id}`);
+    return this.update(task.id, TaskStatus.Rejected, false, user, reason);
   }
 
   async update(taskId: string, status: TaskStatus, open: boolean, user: User, comment?: string | null): Promise<Task> {
-    logger.info(`Updating task ${taskId} with status ${status}`);
+    logger.debug(`Updating task ${taskId} with status ${status}`);
     const task = await Task.findOneByOrFail({ id: taskId });
     const updatedTask = Task.merge(task, { status, open, updatedBy: user, comment });
 

--- a/src/utils/dataset-history.ts
+++ b/src/utils/dataset-history.ts
@@ -31,12 +31,13 @@ export const generateSimulatedEvents = (dataset: Dataset): EventLog[] => {
   const events: EventLog[] = [];
   const now = new Date();
 
-  const firstPublished = dataset.live && isBefore(dataset.live, now) ? dataset.live : undefined;
+  const firstPublished =
+    dataset.firstPublishedAt && isBefore(dataset.firstPublishedAt, now) ? dataset.firstPublishedAt : undefined;
   const firstRev = dataset.revisions?.find((rev) => rev.id === dataset.startRevisionId);
 
   if (firstPublished && firstRev) {
     // make sure the "first published" log entry appears after the first revision was approved
-    const firstPublishedDate = addSeconds(max([firstRev.approvedAt!, dataset.live!]), 1);
+    const firstPublishedDate = addSeconds(max([firstRev.approvedAt!, dataset.firstPublishedAt!]), 1);
 
     const goLiveEvent = EventLog.create({
       id: `simulated-${uuid()}`,

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -24,6 +24,7 @@ export const getPublishingStatus = (dataset: Dataset, revision: Revision): Publi
   const openPublishTask = openTasks.find((task) => task.action === TaskAction.Publish);
   const openUnpublishTask = openTasks.find((task) => task.action === TaskAction.Unpublish);
   const openArchiveTask = openTasks.find((task) => task.action === TaskAction.Archive);
+  const openUnarchiveTask = openTasks.find((task) => task.action === TaskAction.Unarchive);
 
   if (openPublishTask) {
     if (openPublishTask.status === TaskStatus.Requested) {
@@ -40,6 +41,10 @@ export const getPublishingStatus = (dataset: Dataset, revision: Revision): Publi
 
   if (openArchiveTask) {
     return PublishingStatus.ArchiveRequested;
+  }
+
+  if (openUnarchiveTask) {
+    return PublishingStatus.UnarchiveRequested;
   }
 
   if (datasetStatus === DatasetStatus.New) {

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -13,6 +13,10 @@ export const getDatasetStatus = (dataset: Dataset): DatasetStatus => {
     return DatasetStatus.Archived;
   }
 
+  if (dataset.publishedRevision?.unpublishedAt) {
+    return DatasetStatus.Offline;
+  }
+
   return dataset.firstPublishedAt && isBefore(dataset.firstPublishedAt, new Date())
     ? DatasetStatus.Live
     : DatasetStatus.New;
@@ -48,7 +52,7 @@ export const getPublishingStatus = (dataset: Dataset, revision: Revision): Publi
   }
 
   if (datasetStatus === DatasetStatus.Offline) {
-    return PublishingStatus.Unpublished;
+    return revision.approvedAt ? PublishingStatus.UpdateScheduled : PublishingStatus.Unpublished;
   }
 
   if (datasetStatus === DatasetStatus.New) {

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -9,6 +9,10 @@ import { TaskAction } from '../enums/task-action';
 import { TaskStatus } from '../enums/task-status';
 
 export const getDatasetStatus = (dataset: Dataset): DatasetStatus => {
+  if (dataset.archivedAt && isBefore(dataset.archivedAt, new Date())) {
+    return DatasetStatus.Archived;
+  }
+
   return dataset.firstPublishedAt && isBefore(dataset.firstPublishedAt, new Date())
     ? DatasetStatus.Live
     : DatasetStatus.New;

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -13,6 +13,10 @@ export const getDatasetStatus = (dataset: Dataset): DatasetStatus => {
     return DatasetStatus.Archived;
   }
 
+  if (dataset.unpublishedAt && isBefore(dataset.unpublishedAt, new Date())) {
+    return DatasetStatus.Offline;
+  }
+
   return dataset.firstPublishedAt && isBefore(dataset.firstPublishedAt, new Date())
     ? DatasetStatus.Live
     : DatasetStatus.New;
@@ -45,6 +49,10 @@ export const getPublishingStatus = (dataset: Dataset, revision: Revision): Publi
 
   if (openUnarchiveTask) {
     return PublishingStatus.UnarchiveRequested;
+  }
+
+  if (datasetStatus === DatasetStatus.Offline) {
+    return PublishingStatus.Unpublished;
   }
 
   if (datasetStatus === DatasetStatus.New) {

--- a/src/utils/dataset-status.ts
+++ b/src/utils/dataset-status.ts
@@ -13,10 +13,6 @@ export const getDatasetStatus = (dataset: Dataset): DatasetStatus => {
     return DatasetStatus.Archived;
   }
 
-  if (dataset.unpublishedAt && isBefore(dataset.unpublishedAt, new Date())) {
-    return DatasetStatus.Offline;
-  }
-
   return dataset.firstPublishedAt && isBefore(dataset.firstPublishedAt, new Date())
     ? DatasetStatus.Live
     : DatasetStatus.New;

--- a/test/routes/metadata.test.ts
+++ b/test/routes/metadata.test.ts
@@ -89,7 +89,7 @@ describe('API Endpoints for viewing dataset objects', () => {
             title: 'Test Dataset 1',
             title_alt: 'Test Dataset 1',
             group_name: 'Test Group EN',
-            last_updated: expect.stringContaining(today),
+            last_updated_at: expect.stringContaining(today),
             status: 'new',
             publishing_status: 'incomplete'
           }


### PR DESCRIPTION
Provides the ability to "unpublish" a dataset so that changes can be made.

The "unpublish" action marks the currently published revision with an "unpublished_at" timestamp (new col on revision table), and then create's a new revision which follows the standard update journey.

Once the new revision is approved, it becomes the new published revision as usual, and the "unpublished" revision keeps the "unpublished_at" timestamp so that it can be hidden in future if we allow users to browse previous revisions.

Also adds the ability to archive/unarchive a dataset - this just sets or unsets the `archived_at` timestamp on the dataset.

