### PR TITLE
SW-1099 bug with replacing measures in cube builder

### DIFF
--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1973,7 +1973,7 @@ function setupMeasuresAndDataValues(
   orderByStatements: string[]
 ): TransactionBlock {
   let createMeasureTable = true;
-  if (revision.tasks && revision.tasks.measure) {
+  if (revision.tasks && revision.tasks.measure && !revision.tasks.measure.lookupTableUpdated) {
     createMeasureTable = false;
   }
 


### PR DESCRIPTION
There was a bug in the measure handling in the cube builder.  When you replace the measure table it creates a revision task or updates the existing revision task as lookup replaced.  The cube builder was ignoring measure tables where the there was task and not checking if the task was completed.

Fixed the code by only ignoring the measure if the lookup table hasn't been replaced.