### PR TITLE
SW-1139 Fix for multi year period endings not working

### DIFF
--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -522,10 +522,9 @@ function periodDateTableCreator(dateFormat: DateExtractor, dataColumn: string[])
 
 function dateTableCreator(dateFormat: DateExtractor, dataColumn: string[]): DateReferenceDataItem[] {
   const testVal = dataColumn.at(0);
-  let endingCheck = false;
-  if (testVal?.toString().toUpperCase().substring(1, 2).includes('E')) endingCheck = true;
-  if (testVal?.toString().toUpperCase().substring(1, 2).includes('Y')) endingCheck = true;
-  logger.debug(`Ending check: ${endingCheck} based on ${testVal?.toString().toUpperCase().substring(1, 2)}`);
+  const secondChar = testVal?.toString().toUpperCase().substring(1, 2) ?? '';
+  const endingCheck = secondChar.includes('E') || secondChar.includes('Y');
+  logger.debug(`Ending check: ${endingCheck} based on ${secondChar}`);
   if (endingCheck) {
     logger.debug('Period ending creation running...');
     return periodDateTableCreator(dateFormat, dataColumn);


### PR DESCRIPTION
Multiyear periods (e.g. 2Y, 3Y, 5Y, XY) weren't being handle properly as we were only checking for codes which contained `E` but the multi year periods only contain a `Y` so the code was going down the wrong path and erroring out.

This fixes this issue by checking for both types before going down the specific date table creator route.