### PR TITLE
SW-1086: fix datasets showing up in topics that have been removed in subsequent updates

### DIFF
--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -179,7 +179,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
             .innerJoin('rev.revisionTopics', 'rt')
             .andWhere('rev.publish_at < NOW()')
             .andWhere('rev.approved_at < NOW()')
-            .groupBy('rev.id, rm.title')
+            .groupBy('rev.dataset_id, rev.id, rev.publish_at, rm.title')
             .orderBy('rev.dataset_id')
             .addOrderBy('rev.publish_at', 'DESC');
         },


### PR DESCRIPTION
Previously we were filtering on topic before checking it was the latest revision, which meant that the query could return results where a topic was assigned to a previous revision, but then removed in a later update.

This changes the order of the filtering, so that the latest revision for each dataset is fetched first, and then we re-filter the sub-query result for matching topic id.