### PR TITLE
SW-1222: bypass rate limit for frontend requests

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -48,5 +48,8 @@ ENTRAID_CLIENT_SECRET=
 HEALTH_DB_TIMEOUT_MS=2000
 HEALTH_STORAGE_TIMEOUT_MS=2000
 
+# Rate limit bypass token shared with the consumer frontend (optional)
+# RATE_LIMIT_BYPASS_TOKEN=
+
 # Option to preserve failed cubes to aid in debugging issues (optional)
 # CUBE_BUILDER_PRESERVE_FAILED = false

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -54,6 +54,7 @@ export interface AppConfig {
   rateLimit: {
     windowMs: number;
     maxRequests: number;
+    bypassToken?: string;
   };
   requestTimeout: {
     defaultMs: number;
@@ -112,4 +113,12 @@ export interface AppConfig {
 
 // list any optional properties here so we can ignore missing values when we check the config on boot
 // it would be nice to get them directly from the interface, but interfaces are compile-time only
-export const optionalProperties = ['redisUrl', 'redisPassword', 'entraid', 'blob', 'datalake', 'cube_builder'];
+export const optionalProperties = [
+  'redisUrl',
+  'redisPassword',
+  'entraid',
+  'blob',
+  'datalake',
+  'cube_builder',
+  'bypassToken'
+];

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -47,7 +47,8 @@ export const getDefaultConfig = (): AppConfig => {
     },
     rateLimit: {
       windowMs: 60000,
-      maxRequests: 100
+      maxRequests: 100,
+      bypassToken: process.env.RATE_LIMIT_BYPASS_TOKEN || undefined
     },
     requestTimeout: {
       defaultMs: parseInt(process.env.REQUEST_TIMEOUT_MS || '30000', 10),

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'node:crypto';
+
 import { Request, Response, NextFunction } from 'express';
 import { rateLimit, RateLimitRequestHandler } from 'express-rate-limit';
 
@@ -23,9 +25,14 @@ const rateLimitHandler = config.rateLimit.windowMs === -1 ? bypass : limit();
 
 export const rateLimiter = (req: Request, res: Response, next: NextFunction): void => {
   const { bypassToken } = config.rateLimit;
-  const headerToken = req.headers['x-rate-limit-bypass'];
+  const headerToken = req.get('x-rate-limit-bypass');
 
-  if (bypassToken && headerToken === bypassToken) {
+  if (
+    bypassToken &&
+    headerToken &&
+    bypassToken.length === headerToken.length &&
+    timingSafeEqual(Buffer.from(bypassToken), Buffer.from(headerToken))
+  ) {
     next();
     return;
   }

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -4,6 +4,7 @@ import { Request, Response, NextFunction } from 'express';
 import { rateLimit, RateLimitRequestHandler } from 'express-rate-limit';
 
 import { config } from '../config';
+import { logger } from '../utils/logger';
 
 const bypass = (_req: Request, _res: Response, next: NextFunction): void => next();
 
@@ -14,6 +15,7 @@ const limit = (): RateLimitRequestHandler => {
     standardHeaders: true,
     legacyHeaders: false,
     handler: (req, res) => {
+      logger.warn(`Rate limit exceeded for IP: ${req.ip}`);
       res.status(429).json({
         message: 'Too many requests, please try again later.'
       });
@@ -33,6 +35,7 @@ export const rateLimiter = (req: Request, res: Response, next: NextFunction): vo
     bypassToken.length === headerToken.length &&
     timingSafeEqual(Buffer.from(bypassToken), Buffer.from(headerToken))
   ) {
+    logger.trace('Rate limit bypass token matched, skipping rate limiting for this request.');
     next();
     return;
   }

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -3,7 +3,7 @@ import { rateLimit, RateLimitRequestHandler } from 'express-rate-limit';
 
 import { config } from '../config';
 
-const bypass = (re: Request, res: Response, next: NextFunction): void => next();
+const bypass = (_req: Request, _res: Response, next: NextFunction): void => next();
 
 const limit = (): RateLimitRequestHandler => {
   return rateLimit({
@@ -19,4 +19,16 @@ const limit = (): RateLimitRequestHandler => {
   });
 };
 
-export const rateLimiter = config.rateLimit.windowMs === -1 ? bypass : limit();
+const rateLimitHandler = config.rateLimit.windowMs === -1 ? bypass : limit();
+
+export const rateLimiter = (req: Request, res: Response, next: NextFunction): void => {
+  const { bypassToken } = config.rateLimit;
+  const headerToken = req.headers['x-rate-limit-bypass'];
+
+  if (bypassToken && headerToken === bypassToken) {
+    next();
+    return;
+  }
+
+  rateLimitHandler(req, res, next);
+};

--- a/test/middleware/rate-limiter.test.ts
+++ b/test/middleware/rate-limiter.test.ts
@@ -13,6 +13,16 @@ jest.mock('../../src/config', () => ({
   config: mockConfig
 }));
 
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
 function createApp() {
   // Re-import the module each time to get a fresh rate limiter with a clean counter
   let rateLimiter: express.RequestHandler;

--- a/test/middleware/rate-limiter.test.ts
+++ b/test/middleware/rate-limiter.test.ts
@@ -1,0 +1,90 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+
+const mockConfig = {
+  rateLimit: {
+    windowMs: 60000,
+    maxRequests: 2,
+    bypassToken: undefined as string | undefined
+  }
+};
+
+jest.mock('../../src/config', () => ({
+  config: mockConfig
+}));
+
+function createApp() {
+  // Re-import the module each time to get a fresh rate limiter with a clean counter
+  let rateLimiter: express.RequestHandler;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    rateLimiter = require('../../src/middleware/rate-limiter').rateLimiter;
+  });
+
+  const app = express();
+  app.use(rateLimiter!);
+  app.get('/test', (_req: Request, res: Response) => {
+    res.status(200).json({ message: 'ok' });
+  });
+  return app;
+}
+
+describe('rateLimiter middleware', () => {
+  describe('bypass token', () => {
+    beforeEach(() => {
+      mockConfig.rateLimit.bypassToken = 'test-secret-token';
+    });
+
+    test('bypasses rate limit when valid token header is present', async () => {
+      const app = createApp();
+
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/test').set('x-rate-limit-bypass', 'test-secret-token');
+        expect(res.status).toBe(200);
+      }
+    });
+
+    test('applies rate limit when no bypass header is present', async () => {
+      const app = createApp();
+
+      for (let i = 0; i < 2; i++) {
+        const res = await request(app).get('/test');
+        expect(res.status).toBe(200);
+      }
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(429);
+      expect(res.body).toEqual({ message: 'Too many requests, please try again later.' });
+    });
+
+    test('applies rate limit when bypass header has wrong token', async () => {
+      const app = createApp();
+
+      for (let i = 0; i < 2; i++) {
+        const res = await request(app).get('/test').set('x-rate-limit-bypass', 'wrong-token');
+        expect(res.status).toBe(200);
+      }
+
+      const res = await request(app).get('/test').set('x-rate-limit-bypass', 'wrong-token');
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('no bypass token configured', () => {
+    beforeEach(() => {
+      mockConfig.rateLimit.bypassToken = undefined;
+    });
+
+    test('applies rate limit even when bypass header is present', async () => {
+      const app = createApp();
+
+      for (let i = 0; i < 2; i++) {
+        const res = await request(app).get('/test').set('x-rate-limit-bypass', 'some-token');
+        expect(res.status).toBe(200);
+      }
+
+      const res = await request(app).get('/test').set('x-rate-limit-bypass', 'some-token');
+      expect(res.status).toBe(429);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `RATE_LIMIT_BYPASS_TOKEN` env var that, when set, allows requests with a matching `x-rate-limit-bypass` header to skip the backend rate limiter
- The consumer frontend (which already rate-limits its own users) can use this shared token to avoid hitting 429s during traffic spikes
- The feature is opt-in: if the env var is unset, all requests are rate-limited as before

Fixes SW-1222 — 720 `Too Many Requests` errors in 11 hours on 2026-04-02 caused by the frontend's parallel API calls (`Promise.all`) exceeding the backend's 100 req/min per-IP limit.

## Test plan

- [x] New unit tests for rate limiter bypass (valid token, missing header, wrong token, no token configured)
- [ ] Deploy to staging with `RATE_LIMIT_BYPASS_TOKEN` set on both backend and frontend
- [ ] Verify frontend requests no longer receive 429s under load
- [ ] Verify unauthenticated requests without the header are still rate-limited
