### PR TITLE
SW-1083: fix typo when no topic sort order selected

### DIFF
--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -193,7 +193,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     const resultQuery = qb.offset(offset).limit(limit);
 
     if (!sortBy || sortBy.length === 0) {
-      sortBy = [{ columnName: 'd.first_published_at', direction: 'DESC' }];
+      sortBy = [{ columnName: 'first_published_at', direction: 'DESC' }];
     }
 
     const sortOpts: Record<string, string> = {


### PR DESCRIPTION
The column name for the default applied sort needs to match a key of `sortOpts` on line 199, otherwise we end up with an undefined order by clause in the SQL.