### PR TITLE
Move interfaces from cube builder

### DIFF
--- a/src/enums/note-code.ts
+++ b/src/enums/note-code.ts
@@ -1,0 +1,41 @@
+import { NoteCodeItem } from '../interfaces/note-code-item';
+
+export enum NoteCode {
+  Average = 'a',
+  BreakInSeries = 'b',
+  Confidential = 'c',
+  Estimated = 'e',
+  Forecast = 'f',
+  LowFigure = 'k',
+  LowReliability = 'u',
+  MissingData = 'x',
+  NotApplicable = 'z',
+  NotRecorded = 'w',
+  NotStatisticallySignificant = 'ns',
+  Provisional = 'p',
+  Revised = 'r',
+  StatisticallySignificantL1 = 's',
+  StatisticallySignificantL2 = 'ss',
+  StatisticallySignificantL3 = 'sss',
+  Total = 't'
+}
+
+export const NoteCodes: NoteCodeItem[] = [
+  { code: NoteCode.Average, tag: 'average' },
+  { code: NoteCode.BreakInSeries, tag: 'break_in_series' },
+  { code: NoteCode.Confidential, tag: 'confidential' },
+  { code: NoteCode.Estimated, tag: 'estimated' },
+  { code: NoteCode.Forecast, tag: 'forecast' },
+  { code: NoteCode.LowFigure, tag: 'low_figure' },
+  { code: NoteCode.NotStatisticallySignificant, tag: 'not_statistically_significant' },
+  { code: NoteCode.Provisional, tag: 'provisional' },
+  { code: NoteCode.Revised, tag: 'revised' },
+  { code: NoteCode.StatisticallySignificantL1, tag: 'statistically_significant_at_level_1' },
+  { code: NoteCode.StatisticallySignificantL2, tag: 'statistically_significant_at_level_2' },
+  { code: NoteCode.StatisticallySignificantL3, tag: 'statistically_significant_at_level_3' },
+  { code: NoteCode.Total, tag: 'total' },
+  { code: NoteCode.LowReliability, tag: 'low_reliability' },
+  { code: NoteCode.NotRecorded, tag: 'not_recorded' },
+  { code: NoteCode.MissingData, tag: 'missing_data' },
+  { code: NoteCode.NotApplicable, tag: 'not_applicable' }
+];

--- a/src/interfaces/cube-view-builder.ts
+++ b/src/interfaces/cube-view-builder.ts
@@ -1,0 +1,8 @@
+import { CubeViewConfig } from './cube-view-config';
+import { Locale } from '../enums/locale';
+
+export interface CubeViewBuilder {
+  name: string;
+  config: CubeViewConfig;
+  columns: Map<Locale, Set<string>>;
+}

--- a/src/interfaces/fact-table-info.ts
+++ b/src/interfaces/fact-table-info.ts
@@ -1,0 +1,10 @@
+import { FactTableColumn } from '../entities/dataset/fact-table-column';
+
+export interface FactTableInfo {
+  measureColumn?: FactTableColumn;
+  notesCodeColumn?: FactTableColumn;
+  dataValuesColumn?: FactTableColumn;
+  factTableDef: string[];
+  factIdentifiers: FactTableColumn[];
+  compositeKey: string[];
+}

--- a/src/interfaces/measure-format.ts
+++ b/src/interfaces/measure-format.ts
@@ -1,0 +1,4 @@
+export interface MeasureFormat {
+  name: string;
+  method: string;
+}

--- a/src/interfaces/note-code-item.ts
+++ b/src/interfaces/note-code-item.ts
@@ -1,0 +1,4 @@
+export interface NoteCodeItem {
+  code: string;
+  tag: string;
+}

--- a/src/interfaces/unique-measure-details.ts
+++ b/src/interfaces/unique-measure-details.ts
@@ -1,0 +1,6 @@
+export interface UniqueMeasureDetails {
+  reference: string;
+  format: string;
+  sort_order: string | null;
+  decimals: number | null;
+}

--- a/src/services/fact-table-validator.ts
+++ b/src/services/fact-table-validator.ts
@@ -6,12 +6,13 @@ import { Dataset } from '../entities/dataset/dataset';
 import { FactTableColumn } from '../entities/dataset/fact-table-column';
 import { FactTableColumnType } from '../enums/fact-table-column-type';
 import { logger } from '../utils/logger';
-import { FACT_TABLE_NAME, NoteCodes } from './cube-handler';
+import { FACT_TABLE_NAME } from './cube-handler';
 import { FactTableValidationException } from '../exceptions/fact-table-validation-exception';
 import { FactTableValidationExceptionType } from '../enums/fact-table-validation-exception-type';
 import { SourceAssignmentDTO } from '../dtos/source-assignment-dto';
 import { tableDataToViewTable } from '../utils/table-data-to-view-table';
 import { dbManager } from '../db/database-manager';
+import { NoteCodes } from '../enums/note-code';
 
 interface FactTableDefinition {
   factTableColumn: FactTableColumn;


### PR DESCRIPTION
First stage of implemetning the new cube builder is to move the existing interfaces and enums from the cube builder in to their own files. This should cut down some of the noise of the next few PRs.