### PR TITLE
Fix bad error handling in materialized view creation

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -684,6 +684,7 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
     buildScript.all_builds.push(buildId);
     buildScript.current_build = buildId;
     buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    buildLogEntry.status = CubeBuildStatus.Building;
     await buildLogEntry.save();
     try {
       await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
@@ -716,7 +717,7 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
     if (build.status === CubeBuildStatus.Failed) {
       logger.warn(`[${buildLogEntry}]: Cube for revision ${rev.id} has been failed to rebuild.`);
       buildScript.failed_to_build.push(buildId);
-      buildScript.failed_builds = buildScript.failed_builds++;
+      buildScript.failed_builds++;
       failedBuilds.push({
         buildId,
         revisionId: rev.id,
@@ -728,7 +729,7 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
       logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
     }
     buildScript.current_build = null;
-    buildScript.total_builds = buildScript.total_builds++;
+    buildScript.total_builds++;
     buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
     await buildLogEntry.save();
   }


### PR DESCRIPTION
Made the mistake of assuming that objects would be encoded as strings when passed into pgformat but because postgres has native JSON support it pases in raw JSON.  I think this was causing issues with the SQL and failure to correctly end the transaction.

So wrapped the object in JSON.stringify and wrapped the error queries in their own START and END TRASACTION

Also switch away from `END TRANSACTION` to postgres's preferred `COMMIT` syntax and added `ROLLBACK` whenever an error is encountered.  This should stop transactions being left open due to bad SQL.