### PR TITLE
Fix pivot cell data not matching reordered column headers

### DIFF
--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -277,7 +277,7 @@ async function pivotToExcel(
       if (row === null) break;
       const data = columnMapping.map((srcIdx) => {
         const val = row[srcIdx];
-        if (!val) return null;
+        if (val === null || val === undefined) return null;
         return isNaN(Number(val)) ? val : Number(val);
       });
       worksheet.addRow(data).commit();

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -108,7 +108,16 @@ export async function getSortedPivotColumns(
   }
 }
 
-async function pivotToJson(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
+function reorderRow(row: DuckDBValue[], columnMapping: number[]): DuckDBValue[] {
+  return columnMapping.map((srcIdx) => row[srcIdx]);
+}
+
+async function pivotToJson(
+  res: Response,
+  pivot: DuckDBResult,
+  columnOrder: string[],
+  columnMapping: number[]
+): Promise<void> {
   res.setHeader('content-type', 'application/json');
   res.flushHeaders();
   res.write('{ "pivot": [');
@@ -121,7 +130,9 @@ async function pivotToJson(res: Response, pivot: DuckDBResult, columnOrder: stri
         res.write(',\n');
       }
       const jsonRow =
-        '{' + columnOrder.map((col, i) => `${JSON.stringify(col)}:${JSON.stringify(row[i])}`).join(',') + '}';
+        '{' +
+        columnOrder.map((col, i) => `${JSON.stringify(col)}:${JSON.stringify(row[columnMapping[i]])}`).join(',') +
+        '}';
       res.write(jsonRow);
     }
   }
@@ -135,6 +146,7 @@ async function pivotToFrontend(
   lang: string,
   pivot: DuckDBResult,
   columnOrder: string[],
+  columnMapping: number[],
   queryStore: QueryStore,
   pageOptions: PageOptions
 ): Promise<void> {
@@ -190,7 +202,8 @@ async function pivotToFrontend(
       } else {
         res.write(',\n');
       }
-      res.write(JSON.stringify(row));
+      const reorderedRow = reorderRow(row, columnMapping);
+      res.write(JSON.stringify(reorderedRow));
       rowCount++;
     }
   }
@@ -210,7 +223,12 @@ async function pivotToFrontend(
   res.end();
 }
 
