### PR TITLE
Add coverage start and end dates to the revision

### DIFF
--- a/src/dtos/revision-dto.ts
+++ b/src/dtos/revision-dto.ts
@@ -33,6 +33,8 @@ export class RevisionDTO {
   related_links?: RelatedLinkDTO[];
   providers?: RevisionProviderDTO[];
   topics?: TopicDTO[];
+  coverage_start_date?: Date | null;
+  coverage_end_date?: Date | null;
 
   tasks?: RevisionTask;
 
@@ -51,6 +53,8 @@ export class RevisionDTO {
     revDto.approved_at = revision.approvedAt?.toISOString();
     revDto.approved_by = revision.approvedBy?.name;
     revDto.created_by = revision.createdBy?.name;
+    revDto.coverage_start_date = revision.startDate;
+    revDto.coverage_end_date = revision.endDate;
 
     if (revision.dataTable) {
       revDto.data_table = DataTableDto.fromDataTable(revision.dataTable);


### PR DESCRIPTION
We have some logic on the dataset dto to pull these from the latest published revision but this logic can only trigger if there's a published revision in the requested object.

Adding it to the revision means it'll be there when the revisions metadata is pulled down.  It also means we can check to make sure the correct dates are being populated.