### PR TITLE
Expand whats in the build log for bulk builds

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -684,7 +684,7 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
     buildScript.all_builds.push(buildId);
     buildScript.current_build = buildId;
     buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-    void buildLogEntry.save();
+    await buildLogEntry.save();
     try {
       await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
     } catch (err) {


### PR DESCRIPTION
Using the build script to log the current build, successful builds as well as failed builds to track what the job is doing rather than the current binary has it finished yet situation we have now.