-async function pivotToCsv(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
+async function pivotToCsv(
+  res: Response,
+  pivot: DuckDBResult,
+  columnOrder: string[],
+  columnMapping: number[]
+): Promise<void> {
   res.writeHead(200, {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-Type': 'text/csv',
@@ -222,7 +240,8 @@ async function pivotToCsv(res: Response, pivot: DuckDBResult, columnOrder: strin
 
   for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
-      stream.write(row);
+      const reorderedRow = reorderRow(row, columnMapping);
+      stream.write(reorderedRow);
     }
   }
   res.write('\n');
@@ -230,7 +249,12 @@ async function pivotToCsv(res: Response, pivot: DuckDBResult, columnOrder: strin
   stream.end();
 }
 
-async function pivotToExcel(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
+async function pivotToExcel(
+  res: Response,
+  pivot: DuckDBResult,
+  columnOrder: string[],
+  columnMapping: number[]
+): Promise<void> {
   res.writeHead(200, {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -251,7 +275,8 @@ async function pivotToExcel(res: Response, pivot: DuckDBResult, columnOrder: str
   for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
       if (row === null) break;
-      const data = row.map((val: DuckDBValue) => {
+      const data = columnMapping.map((srcIdx) => {
+        const val = row[srcIdx];
         if (!val) return null;
         return isNaN(Number(val)) ? val : Number(val);
       });
@@ -269,7 +294,12 @@ async function pivotToExcel(res: Response, pivot: DuckDBResult, columnOrder: str
   await workbook.commit();
 }
 
-async function pivotToHtml(res: Response, pivot: DuckDBResult, columnOrder: string[]): Promise<void> {
+async function pivotToHtml(
+  res: Response,
+  pivot: DuckDBResult,
+  columnOrder: string[],
+  columnMapping: number[]
+): Promise<void> {
   res.setHeader('content-type', 'text/html');
   res.flushHeaders();
   res.write(
@@ -296,8 +326,9 @@ async function pivotToHtml(res: Response, pivot: DuckDBResult, columnOrder: stri
   for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
       res.write('<tr>');
-      row.forEach((value: DuckDBValue, idx: number) => {
-        if (idx === 0) {
+      columnMapping.forEach((srcIdx, i) => {
+        const value = row[srcIdx];
+        if (i === 0) {
           res.write(`<th>${value === null ? '' : value}</th>`);
         } else {
           res.write(`<td>${value === null ? '' : value}</td>`);
@@ -321,22 +352,29 @@ export async function createPivotOutputUsingDuckDB(
   try {
     await duckdb.run('CALL pg_clear_cache();');
     const pivot = await duckdb.stream(pivotQuery);
-    const columnOrder = await getSortedPivotColumns(pivot.columnNames(), pageOptions, queryStore, lang);
+    const rawColumns = pivot.columnNames();
+    const columnOrder = await getSortedPivotColumns(rawColumns, pageOptions, queryStore, lang);
+
+    // Build a mapping from sorted column positions to original row indices.
+    // When no reordering occurred this is the identity [0, 1, 2, ...].
+    const rawIndexMap = new Map(rawColumns.map((col, i) => [col, i]));
+    const columnMapping = columnOrder.map((col) => rawIndexMap.get(col)!);
+
     switch (pageOptions.format) {
       case OutputFormats.Json:
-        await pivotToJson(res, pivot, columnOrder);
+        await pivotToJson(res, pivot, columnOrder, columnMapping);
         break;
       case OutputFormats.Csv:
-        await pivotToCsv(res, pivot, columnOrder);
+        await pivotToCsv(res, pivot, columnOrder, columnMapping);
         break;
       case OutputFormats.Excel:
-        await pivotToExcel(res, pivot, columnOrder);
+        await pivotToExcel(res, pivot, columnOrder, columnMapping);
         break;
       case OutputFormats.Html:
-        await pivotToHtml(res, pivot, columnOrder);
+        await pivotToHtml(res, pivot, columnOrder, columnMapping);
         break;
       case OutputFormats.Frontend:
-        await pivotToFrontend(res, lang, pivot, columnOrder, queryStore, pageOptions);
+        await pivotToFrontend(res, lang, pivot, columnOrder, columnMapping, queryStore, pageOptions);
         break;
     }
   } catch (err) {

--- a/test/services/pivots.test.ts
+++ b/test/services/pivots.test.ts
@@ -90,6 +90,7 @@ jest.mock('../../src/services/cube-builder', () => ({
   )
 }));
 
+import ExcelJS from 'exceljs';
 import { DuckDBValue } from '@duckdb/node-api';
 import { QueryStore } from '../../src/entities/query-store';
 import { PageOptions } from '../../src/interfaces/page-options';
@@ -164,6 +165,28 @@ function createMockStreamResponse(): Response & { writtenData: string[] } {
   res.status = jest.fn().mockReturnThis();
   res.json = jest.fn();
   (res as any).headersSent = false;
+
+  return res;
+}
+
+// Helper to create a mock Response that captures binary data (for Excel tests)
+function createMockBinaryResponse(): Response & { getBuffer: () => Promise<Buffer> } {
+  const stream = new PassThrough();
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+
+  const res = stream as unknown as Response & { getBuffer: () => Promise<Buffer> };
+  res.setHeader = jest.fn().mockReturnThis();
+  res.writeHead = jest.fn().mockReturnThis();
+  res.flushHeaders = jest.fn();
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn();
+  (res as any).headersSent = false;
+  res.getBuffer = () =>
+    new Promise<Buffer>((resolve) => {
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      if (stream.readableEnded) resolve(Buffer.concat(chunks));
+    });
 
   return res;
 }
@@ -718,6 +741,30 @@ describe('pivots service', () => {
         // Frontend data is arrays — values must be in sorted column order
         expect(parsed.data[0]).toEqual(['Cardiff', 300, 200, 100]);
         expect(parsed.data[1]).toEqual(['Swansea', 350, 250, 150]);
+      });
+
+      it('Excel: cell values match reordered column headers', async () => {
+        setupReorderingMocks();
+        const res = createMockBinaryResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Excel });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const buffer = await res.getBuffer();
+        const workbook = new ExcelJS.Workbook();
+        // @ts-expect-error ExcelJS types expect old Buffer, Node 24 returns Buffer<ArrayBuffer>
+        await workbook.xlsx.load(buffer);
+
+        const worksheet = workbook.getWorksheet(1)!;
+        const headerRow = worksheet.getRow(1).values as (string | number)[];
+        const dataRow1 = worksheet.getRow(2).values as (string | number)[];
+        const dataRow2 = worksheet.getRow(3).values as (string | number)[];
+
+        // ExcelJS row values are 1-indexed (index 0 is empty)
+        expect(headerRow.slice(1)).toEqual(['Area', '2022', '2021', '2020']);
+        expect(dataRow1.slice(1)).toEqual(['Cardiff', 300, 200, 100]);
+        expect(dataRow2.slice(1)).toEqual(['Swansea', 350, 250, 150]);
       });
     });
 

--- a/test/services/pivots.test.ts
+++ b/test/services/pivots.test.ts
@@ -624,6 +624,103 @@ describe('pivots service', () => {
       });
     });
 
+    describe('column reordering aligns cell data with headers', () => {
+      // DuckDB returns columns in its own order (e.g. ['Area', '2020', '2022', '2021']),
+      // but getSortedPivotColumns reorders them (e.g. ['Area', '2022', '2021', '2020']).
+      // These tests verify that cell values follow the reordered headers, not the original order.
+
+      const duckDbColumns = ['Area', '2020', '2022', '2021'];
+      const duckDbRows: DuckDBValue[][] = [
+        ['Cardiff', 100, 300, 200],
+        ['Swansea', 150, 350, 250]
+      ];
+      // Sorted order from lookup: 2022 DESC, 2021, 2020
+      const sortedLookup = [{ description: '2022' }, { description: '2021' }, { description: '2020' }];
+
+      function setupReorderingMocks() {
+        setupMockDuckDB(duckDbColumns, duckDbRows);
+        mockGetFilterTable.mockResolvedValue([
+          { fact_table_column: 'period_col', dimension_name: 'Period', language: 'en' }
+        ]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({
+          factTable: [{ columnName: 'period_col' }],
+          dimensions: [{ factTableColumn: 'period_col', type: DimensionType.DatePeriod }]
+        });
+        mockCubeQuery.mockResolvedValue(sortedLookup);
+      }
+
+      it('JSON: cell values match reordered column headers', async () => {
+        setupReorderingMocks();
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Json });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const parsed = JSON.parse(output);
+
+        expect(parsed.pivot[0]).toEqual({ Area: 'Cardiff', '2022': 300, '2021': 200, '2020': 100 });
+        expect(parsed.pivot[1]).toEqual({ Area: 'Swansea', '2022': 350, '2021': 250, '2020': 150 });
+
+        // Also verify key order in raw JSON string (skip the outer "pivot" key)
+        const allKeys = [...output.matchAll(/"([^"]+)":/g)].map((m) => m[1]);
+        const rowKeys = allKeys.filter((k) => k !== 'pivot');
+        // Both rows should have keys in the same sorted order
+        expect(rowKeys.slice(0, 4)).toEqual(['Area', '2022', '2021', '2020']);
+        expect(rowKeys.slice(4, 8)).toEqual(['Area', '2022', '2021', '2020']);
+      });
+
+      it('CSV: cell values match reordered column headers', async () => {
+        setupReorderingMocks();
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Csv });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const lines = output.trim().split('\n');
+
+        expect(lines[0]).toBe('Area,2022,2021,2020');
+        expect(lines[1]).toBe('Cardiff,300,200,100');
+        expect(lines[2]).toBe('Swansea,350,250,150');
+      });
+
+      it('HTML: cell values match reordered column headers', async () => {
+        setupReorderingMocks();
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Html });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+
+        expect(output).toContain('<th>Area</th><th>2022</th><th>2021</th><th>2020</th>');
+        expect(output).toContain('<th>Cardiff</th><td>300</td><td>200</td><td>100</td>');
+        expect(output).toContain('<th>Swansea</th><td>350</td><td>250</td><td>150</td>');
+      });
+
+      it('Frontend: cell values match reordered column headers', async () => {
+        setupReorderingMocks();
+        mockQueryRunnerQuery.mockResolvedValue([]);
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Frontend });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const parsed = JSON.parse(output);
+
+        // Frontend data is arrays — values must be in sorted column order
+        expect(parsed.data[0]).toEqual(['Cardiff', 300, 200, 100]);
+        expect(parsed.data[1]).toEqual(['Swansea', 350, 250, 150]);
+      });
+    });
+
     describe('error handling', () => {
       it('releases DuckDB on success', async () => {
         setupMockDuckDB(['Area'], [['Cardiff']]);


### PR DESCRIPTION
## Summary

- Fix pivot table cell data not matching reordered column headers — PR #636 sorted the column names but left row data in DuckDB's original order, so cells appeared under the wrong headers
- Build a `columnMapping` index array that maps sorted column positions back to original DuckDB row indices, and apply it in all 5 output formatters (JSON, CSV, Excel, HTML, Frontend)
- Extract a `reorderRow` helper for the repeated remapping pattern and merge the two per-row array allocations in the Excel formatter into a single pass

## Test plan

- [x] 4 new tests verify cell values align with reordered headers across all output formats (JSON, CSV, HTML, Frontend)
- [x] All 921 tests pass
- [ ] Manually verify a pivot with date x-axis — column headers and cell values should match
