### PR TITLE
undo bad copilot suggestion

### DIFF
--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -239,7 +239,7 @@ export function createBaseQuery(
 
   return pgformat(
     'SELECT %s FROM %I.%I %s',
-    columns.map((column) => pgformat('%I', column)).join(', '),
+    columns.join(', '),
     revisionId,
     view,
     filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : ''


### PR DESCRIPTION
Copilot suggested a fix to prevent sql injection but it looks like it's getting double-escaped and breaks the query. Reverting to original.