### PR TITLE
Fix pivot table column ordering issues

### DIFF
--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -51,7 +51,22 @@ export async function getSortedPivotColumns(
   try {
     const dataset = await DatasetRepository.getById(queryStore.datasetId, { factTable: true, dimensions: true });
     const filterTable = await getFilterTable(queryStore.revisionId);
-    const factCol = resolveDimensionToFactTableColumn(pageOptions.x, filterTable);
+
+    // pageOptions.x may be a translated dimension name (e.g. "Date") or a raw
+    // fact table column name (e.g. "DateRef"). Try resolving as a dimension name
+    // first, then fall back to checking fact_table_column directly.
+    let factCol: string;
+    try {
+      factCol = resolveDimensionToFactTableColumn(pageOptions.x, filterTable);
+    } catch {
+      const byFactCol = filterTable.find(
+        (f) => f.fact_table_column.toLowerCase() === pageOptions.x!.toString().toLowerCase()
+      );
+      if (!byFactCol) {
+        return rawColumnOrder;
+      }
+      factCol = byFactCol.fact_table_column;
+    }
     const dimension = dataset.dimensions?.find((d) => d.factTableColumn === factCol);
 
     if (!dimension || !LookupTableTypes.includes(dimension.type)) {
@@ -65,7 +80,7 @@ export async function getSortedPivotColumns(
     const cubeDataSource = dbManager.getCubeDataSource();
     const sortRows: { description: string }[] = await cubeDataSource.query(
       pgformat(
-        `SELECT DISTINCT description FROM %I.%I WHERE language = %L ORDER BY sort_order %s, description`,
+        `SELECT description FROM (SELECT DISTINCT description, sort_order FROM %I.%I WHERE language = %L) sub ORDER BY sort_order %s, description`,
         queryStore.revisionId,
         dimTable,
         lang.toLowerCase(),

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -30,7 +30,7 @@ const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76
  * sort information is unavailable (e.g. numeric/text dimensions without
  * a lookup table, or multi-dimensional pivots).
  */
-async function getSortedPivotColumns(
+export async function getSortedPivotColumns(
   rawColumnOrder: string[],
   pageOptions: PageOptions,
   queryStore: QueryStore,
@@ -105,8 +105,9 @@ async function pivotToJson(res: Response, pivot: DuckDBResult, columnOrder: stri
       } else {
         res.write(',\n');
       }
-      const ordered = Object.fromEntries(columnOrder.map((col, i) => [col, row[i]]));
-      res.write(JSON.stringify(ordered));
+      const jsonRow =
+        '{' + columnOrder.map((col, i) => `${JSON.stringify(col)}:${JSON.stringify(row[i])}`).join(',') + '}';
+      res.write(jsonRow);
     }
   }
   res.write(']');

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -5,7 +5,7 @@ import { QueryStore } from '../entities/query-store';
 import { PageOptions } from '../interfaces/page-options';
 import { acquireDuckDB } from './duckdb';
 import { t } from '../middleware/translation';
-import { DuckDBResult } from '@duckdb/node-api';
+import { DuckDBResult, DuckDBValue } from '@duckdb/node-api';
 import { logger } from '../utils/logger';
 import { OutputFormats } from '../enums/output-formats';
 import { format as csvFormat } from '@fast-csv/format';
@@ -19,26 +19,94 @@ import { FactTableToDimensionName } from '../interfaces/fact-table-column-to-dim
 import { BadRequestException } from '../exceptions/bad-request.exception';
 import { FilterRow } from '../interfaces/filter-row';
 import { UnknownException } from '../exceptions/unknown.exception';
+import { makeCubeSafeString } from './cube-builder';
+import { DimensionType, LookupTableTypes } from '../enums/dimension-type';
 
 const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76 rows because ?
 
-async function pivotToJson(res: Response, pivot: DuckDBResult): Promise<void> {
+/**
+ * Query the lookup table for the x dimension to get the correct sort order
+ * for pivot column headers. Falls back to the original column order when
+ * sort information is unavailable (e.g. numeric/text dimensions without
+ * a lookup table, or multi-dimensional pivots).
+ */
+async function getSortedPivotColumns(
+  rawColumnOrder: string[],
+  pageOptions: PageOptions,
+  queryStore: QueryStore,
+  lang: string
+): Promise<string[]> {
+  if (!pageOptions.x || Array.isArray(pageOptions.x)) {
+    return rawColumnOrder;
+  }
+
+  const yCount = Array.isArray(pageOptions.y) ? pageOptions.y.length : 1;
+  const yColumns = rawColumnOrder.slice(0, yCount);
+  const xValueColumns = rawColumnOrder.slice(yCount);
+
+  if (xValueColumns.length <= 1) {
+    return rawColumnOrder;
+  }
+
+  try {
+    const dataset = await DatasetRepository.getById(queryStore.datasetId, { factTable: true, dimensions: true });
+    const filterTable = await getFilterTable(queryStore.revisionId);
+    const factCol = resolveDimensionToFactTableColumn(pageOptions.x, filterTable);
+    const dimension = dataset.dimensions?.find((d) => d.factTableColumn === factCol);
+
+    if (!dimension || !LookupTableTypes.includes(dimension.type)) {
+      return rawColumnOrder;
+    }
+
+    const dimTable = `${makeCubeSafeString(factCol)}_lookup`;
+    const isDateDimension = dimension.type === DimensionType.DatePeriod || dimension.type === DimensionType.Date;
+    const sortDirection = isDateDimension ? 'DESC' : 'ASC';
+
+    const cubeDataSource = dbManager.getCubeDataSource();
+    const sortRows: { description: string }[] = await cubeDataSource.query(
+      pgformat(
+        `SELECT DISTINCT description FROM %I.%I WHERE language = %L ORDER BY sort_order %s, description`,
+        queryStore.revisionId,
+        dimTable,
+        lang.toLowerCase(),
+        sortDirection
+      )
+    );
+
+    if (sortRows.length === 0) {
+      return rawColumnOrder;
+    }
+
+    const sortPosition = new Map<string, number>();
+    sortRows.forEach((row, idx) => sortPosition.set(row.description, idx));
+
+    const sorted = [...xValueColumns].sort((a, b) => {
+      const posA = sortPosition.get(a) ?? Number.MAX_SAFE_INTEGER;
+      const posB = sortPosition.get(b) ?? Number.MAX_SAFE_INTEGER;
+      return posA - posB;
+    });
+
+    return [...yColumns, ...sorted];
+  } catch (err) {
+    logger.warn(err, 'Failed to determine pivot column sort order, using default order');
+    return rawColumnOrder;
+  }
+}
+
+async function pivotToJson(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
   res.setHeader('content-type', 'application/json');
   res.flushHeaders();
   res.write('{ "pivot": [');
-  let rows = await pivot.getRowObjects();
-  while (rows.length > 0) {
-    const lastRowIndex = rows.length - 1;
-    rows.forEach((row: unknown, index: number) => {
-      if (index < lastRowIndex) {
-        res.write(`${JSON.stringify(row)},\n`);
+  let first = true;
+  for await (const rows of pivot.yieldRows()) {
+    for (const row of rows) {
+      if (first) {
+        first = false;
       } else {
-        res.write(`${JSON.stringify(row)}`);
+        res.write(',\n');
       }
-    });
-    rows = await pivot.getRowObjects();
-    if (rows.length > 0) {
-      res.write(',\n');
+      const ordered = Object.fromEntries(columnOrder.map((col, i) => [col, row[i]]));
+      res.write(JSON.stringify(ordered));
     }
   }
   res.write(']');
@@ -50,6 +118,7 @@ async function pivotToFrontend(
   res: Response,
   lang: string,
   pivot: DuckDBResult,
+  columnOrder: string[],
   queryStore: QueryStore,
   pageOptions: PageOptions
 ): Promise<void> {
@@ -92,28 +161,22 @@ async function pivotToFrontend(
   res.write(`"pivot": ${JSON.stringify(queryStore.requestObject.pivot || {})},`);
   res.write(`"note_codes": ${JSON.stringify(note_codes || [])},`);
 
-  let rows = await pivot.getRowObjects();
-  if (rows.length > 0) {
-    const tableHeaders = Object.keys(rows[0]);
-    const headers = getColumnHeaders(dataset, tableHeaders, filters);
-    res.write(`"headers": ${JSON.stringify(headers)},`);
-  }
+  const headers = getColumnHeaders(dataset, columnOrder, filters);
+  res.write(`"headers": ${JSON.stringify(headers)},`);
 
   res.write('"data": [');
   let firstRow = true;
   let rowCount = 0;
-  while (rows.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rows.forEach((row: any) => {
+  for await (const rows of pivot.yieldRows()) {
+    for (const row of rows) {
       if (firstRow) {
         firstRow = false;
       } else {
         res.write(',\n');
       }
-      res.write(JSON.stringify(Object.values(row)));
+      res.write(JSON.stringify(row));
       rowCount++;
-    });
-    rows = await pivot.getRowObjects();
+    }
   }
   res.write('],');
   const totalPages = queryStore.totalPivotLines ? Math.max(1, Math.ceil(queryStore.totalPivotLines / pageSize)) : 0;
@@ -131,29 +194,27 @@ async function pivotToFrontend(
   res.end();
 }
 
-async function pivotToCsv(res: Response, pivot: DuckDBResult): Promise<void> {
+async function pivotToCsv(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
   res.writeHead(200, {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-Type': 'text/csv',
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-disposition': `attachment;filename=pivot-${Date.now()}.csv`
   });
-  const stream = csvFormat({ delimiter: ',', headers: true });
+  const stream = csvFormat({ delimiter: ',', headers: columnOrder });
   stream.pipe(res);
 
-  let rows = await pivot.getRowObjects();
-  while (rows.length > 0) {
-    rows.map((row: unknown) => {
+  for await (const rows of pivot.yieldRows()) {
+    for (const row of rows) {
       stream.write(row);
-    });
-    rows = await pivot.getRowObjects();
+    }
   }
   res.write('\n');
   res.end();
   stream.end();
 }
 
-async function pivotToExcel(res: Response, pivot: DuckDBResult): Promise<void> {
+async function pivotToExcel(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
   res.writeHead(200, {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -162,7 +223,6 @@ async function pivotToExcel(res: Response, pivot: DuckDBResult): Promise<void> {
   });
   res.flushHeaders();
   const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
-    filename: `${pivot} ${Date.now()}.xlsx`,
     useStyles: true,
     useSharedStrings: true,
     stream: res
@@ -171,16 +231,15 @@ async function pivotToExcel(res: Response, pivot: DuckDBResult): Promise<void> {
   let totalRows = 0;
   let worksheet = workbook.addWorksheet(`Sheet-${sheetCount}`);
 
-  let rows = await pivot.getRowObjects();
-  worksheet.addRow(Object.keys(rows[0]));
-  while (rows.length > 0) {
+  worksheet.addRow(columnOrder);
+  for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
       if (row === null) break;
-      const data = Object.values(row).map((val) => {
+      const data = row.map((val: DuckDBValue) => {
         if (!val) return null;
         return isNaN(Number(val)) ? val : Number(val);
       });
-      worksheet.addRow(Object.values(data)).commit();
+      worksheet.addRow(data).commit();
     }
     totalRows += rows.length;
     if (totalRows > EXCEL_ROW_LIMIT) {
@@ -189,13 +248,12 @@ async function pivotToExcel(res: Response, pivot: DuckDBResult): Promise<void> {
       totalRows = 0;
       worksheet = workbook.addWorksheet(`Sheet-${sheetCount}`);
     }
-    rows = await pivot.getRowObjects();
   }
   worksheet.commit();
   await workbook.commit();
 }
 
-async function pivotToHtml(res: Response, pivot: DuckDBResult): Promise<void> {
+async function pivotToHtml(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
   res.setHeader('content-type', 'text/html');
   res.flushHeaders();
   res.write(
@@ -210,20 +268,19 @@ async function pivotToHtml(res: Response, pivot: DuckDBResult): Promise<void> {
       '<thead><tr>'
   );
 
-  let rows = await pivot.getRowObjects();
-  if (rows.length === 0) {
+  if (columnOrder.length === 0) {
     res.write('</tr>\n</thead>\n<tbody>\n</tbody>\n' + '</table>\n' + '</body>\n' + '</html>\n');
     res.end();
     return;
   }
-  Object.keys(rows[0]).forEach((key) => {
+  columnOrder.forEach((key) => {
     res.write(`<th>${key}</th>`);
   });
   res.write('</tr></thead><tbody>');
-  while (rows.length > 0) {
+  for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
       res.write('<tr>');
-      Object.values(row).forEach((value, idx) => {
+      row.forEach((value: DuckDBValue, idx: number) => {
         if (idx === 0) {
           res.write(`<th>${value === null ? '' : value}</th>`);
         } else {
@@ -232,7 +289,6 @@ async function pivotToHtml(res: Response, pivot: DuckDBResult): Promise<void> {
       });
       res.write('</tr>');
     }
-    rows = await pivot.getRowObjects();
   }
   res.write('</tbody>\n' + '</table>\n' + '</body>\n' + '</html>\n');
   res.end();
@@ -249,21 +305,22 @@ export async function createPivotOutputUsingDuckDB(
   try {
     await duckdb.run('CALL pg_clear_cache();');
     const pivot = await duckdb.stream(pivotQuery);
+    const columnOrder = await getSortedPivotColumns(pivot.columnNames(), pageOptions, queryStore, lang);
     switch (pageOptions.format) {
       case OutputFormats.Json:
-        await pivotToJson(res, pivot);
+        await pivotToJson(res, pivot, columnOrder);
         break;
       case OutputFormats.Csv:
-        await pivotToCsv(res, pivot);
+        await pivotToCsv(res, pivot, columnOrder);
         break;
       case OutputFormats.Excel:
-        await pivotToExcel(res, pivot);
+        await pivotToExcel(res, pivot, columnOrder);
         break;
       case OutputFormats.Html:
-        await pivotToHtml(res, pivot);
+        await pivotToHtml(res, pivot, columnOrder);
         break;
       case OutputFormats.Frontend:
-        await pivotToFrontend(res, lang, pivot, queryStore, pageOptions);
+        await pivotToFrontend(res, lang, pivot, columnOrder, queryStore, pageOptions);
         break;
     }
   } catch (err) {

--- a/test/services/pivots.test.ts
+++ b/test/services/pivots.test.ts
@@ -1,0 +1,634 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { PassThrough } from 'node:stream';
+import { Response } from 'express';
+
+// Mock logger before other imports
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    trace: jest.fn()
+  }
+}));
+
+// Mock DuckDB
+const mockDuckdbRun = jest.fn();
+const mockDuckdbStream = jest.fn();
+const mockReleaseDuckDB = jest.fn();
+jest.mock('../../src/services/duckdb', () => ({
+  acquireDuckDB: jest.fn().mockImplementation(async () => ({
+    duckdb: { run: mockDuckdbRun, stream: mockDuckdbStream },
+    releaseDuckDB: mockReleaseDuckDB
+  }))
+}));
+
+// Mock database manager
+const mockCubeQuery = jest.fn();
+const mockQueryRunnerQuery = jest.fn();
+const mockQueryRunnerRelease = jest.fn();
+jest.mock('../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: () => ({
+      query: mockCubeQuery,
+      createQueryRunner: () => ({
+        query: mockQueryRunnerQuery,
+        release: mockQueryRunnerRelease
+      })
+    })
+  }
+}));
+
+// Mock translation
+const mockT = jest.fn().mockImplementation((key: string) => {
+  if (key === 'column_headers.data_values') return 'Data values';
+  return key;
+});
+jest.mock('../../src/middleware/translation', () => ({
+  t: (...args: any[]) => mockT(...args)
+}));
+
+// Mock DatasetRepository
+const mockGetById = jest.fn();
+jest.mock('../../src/repositories/dataset', () => ({
+  DatasetRepository: {
+    getById: (...args: unknown[]) => mockGetById(...args)
+  }
+}));
+
+// Mock consumer utils
+const mockGetFilterTable = jest.fn();
+const mockResolveDimensionToFactTableColumn = jest.fn();
+const mockResolveFactColumnToDimension = jest.fn();
+jest.mock('../../src/utils/consumer', () => ({
+  getFilterTable: (...args: unknown[]) => mockGetFilterTable(...args),
+  resolveDimensionToFactTableColumn: (...args: unknown[]) => mockResolveDimensionToFactTableColumn(...args),
+  resolveFactColumnToDimension: (...args: unknown[]) => mockResolveFactColumnToDimension(...args)
+}));
+
+// Mock column headers
+jest.mock('../../src/utils/column-headers', () => ({
+  getColumnHeaders: jest.fn().mockReturnValue([{ index: 0, name: 'Col1', source_type: 'dimension' }])
+}));
+
+// Mock ConsumerDatasetDTO
+jest.mock('../../src/dtos/consumer-dataset-dto', () => ({
+  ConsumerDatasetDTO: {
+    fromDataset: jest.fn().mockReturnValue({ id: 'dataset-id', title: 'Test Dataset' })
+  }
+}));
+
+// Mock cube-builder
+jest.mock('../../src/services/cube-builder', () => ({
+  makeCubeSafeString: jest.fn((str: string) =>
+    str
+      .toLowerCase()
+      .replace(/[ ]/g, '_')
+      .replace(/[^a-zA-Z_]/g, '')
+  )
+}));
+
+import { DuckDBValue } from '@duckdb/node-api';
+import { QueryStore } from '../../src/entities/query-store';
+import { PageOptions } from '../../src/interfaces/page-options';
+import { Locale } from '../../src/enums/locale';
+import { OutputFormats } from '../../src/enums/output-formats';
+import { DimensionType } from '../../src/enums/dimension-type';
+import { BadRequestException } from '../../src/exceptions/bad-request.exception';
+import {
+  langToLocale,
+  createPivotQuery,
+  createPivotOutputUsingDuckDB,
+  getSortedPivotColumns
+} from '../../src/services/pivots';
+
+// Helper to create a mock QueryStore
+function createMockQueryStore(overrides: Partial<QueryStore> = {}): QueryStore {
+  return {
+    id: 'test-query-store-id',
+    hash: 'test-hash',
+    datasetId: 'test-dataset-id',
+    revisionId: 'test-revision-id',
+    requestObject: { filters: [], pivot: {} },
+    query: { en: 'SELECT * FROM "test-revision-id"."view"', cy: 'SELECT * FROM "test-revision-id"."view"' },
+    totalLines: 100,
+    totalPivotLines: 50,
+    columnMapping: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides
+  } as QueryStore;
+}
+
+// Helper to create a mock DuckDBResult with yieldRows() and columnNames()
+function createMockDuckDBResult(
+  columns: string[],
+  rows: DuckDBValue[][]
+): {
+  columnNames: () => string[];
+  yieldRows: () => AsyncIterableIterator<DuckDBValue[][]>;
+} {
+  return {
+    columnNames: () => columns,
+    async *yieldRows() {
+      if (rows.length > 0) {
+        yield rows;
+      }
+    }
+  };
+}
+
+// Helper to create a mock Response that captures written data
+function createMockStreamResponse(): Response & { writtenData: string[] } {
+  const writtenData: string[] = [];
+  const stream = new PassThrough();
+
+  const originalWrite = stream.write.bind(stream);
+  stream.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
+    if (chunk) {
+      writtenData.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    }
+    if (typeof encodingOrCallback === 'function') {
+      return originalWrite(chunk, encodingOrCallback);
+    }
+    return originalWrite(chunk, encodingOrCallback, callback);
+  }) as typeof stream.write;
+
+  const res = stream as unknown as Response & { writtenData: string[] };
+  res.writtenData = writtenData;
+  res.setHeader = jest.fn().mockReturnThis();
+  res.writeHead = jest.fn().mockReturnThis();
+  res.flushHeaders = jest.fn();
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn();
+  (res as any).headersSent = false;
+
+  return res;
+}
+
+function defaultPageOptions(overrides: Partial<PageOptions> = {}): PageOptions {
+  return {
+    format: OutputFormats.Json,
+    pageNumber: 1,
+    pageSize: 100,
+    sort: [],
+    locale: Locale.EnglishGb,
+    x: 'Period',
+    y: 'Area',
+    ...overrides
+  };
+}
+
+describe('pivots service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryRunnerRelease.mockResolvedValue(undefined);
+  });
+
+  describe('langToLocale', () => {
+    it('returns en-GB for "en"', () => {
+      expect(langToLocale('en')).toBe('en-GB');
+    });
+
+    it('returns cy-GB for "cy"', () => {
+      expect(langToLocale('cy')).toBe('cy-GB');
+    });
+
+    it('returns en-GB for empty string', () => {
+      expect(langToLocale('')).toBe('en-GB');
+    });
+
+    it('returns en-GB for unknown language', () => {
+      expect(langToLocale('fr')).toBe('en-GB');
+    });
+
+    it('truncates 5-char locale to 2-char code', () => {
+      expect(langToLocale('en-GB')).toBe('en-GB');
+      expect(langToLocale('cy-GB')).toBe('cy-GB');
+    });
+  });
+
+  describe('getSortedPivotColumns', () => {
+    const queryStore = createMockQueryStore();
+
+    beforeEach(() => {
+      mockGetFilterTable.mockResolvedValue([
+        { fact_table_column: 'period_col', dimension_name: 'Period', language: 'en' }
+      ]);
+      mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+      mockGetById.mockResolvedValue({
+        factTable: [{ columnName: 'period_col' }],
+        dimensions: [{ factTableColumn: 'period_col', type: DimensionType.DatePeriod }]
+      });
+    });
+
+    it('returns original order when x is an array (multi-dimensional pivot)', async () => {
+      const columns = ['Area', '2020', '2021', '2022'];
+      const pageOptions = defaultPageOptions({ x: ['Period', 'Measure'] });
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+
+    it('returns original order when x is undefined', async () => {
+      const columns = ['Area', '2020', '2021'];
+      const pageOptions = defaultPageOptions({ x: undefined });
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+
+    it('returns original order when there is only one x-value column', async () => {
+      const columns = ['Area', '2020'];
+      const pageOptions = defaultPageOptions();
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+
+    it('sorts date dimension columns in DESC order from lookup table', async () => {
+      const columns = ['Area', '2020', '2022', '2021'];
+      const pageOptions = defaultPageOptions();
+
+      mockCubeQuery.mockResolvedValue([{ description: '2022' }, { description: '2021' }, { description: '2020' }]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(['Area', '2022', '2021', '2020']);
+    });
+
+    it('sorts non-date dimension columns in ASC order from lookup table', async () => {
+      const columns = ['Period', 'Zebra', 'Aardvark', 'Mango'];
+      const pageOptions = defaultPageOptions({ x: 'Fruit' });
+
+      mockResolveDimensionToFactTableColumn.mockReturnValue('fruit_col');
+      mockGetById.mockResolvedValue({
+        factTable: [{ columnName: 'fruit_col' }],
+        dimensions: [{ factTableColumn: 'fruit_col', type: DimensionType.LookupTable }]
+      });
+      mockCubeQuery.mockResolvedValue([
+        { description: 'Aardvark' },
+        { description: 'Mango' },
+        { description: 'Zebra' }
+      ]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(['Period', 'Aardvark', 'Mango', 'Zebra']);
+    });
+
+    it('preserves multiple y columns at the start', async () => {
+      const columns = ['Area', 'Measure', '2022', '2020', '2021'];
+      const pageOptions = defaultPageOptions({ y: ['Area', 'Measure'] });
+
+      mockCubeQuery.mockResolvedValue([{ description: '2022' }, { description: '2021' }, { description: '2020' }]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(['Area', 'Measure', '2022', '2021', '2020']);
+    });
+
+    it('returns original order when dimension has no lookup table', async () => {
+      const columns = ['Area', 'B', 'A', 'C'];
+      const pageOptions = defaultPageOptions({ x: 'Value' });
+
+      mockResolveDimensionToFactTableColumn.mockReturnValue('value_col');
+      mockGetById.mockResolvedValue({
+        factTable: [{ columnName: 'value_col' }],
+        dimensions: [{ factTableColumn: 'value_col', type: DimensionType.Numeric }]
+      });
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+      expect(mockCubeQuery).not.toHaveBeenCalled();
+    });
+
+    it('falls back to original order on query failure', async () => {
+      const columns = ['Area', '2020', '2021'];
+      const pageOptions = defaultPageOptions();
+
+      mockCubeQuery.mockRejectedValue(new Error('DB connection failed'));
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+
+    it('falls back to original order when lookup returns empty results', async () => {
+      const columns = ['Area', '2020', '2021'];
+      const pageOptions = defaultPageOptions();
+
+      mockCubeQuery.mockResolvedValue([]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+  });
+
+  describe('createPivotQuery', () => {
+    beforeEach(() => {
+      mockGetFilterTable.mockResolvedValue([
+        { fact_table_column: 'period_col', dimension_name: 'Period', language: 'en' },
+        { fact_table_column: 'area_col', dimension_name: 'Area', language: 'en' }
+      ]);
+      mockResolveDimensionToFactTableColumn.mockImplementation((name: string) => name);
+    });
+
+    it('generates a PIVOT query with x and y', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions();
+
+      const result = await createPivotQuery('en', queryStore, pageOptions);
+
+      expect(result).toContain('PIVOT');
+      expect(result).toContain('GROUP BY');
+      expect(result).toContain('"Period"');
+      expect(result).toContain('"Area"');
+    });
+
+    it('throws when x is missing', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ x: undefined });
+
+      await expect(createPivotQuery('en', queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws when y is missing', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ y: undefined });
+
+      await expect(createPivotQuery('en', queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+    });
+
+    it('includes LIMIT and OFFSET when pageSize is set', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ pageSize: 50, pageNumber: 3 });
+
+      const result = await createPivotQuery('en', queryStore, pageOptions);
+
+      expect(result).toContain('LIMIT 50');
+      expect(result).toContain('OFFSET 100');
+    });
+
+    it('handles array x values with concatenation', async () => {
+      const queryStore = createMockQueryStore({
+        query: {
+          en: 'SELECT "Period", "Measure" FROM "test-revision-id"."view"',
+          cy: 'SELECT "Period", "Measure" FROM "test-revision-id"."view"'
+        }
+      });
+      const pageOptions = defaultPageOptions({ x: ['Period', 'Measure'] });
+
+      const result = await createPivotQuery('en', queryStore, pageOptions);
+
+      expect(result).toContain("|| ' & ' ||");
+    });
+
+    it('handles array y values', async () => {
+      const queryStore = createMockQueryStore({
+        query: {
+          en: 'SELECT "Area", "Period" FROM "test-revision-id"."view"',
+          cy: 'SELECT "Area", "Period" FROM "test-revision-id"."view"'
+        }
+      });
+      const pageOptions = defaultPageOptions({ y: ['Area', 'Period'] });
+
+      const result = await createPivotQuery('en', queryStore, pageOptions);
+
+      expect(result).toContain('"Area", "Period"');
+    });
+
+    it('includes ORDER BY when sort is specified', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ sort: ['Area|ASC'] });
+
+      const result = await createPivotQuery('en', queryStore, pageOptions);
+
+      expect(result).toContain('ORDER BY');
+      expect(result).toContain('"Area" ASC');
+    });
+
+    it('throws on invalid sort direction', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ sort: ['Area|INVALID'] });
+
+      await expect(createPivotQuery('en', queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws when x value is not present in the query', async () => {
+      const queryStore = createMockQueryStore();
+      const pageOptions = defaultPageOptions({ x: ['NotInQuery'] });
+
+      await expect(createPivotQuery('en', queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('createPivotOutputUsingDuckDB', () => {
+    function setupMockDuckDB(columns: string[], rows: DuckDBValue[][]) {
+      const mockResult = createMockDuckDBResult(columns, rows);
+      mockDuckdbRun.mockResolvedValue({ rowCount: rows.length });
+      mockDuckdbStream.mockResolvedValue(mockResult);
+    }
+
+    describe('JSON output', () => {
+      it('produces valid JSON with all data', async () => {
+        const columns = ['Area', '2020', '2021', '2022'];
+        const rows: DuckDBValue[][] = [
+          ['Cardiff', 100, 200, 300],
+          ['Swansea', 150, 250, 350]
+        ];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const parsed = JSON.parse(output);
+
+        expect(parsed.pivot).toHaveLength(2);
+        expect(parsed.pivot[0]).toEqual({ Area: 'Cardiff', '2020': 100, '2021': 200, '2022': 300 });
+        expect(parsed.pivot[1]).toEqual({ Area: 'Swansea', '2020': 150, '2021': 250, '2022': 350 });
+      });
+
+      it('preserves column order even with integer-like keys', async () => {
+        // This is the core bug fix — integer-like keys would be reordered by Object.keys()
+        // after JSON.parse, so we verify the raw serialised output string order instead.
+        const columns = ['Region', '2020', '2021', '100'];
+        const rows: DuckDBValue[][] = [['Wales', 'a', 'b', 'c']];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        // The raw JSON keys must appear in DuckDB's column order, not V8's integer-first order.
+        // Extract the first row object from within the pivot array.
+        const pivotArrayMatch = output.match(/\[\{([^}]+)\}/);
+        expect(pivotArrayMatch).not.toBeNull();
+        const keyOrder = [...pivotArrayMatch![0].matchAll(/"([^"]+)":/g)].map((m) => m[1]);
+        expect(keyOrder).toEqual(['Region', '2020', '2021', '100']);
+      });
+    });
+
+    describe('CSV output', () => {
+      it('writes CSV with headers in correct order', async () => {
+        const columns = ['Area', '2020', '2021'];
+        const rows: DuckDBValue[][] = [['Cardiff', 100, 200]];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Csv });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const lines = output.trim().split('\n');
+
+        expect(lines[0]).toBe('Area,2020,2021');
+        expect(lines[1]).toBe('Cardiff,100,200');
+      });
+    });
+
+    describe('HTML output', () => {
+      it('writes HTML table with headers in correct order', async () => {
+        const columns = ['Area', '2020', '2021'];
+        const rows: DuckDBValue[][] = [['Cardiff', 100, 200]];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Html });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+
+        expect(output).toContain('<th>Area</th><th>2020</th><th>2021</th>');
+        expect(output).toContain('<th>Cardiff</th><td>100</td><td>200</td>');
+      });
+
+      it('renders empty table when no columns', async () => {
+        const mockResult = createMockDuckDBResult([], []);
+        mockDuckdbRun.mockResolvedValue({ rowCount: 0 });
+        mockDuckdbStream.mockResolvedValue(mockResult);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Html });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        expect(output).toContain('<tbody>');
+        expect(output).toContain('</tbody>');
+      });
+    });
+
+    describe('Frontend output', () => {
+      it('writes frontend JSON with page_info and data as arrays', async () => {
+        const columns = ['Area', '2020', '2021'];
+        const rows: DuckDBValue[][] = [
+          ['Cardiff', 100, 200],
+          ['Swansea', 150, 250]
+        ];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Frontend });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ factTable: [], dimensions: [] });
+        mockQueryRunnerQuery.mockResolvedValue([]);
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const parsed = JSON.parse(output);
+
+        expect(parsed.data).toHaveLength(2);
+        // Frontend data is arrays, not objects
+        expect(parsed.data[0]).toEqual(['Cardiff', 100, 200]);
+        expect(parsed.data[1]).toEqual(['Swansea', 150, 250]);
+        expect(parsed.page_info.total_records).toBe(50);
+        expect(parsed.page_info.current_page).toBe(1);
+      });
+    });
+
+    describe('error handling', () => {
+      it('releases DuckDB on success', async () => {
+        setupMockDuckDB(['Area'], [['Cardiff']]);
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        expect(mockReleaseDuckDB).toHaveBeenCalled();
+      });
+
+      it('releases DuckDB on error', async () => {
+        mockDuckdbRun.mockResolvedValue(undefined);
+        mockDuckdbStream.mockRejectedValue(new Error('Query failed'));
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        await expect(createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore)).rejects.toThrow();
+
+        expect(mockReleaseDuckDB).toHaveBeenCalled();
+      });
+
+      it('throws BadRequestException for Binder Error', async () => {
+        mockDuckdbRun.mockResolvedValue(undefined);
+        mockDuckdbStream.mockRejectedValue(new Error('Binder Error: column not found'));
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        await expect(createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore)).rejects.toThrow(
+          BadRequestException
+        );
+      });
+    });
+  });
+});

--- a/test/services/pivots.test.ts
+++ b/test/services/pivots.test.ts
@@ -309,6 +309,41 @@ describe('pivots service', () => {
       expect(mockCubeQuery).not.toHaveBeenCalled();
     });
 
+    it('resolves x as raw fact table column name when dimension name lookup fails', async () => {
+      const columns = ['Area', '2020', '2022', '2021'];
+      const pageOptions = defaultPageOptions({ x: 'DateRef' });
+
+      // resolveDimensionToFactTableColumn throws — x is a raw column name, not a dimension name
+      mockResolveDimensionToFactTableColumn.mockImplementation(() => {
+        throw new Error('Column not found');
+      });
+      // But the filter table has the fact_table_column
+      mockGetFilterTable.mockResolvedValue([{ fact_table_column: 'DateRef', dimension_name: 'Date', language: 'en' }]);
+      mockGetById.mockResolvedValue({
+        factTable: [{ columnName: 'DateRef' }],
+        dimensions: [{ factTableColumn: 'DateRef', type: DimensionType.Date }]
+      });
+      mockCubeQuery.mockResolvedValue([{ description: '2022' }, { description: '2021' }, { description: '2020' }]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(['Area', '2022', '2021', '2020']);
+    });
+
+    it('returns original order when x matches neither dimension name nor fact table column', async () => {
+      const columns = ['Area', '2020', '2021'];
+      const pageOptions = defaultPageOptions({ x: 'Unknown' });
+
+      mockResolveDimensionToFactTableColumn.mockImplementation(() => {
+        throw new Error('Column not found');
+      });
+      mockGetFilterTable.mockResolvedValue([{ fact_table_column: 'DateRef', dimension_name: 'Date', language: 'en' }]);
+
+      const result = await getSortedPivotColumns(columns, pageOptions, queryStore, 'en');
+
+      expect(result).toEqual(columns);
+    });
+
     it('falls back to original order on query failure', async () => {
       const columns = ['Area', '2020', '2021'];
       const pageOptions = defaultPageOptions();


### PR DESCRIPTION
## Summary

- Fix pivot table row dimension (y axis) not appearing as the first column by switching all formatters from `getRowObjects()` (JS objects with unreliable key ordering) to `yieldRows()` (arrays that preserve DuckDB's column order)
- Fix pivot column headers ignoring dimension sort order by querying lookup tables post-pivot and reordering columns accordingly (DESC for date dimensions, ASC for others)
- Fix `pivotToJson` building JSON objects via `Object.fromEntries` which still reordered integer-like keys — now builds JSON strings directly to preserve column order
- Fix Excel formatter bug where DuckDBResult object was being stringified in the filename

## Changes

All production changes in `src/services/pivots.ts`:

- **Array-based streaming**: Replaced manual `while` loops using `getRowObjects()` with `for await...of` loops using `yieldRows()`, giving properly typed `DuckDBValue[][]` rows with deterministic column ordering
- **New `getSortedPivotColumns()` helper**: Queries PostgreSQL lookup tables to determine correct sort order for x-axis dimension values, with fallback to original order for multi-dimensional pivots or missing lookup tables
- **Handles both dimension names and raw column names**: `pageOptions.x` can be either a translated dimension name (e.g. "Date") or a raw fact table column name (e.g. "DateRef") — the function tries both resolution paths
- **Fixed `SELECT DISTINCT ... ORDER BY` SQL error**: PostgreSQL requires ORDER BY columns to appear in the SELECT list when using DISTINCT — resolved with a subquery
- **Updated all 5 formatters** (JSON, CSV, Excel, HTML, Frontend) to accept and use a `columnOrder: string[]` parameter instead of inferring column names from object keys
- **Added 34 unit tests** in `test/services/pivots.test.ts` covering `langToLocale`, `getSortedPivotColumns`, `createPivotQuery`, and all output formatters via `createPivotOutputUsingDuckDB`

## Test plan

- [x] Verify pivot with date x values — columns in chronological (DESC) order
- [x] Verify row dimension appears as first column
- [x] All 913 existing + new tests pass
- [ ] Verify pivot with lookup dimension — columns respect sort_order
- [ ] Verify all output formats: JSON, CSV, Excel, HTML, Frontend
- [ ] Verify multi-dimensional pivot falls back gracefully
- [ ] Verify Welsh language pivot
