### PR TITLE
Checking to see if the trace message is causing a 500

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -156,7 +156,7 @@ export const generateFilterId = async (req: Request, res: Response, next: NextFu
   if (!dataset.publishedRevisionId) return next(new NotFoundException('errors.no_published_revision'));
 
   try {
-    logger.trace(`req body = ${JSON.stringify(req.body)}`);
+    // logger.trace(`req body = ${JSON.stringify(req.body)}`);
     const dataOptions = await dtoValidator(DataOptionsDTO, req.body);
     const queryStore = await QueryStoreRepository.getByRequest(dataset.id, dataset.publishedRevisionId, dataOptions);
     res.json({ filterId: queryStore.id });


### PR DESCRIPTION
When hitting this route with a large selection, the app is throwing a 500 in that block.

Thinking it might be the JSON.stringify()... turning it off to check.