### PR TITLE
official arm64 supported image for clamav

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,7 @@ services:
       - "10002:10002"
 
   clamav:
-    image: clamav/clamav:latest
-    platform: linux/amd64 # no arm64 image currently available, force amd64
+    image: clamav/clamav-debian:latest
     ports:
       - '3310:3310'
     environment:


### PR DESCRIPTION
Not a huge thing as this is only used in dev, but I found an official ClamAV image that supports both amd64 and arm64. It just means that we can run a native version on Apple silicon instead of emulating the amd64 image using rosetta.

It uses Debian instead of Alpine as the base, but otherwise should be identical.