### PR TITLE
Fix missing semis on numeric and text type dimensions

### DIFF
--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1750,7 +1750,7 @@ function setupNumericDimension(
       pgformat(
         `INSERT INTO %I.filter_table
          SELECT DISTINCT CAST(%I AS VARCHAR), %L, %L, %L, CAST (%I AS VARCHAR), NULL
-         FROM %I.%I ORDER BY %I`,
+         FROM %I.%I ORDER BY %I;`,
         buildId,
         dimension.factTableColumn,
         locale.toLowerCase(),
@@ -1819,7 +1819,7 @@ function setupTextDimension(
       pgformat(
         `INSERT INTO %I.filter_table
          SELECT DISTINCT CAST(%I AS VARCHAR), %L, %L, %L, CAST (%I AS VARCHAR), NULL
-         FROM %I.%I`,
+         FROM %I.%I;`,
         buildId,
         dimension.factTableColumn,
         locale.toLowerCase(),


### PR DESCRIPTION
There was a pair of missing semicolons on the insert statements for the filter tables when dealing with plain text and numeric dimensions.