### PR TITLE
Reduce Excel Row Limit

### DIFF
--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -20,7 +20,7 @@ import { getColumnHeaders } from '../utils/column-headers';
 import { t } from 'i18next';
 import cubeConfig from '../config/cube-view.json';
 
-const EXCEL_ROW_LIMIT = 1048576;
+const EXCEL_ROW_LIMIT = 1048500; // Excel Limit is 1048576 but removed 76 rows
 const CURSOR_ROW_LIMIT = 500;
 
 interface FilterValues {


### PR DESCRIPTION
The Excel Row Limit is 1048576 but the roll over to new sheet results in Excel complaining about unreadable data above this limit.  So reduced the hardcoded limit to prevent unreadable data.