### PR TITLE
Rebuild consumer view to use QueryRunner

### DIFF
--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -356,16 +356,18 @@ export const createFrontendView = async (
     };
   }
 
-  const filterTable = filterTableColumnQueryResult
-    .filter((row) => {
-      return row.language === `${lang}-gb`;
-    })
-    .map((row) => {
-      return {
-        fact_table_column: row.fact_table_column,
-        dimension_name: row.dimension_name
-      };
-    });
+  const filterTable = filterTableColumnQueryResult.reduce(
+    (acc: { fact_table_column: string; dimension_name: string }[], row) => {
+      if (row.language === `${lang}-gb`) {
+        acc.push({
+          fact_table_column: row.fact_table_column,
+          dimension_name: row.dimension_name
+        });
+      }
+      return acc;
+    },
+    []
+  );
 
   const tableHeaders = Object.keys(preview[0] as Record<string, never>);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Switched from using a single connection to generate the consumer view to using the query runner to do the heavy lifting.  Hoping this will reduce connection usage within the app.