### PR TITLE
SW-1071: update API docs for language query param

### DIFF
--- a/src/routes/consumer/v1/openapi.json
+++ b/src/routes/consumer/v1/openapi.json
@@ -256,13 +256,15 @@
   "components": {
     "parameters": {
       "language": {
-        "name": "accept-language",
-        "in": "header",
-        "description": "Language to use for the response, either \"cy-gb\" for Welsh or \"en-gb\" for English",
+        "name": "lang",
+        "in": "query",
+        "description": "Language to use for the response, \"cy\" or \"cy-gb\" for Welsh and \"en\" or \"en-gb\" for English",
         "required": false,
         "schema": {
           "type": "string",
           "enum": [
+            "cy",
+            "en",
             "cy-gb",
             "en-gb"
           ],

--- a/src/routes/consumer/v1/schema.ts
+++ b/src/routes/consumer/v1/schema.ts
@@ -14,11 +14,11 @@ export const schema = {
   components: {
     parameters: {
       language: {
-        name: 'accept-language',
-        in: 'header',
-        description: 'Language to use for the response, either "cy-gb" for Welsh or "en-gb" for English',
+        name: 'lang',
+        in: 'query',
+        description: 'Language to use for the response, "cy" or "cy-gb" for Welsh and "en" or "en-gb" for English',
         required: false,
-        schema: { type: 'string', enum: ['cy-gb', 'en-gb'], default: 'en-gb' }
+        schema: { type: 'string', enum: ['cy', 'en', 'cy-gb', 'en-gb'], default: 'en-gb' }
       },
       dataset_id: {
         name: 'dataset_id',


### PR DESCRIPTION
When front door cache was enabled, our accept-language header started being dropped and we switched to a query param `lang` for language selection. This change got missed in the API docs.