### PR TITLE
fix: resolve timezone bug in financial year date handling (SW-1109)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@azure/core-paging": "^1.6.2",
         "@azure/storage-blob": "^12.29.1",
         "@azure/storage-file-datalake": "^12.28.1",
+        "@date-fns/tz": "^1.4.1",
         "@duckdb/node-api": "^1.4.2-r.1",
         "@fast-csv/format": "^5.0.5",
         "@scaleleap/pg-format": "^1.0.0",
@@ -861,6 +862,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@duckdb/node-api": {
       "version": "1.4.2-r.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/storage-blob": "^12.29.1",
     "@azure/storage-file-datalake": "^12.28.1",
+    "@date-fns/tz": "^1.4.1",
     "@duckdb/node-api": "^1.4.2-r.1",
     "@fast-csv/format": "^5.0.5",
     "@scaleleap/pg-format": "^1.0.0",

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -46,8 +46,8 @@ export class ConsumerDatasetDTO {
       dto.published_revision = ConsumerRevisionDTO.fromRevision(dataset.publishedRevision);
     }
 
-    dto.start_date = typeof dataset.startDate === 'string' ? dataset.startDate : dataset.startDate?.toISOString();
-    dto.end_date = typeof dataset.endDate === 'string' ? dataset.endDate : dataset.endDate?.toISOString();
+    dto.start_date = dataset.startDate?.toISOString();
+    dto.end_date = dataset.endDate?.toISOString();
 
     return dto;
   }

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -46,8 +46,8 @@ export class ConsumerDatasetDTO {
       dto.published_revision = ConsumerRevisionDTO.fromRevision(dataset.publishedRevision);
     }
 
-    dto.start_date = dataset.startDate?.toISOString();
-    dto.end_date = dataset.endDate?.toISOString();
+    dto.start_date = dataset.startDate?.toISOString().split('T')[0];
+    dto.end_date = dataset.endDate?.toISOString().split('T')[0];
 
     return dto;
   }

--- a/src/dtos/consumer-revision-dto.ts
+++ b/src/dtos/consumer-revision-dto.ts
@@ -41,8 +41,8 @@ export class ConsumerRevisionDTO {
     revDto.unpublished_at = revision.unpublishedAt?.toISOString();
     revDto.approved_at = revision.approvedAt?.toISOString();
 
-    revDto.coverage_start_date = revision.startDate?.toISOString();
-    revDto.coverage_end_date = revision.endDate?.toISOString();
+    revDto.coverage_start_date = revision.startDate?.toISOString().split('T')[0];
+    revDto.coverage_end_date = revision.endDate?.toISOString().split('T')[0];
     revDto.rounding_applied = revision.roundingApplied;
     revDto.update_frequency = revision.updateFrequency;
     revDto.designation = revision.designation;

--- a/src/dtos/consumer/single-language-dataset-dto.ts
+++ b/src/dtos/consumer/single-language-dataset-dto.ts
@@ -34,8 +34,8 @@ export class SingleLanguageDatasetDTO {
         auto_redirect: dataset.replacementAutoRedirect ?? false
       };
     }
-    dto.start_date = dataset.startDate?.toISOString();
-    dto.end_date = dataset.endDate?.toISOString();
+    dto.start_date = dataset.startDate?.toISOString().split('T')[0];
+    dto.end_date = dataset.endDate?.toISOString().split('T')[0];
 
     dto.dimensions = dataset.dimensions?.map((dimension: Dimension) =>
       SingleLanguageDimensionDTO.fromDimension(dimension, lang)

--- a/src/dtos/consumer/single-language-revision-dto.ts
+++ b/src/dtos/consumer/single-language-revision-dto.ts
@@ -35,8 +35,8 @@ export class SingleLanguageRevisionDTO {
     revDto.publish_at = revision.publishAt?.toISOString();
     revDto.rounding_applied = revision.roundingApplied;
     revDto.update_frequency = revision.updateFrequency;
-    revDto.coverage_start_date = revision.startDate?.toISOString();
-    revDto.coverage_end_date = revision.endDate?.toISOString();
+    revDto.coverage_start_date = revision.startDate?.toISOString().split('T')[0];
+    revDto.coverage_end_date = revision.endDate?.toISOString().split('T')[0];
     revDto.designation = revision.designation;
 
     revDto.related_links = revision.relatedLinks?.map((link: RelatedLink) => RelatedLinkDTO.fromRelatedLink(link));

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -52,10 +52,20 @@ export class Dataset extends BaseEntity {
   @Column({ name: 'replacement_auto_redirect', type: 'boolean', nullable: false, default: false })
   replacementAutoRedirect: boolean;
 
-  @Column({ name: 'start_date', type: 'date', nullable: true })
+  @Column({
+    name: 'start_date',
+    type: 'date',
+    nullable: true,
+    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+  })
   startDate: Date | null;
 
-  @Column({ name: 'end_date', type: 'date', nullable: true })
+  @Column({
+    name: 'end_date',
+    type: 'date',
+    nullable: true,
+    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+  })
   endDate: Date | null;
 
   @OneToMany(() => Dimension, (dimension) => dimension.dataset, { cascade: true })

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -57,7 +57,10 @@ export class Dataset extends BaseEntity {
     type: 'date',
     nullable: true,
     transformer: {
-      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      to: (value: Date | string | null) => {
+        if (!value) return null;
+        return value instanceof Date ? value.toISOString().split('T')[0] : value;
+      },
       from: (value: string | null) => (value ? new Date(value) : null)
     }
   })
@@ -68,7 +71,10 @@ export class Dataset extends BaseEntity {
     type: 'date',
     nullable: true,
     transformer: {
-      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      to: (value: Date | string | null) => {
+        if (!value) return null;
+        return value instanceof Date ? value.toISOString().split('T')[0] : value;
+      },
       from: (value: string | null) => (value ? new Date(value) : null)
     }
   })

--- a/src/entities/dataset/dataset.ts
+++ b/src/entities/dataset/dataset.ts
@@ -56,7 +56,10 @@ export class Dataset extends BaseEntity {
     name: 'start_date',
     type: 'date',
     nullable: true,
-    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+    transformer: {
+      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      from: (value: string | null) => (value ? new Date(value) : null)
+    }
   })
   startDate: Date | null;
 
@@ -64,7 +67,10 @@ export class Dataset extends BaseEntity {
     name: 'end_date',
     type: 'date',
     nullable: true,
-    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+    transformer: {
+      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      from: (value: string | null) => (value ? new Date(value) : null)
+    }
   })
   endDate: Date | null;
 

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -127,7 +127,10 @@ export class Revision extends BaseEntity {
     type: 'date',
     nullable: true,
     transformer: {
-      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      to: (value: Date | string | null) => {
+        if (!value) return null;
+        return value instanceof Date ? value.toISOString().split('T')[0] : value;
+      },
       from: (value: string | null) => (value ? new Date(value) : null)
     }
   })
@@ -138,7 +141,10 @@ export class Revision extends BaseEntity {
     type: 'date',
     nullable: true,
     transformer: {
-      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      to: (value: Date | string | null) => {
+        if (!value) return null;
+        return value instanceof Date ? value.toISOString().split('T')[0] : value;
+      },
       from: (value: string | null) => (value ? new Date(value) : null)
     }
   })

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -122,9 +122,19 @@ export class Revision extends BaseEntity {
   })
   cubeType: CubeType | null;
 
-  @Column({ name: 'start_date', type: 'timestamp without time zone', nullable: true })
+  @Column({
+    name: 'start_date',
+    type: 'date',
+    nullable: true,
+    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+  })
   startDate: Date | null;
 
-  @Column({ name: 'end_date', type: 'timestamp without time zone', nullable: true })
+  @Column({
+    name: 'end_date',
+    type: 'date',
+    nullable: true,
+    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+  })
   endDate: Date | null;
 }

--- a/src/entities/dataset/revision.ts
+++ b/src/entities/dataset/revision.ts
@@ -126,7 +126,10 @@ export class Revision extends BaseEntity {
     name: 'start_date',
     type: 'date',
     nullable: true,
-    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+    transformer: {
+      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      from: (value: string | null) => (value ? new Date(value) : null)
+    }
   })
   startDate: Date | null;
 
@@ -134,7 +137,10 @@ export class Revision extends BaseEntity {
     name: 'end_date',
     type: 'date',
     nullable: true,
-    transformer: { to: (value: Date | null) => value, from: (value: string | null) => (value ? new Date(value) : null) }
+    transformer: {
+      to: (value: Date | null) => (value ? value.toISOString().split('T')[0] : null),
+      from: (value: string | null) => (value ? new Date(value) : null)
+    }
   })
   endDate: Date | null;
 }

--- a/src/migrations/1776249719058-revision-dates-to-date-type.ts
+++ b/src/migrations/1776249719058-revision-dates-to-date-type.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RevisionDatesToDateType1776249719058 implements MigrationInterface {
+  name = 'RevisionDatesToDateType1776249719058';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "start_date" TYPE date USING start_date::date`);
+    await queryRunner.query(`ALTER TABLE "revision" ALTER COLUMN "end_date" TYPE date USING end_date::date`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "revision" ALTER COLUMN "start_date" TYPE timestamp without time zone USING start_date::timestamp`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "revision" ALTER COLUMN "end_date" TYPE timestamp without time zone USING end_date::timestamp`
+    );
+  }
+}

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -56,11 +56,26 @@ export const createDatePeriodTableQuery = (
   );
 };
 
+// Wrap a Date as a UTC TZDate so date-fns arithmetic (add/sub/isBefore)
+// operates in UTC rather than the server's local timezone.
+function toUTC(date: Date): TZDate {
+  return new TZDate(date, 'UTC');
+}
+
 // Parse a date string into a UTC midnight Date, avoiding local-timezone pollution.
 // Uses date-fns parse to understand the format, then reconstructs as UTC.
+// Returns invalid dates unchanged so downstream isValid() checks still work.
 function parseAsUTC(value: string, formatStr: string): Date {
   const parsed = parse(value, formatStr, new Date());
-  return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()));
+  if (!isValid(parsed)) {
+    return parsed;
+  }
+  return toUTC(new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate())));
+}
+
+// Parse an ISO date string as UTC, returning a TZDate for timezone-safe arithmetic.
+function parseISOasUTC(value: string): TZDate {
+  return toUTC(parseISO(value));
 }
 
 // Format a Date in UTC, regardless of server timezone.
@@ -290,8 +305,8 @@ function periodTableCreator(
   const endYear = Math.max(...dataYears);
   const type = yearType(dateFormat.type, dateFormat.startDay, dateFormat.startMonth);
 
-  let year = parseISO(`${startYear}-${type.start}T00:00:00Z`);
-  const end = add(parseISO(`${endYear}-${type.start}T00:00:00Z`), { years: 1 });
+  let year = parseISOasUTC(`${startYear}-${type.start}T00:00:00Z`);
+  const end = add(parseISOasUTC(`${endYear}-${type.start}T00:00:00Z`), { years: 1 });
   // Quarters and month numbers are different depending on the type of year
   let quarterIndex = 1;
   let monthIndex = 1;
@@ -436,7 +451,7 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: string[
 
       case 'yyyy-MM-dd':
       case 'YYYY-MM-DD':
-        parsedDate = parseISO(`${value}T00:00:00Z`);
+        parsedDate = parseISOasUTC(`${value}T00:00:00Z`);
         break;
 
       case 'yyyyMMdd':
@@ -444,7 +459,7 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: string[
         year = value.substring(0, 4);
         month = value.substring(4, 6);
         day = value.substring(6, 8);
-        parsedDate = parseISO(`${year}-${month}-${day}T00:00:00Z`);
+        parsedDate = parseISOasUTC(`${year}-${month}-${day}T00:00:00Z`);
         break;
 
       default:
@@ -492,13 +507,13 @@ function periodDateTableCreator(dateFormat: DateExtractor, dataColumn: string[])
         parsedDate = parseAsUTC(value, 'dd-MM-yyyy');
         break;
       case 'YYYY-MM-DD':
-        parsedDate = parseISO(`${value}T00:00:00Z`);
+        parsedDate = parseISOasUTC(`${value}T00:00:00Z`);
         break;
       case 'YYYYMMDD':
         year = value.substring(0, 4);
         month = value.substring(4, 6);
         day = value.substring(6, 8);
-        parsedDate = parseISO(`${year}-${month}-${day}T00:00:00Z`);
+        parsedDate = parseISOasUTC(`${year}-${month}-${day}T00:00:00Z`);
         break;
 
       default:

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -1,4 +1,5 @@
 import { add, format, isBefore, isDate, isValid, parse, parseISO, sub, Duration } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
 
 import { logger } from '../utils/logger';
 import { YearType } from '../enums/year-type';
@@ -54,6 +55,18 @@ export const createDatePeriodTableQuery = (
     factTableColumn.columnDatatype
   );
 };
+
+// Parse a date string into a UTC midnight Date, avoiding local-timezone pollution.
+// Uses date-fns parse to understand the format, then reconstructs as UTC.
+function parseAsUTC(value: string, formatStr: string): Date {
+  const parsed = parse(value, formatStr, new Date());
+  return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()));
+}
+
+// Format a Date in UTC, regardless of server timezone.
+function formatUTC(date: Date, formatStr: string): string {
+  return format(new TZDate(date, 'UTC'), formatStr);
+}
 
 // Date parsing methods start here
 function yearType(type: YearType, startDay = 1, startMonth = 1): YearTypeDetails {
@@ -277,8 +290,8 @@ function periodTableCreator(
   const endYear = Math.max(...dataYears);
   const type = yearType(dateFormat.type, dateFormat.startDay, dateFormat.startMonth);
 
-  let year = parse(`${startYear}-${type.start}`, 'yyyy-MM-dd', new Date());
-  const end = add(parse(`${endYear}-${type.start}`, 'yyyy-MM-dd', new Date()), { years: 1, seconds: -1 });
+  let year = parseISO(`${startYear}-${type.start}T00:00:00Z`);
+  const end = add(parseISO(`${endYear}-${type.start}T00:00:00Z`), { years: 1, seconds: -1 });
   // Quarters and month numbers are different depending on the type of year
   let quarterIndex = 1;
   let monthIndex = 1;
@@ -288,27 +301,27 @@ function periodTableCreator(
   // While loop builds our table we can match against and load into our Cube
   let displayYear = year;
   while (isBefore(year, end)) {
-    const monthNo = parseInt(format(year, 'MM'), 10);
+    const monthNo = parseInt(formatUTC(year, 'MM'), 10);
     const dateStr = formatObj.formatStr
-      .replace('[full-start]', format(displayYear, 'yyyy'))
-      .replace('[full-end]', format(add(displayYear, { years: 1 }), 'yyyy'))
-      .replace('[end-year]', format(add(displayYear, { years: 1 }), 'yy'))
+      .replace('[full-start]', formatUTC(displayYear, 'yyyy'))
+      .replace('[full-end]', formatUTC(add(displayYear, { years: 1 }), 'yyyy'))
+      .replace('[end-year]', formatUTC(add(displayYear, { years: 1 }), 'yy'))
       .replace('[quarterNo]', quarterIndex.toString())
-      .replace('[monthStr]', format(year, 'MMM'))
+      .replace('[monthStr]', formatUTC(year, 'MMM'))
       .replace('[monthNo]', String(monthNo).padStart(2, '0'));
 
     let parent: string | null = null;
     if (parentType === ParentType.Year) {
       parent = yearFormat
-        .replace('[full-start]', format(displayYear, 'yyyy'))
-        .replace('[full-end]', format(add(displayYear, { years: 1 }), 'yyyy'))
-        .replace('[end-year]', format(add(displayYear, { years: 1 }), 'yy'));
+        .replace('[full-start]', formatUTC(displayYear, 'yyyy'))
+        .replace('[full-end]', formatUTC(add(displayYear, { years: 1 }), 'yyyy'))
+        .replace('[end-year]', formatUTC(add(displayYear, { years: 1 }), 'yy'));
     }
     if (parentType === ParentType.Quarter) {
       parent = quarterFormat
-        .replace('[full-start]', format(displayYear, 'yyyy'))
-        .replace('[full-end]', format(add(displayYear, { years: 1 }), 'yyyy'))
-        .replace('[end-year]', format(add(displayYear, { years: 1 }), 'yy'))
+        .replace('[full-start]', formatUTC(displayYear, 'yyyy'))
+        .replace('[full-end]', formatUTC(add(displayYear, { years: 1 }), 'yyyy'))
+        .replace('[end-year]', formatUTC(add(displayYear, { years: 1 }), 'yy'))
         .replace('[quarterNo]', quarterIndex.toString());
     }
 
@@ -318,20 +331,20 @@ function periodTableCreator(
         case GeneratorType.Year:
           description =
             dateFormat.type === YearType.Calendar
-              ? format(displayYear, 'yyyy')
-              : `${format(displayYear, 'yyyy')}${type.separator}${format(add(displayYear, { years: 1 }), 'yy')}`;
+              ? formatUTC(displayYear, 'yyyy')
+              : `${formatUTC(displayYear, 'yyyy')}${type.separator}${formatUTC(add(displayYear, { years: 1 }), 'yy')}`;
           break;
         case GeneratorType.Quarter:
           description =
             dateFormat.type === YearType.Calendar
-              ? `${t('date_format.quarter_abr', { lng: locale })}${quarterIndex} ${format(displayYear, 'yyyy')}`
-              : `${t('date_format.quarter_abr', { lng: locale })}${quarterIndex} ${format(displayYear, 'yyyy')}${type.separator}${format(add(displayYear, { years: 1 }), 'yy')}`;
+              ? `${t('date_format.quarter_abr', { lng: locale })}${quarterIndex} ${formatUTC(displayYear, 'yyyy')}`
+              : `${t('date_format.quarter_abr', { lng: locale })}${quarterIndex} ${formatUTC(displayYear, 'yyyy')}${type.separator}${formatUTC(add(displayYear, { years: 1 }), 'yy')}`;
           break;
         case GeneratorType.Month:
           description =
             dateFormat.type === YearType.Calendar
-              ? `${t(`months.${monthNo}`, { lng: locale })} ${format(displayYear, 'yyyy')}`
-              : `${t(`months.${monthNo}`, { lng: locale })} ${format(displayYear, 'yyyy')}${type.separator}${format(add(displayYear, { years: 1 }), 'yy')}`;
+              ? `${t(`months.${monthNo}`, { lng: locale })} ${formatUTC(displayYear, 'yyyy')}`
+              : `${t(`months.${monthNo}`, { lng: locale })} ${formatUTC(displayYear, 'yyyy')}${type.separator}${formatUTC(add(displayYear, { years: 1 }), 'yy')}`;
           break;
       }
 
@@ -348,11 +361,11 @@ function periodTableCreator(
 
     if (dateFormat.quarterTotalIsFifthQuart && quarterIndex === 4) {
       const yearStr = formatObj.formatStr
-        .replace('[full-start]', format(displayYear, 'yyyy'))
-        .replace('[full-end]', format(add(displayYear, { years: 1 }), 'yyyy'))
-        .replace('[end-year]', format(add(displayYear, { years: 1 }), 'yy'))
+        .replace('[full-start]', formatUTC(displayYear, 'yyyy'))
+        .replace('[full-end]', formatUTC(add(displayYear, { years: 1 }), 'yyyy'))
+        .replace('[end-year]', formatUTC(add(displayYear, { years: 1 }), 'yy'))
         .replace('[quarterNo]', (quarterIndex + 1).toString())
-        .replace('[monthStr]', format(year, 'MMM'))
+        .replace('[monthStr]', formatUTC(year, 'MMM'))
         .replace('[monthNo]', String(monthNo).padStart(2, '0'));
       for (const locale of SUPPORTED_LOCALES) {
         referenceTable.push({
@@ -360,8 +373,8 @@ function periodTableCreator(
           lang: locale.toLowerCase(),
           description:
             dateFormat.type === YearType.Calendar
-              ? format(displayYear, 'yyyy')
-              : `${format(displayYear, 'yyyy')}-${format(add(displayYear, { years: 1 }), 'yy')}`,
+              ? formatUTC(displayYear, 'yyyy')
+              : `${formatUTC(displayYear, 'yyyy')}-${formatUTC(add(displayYear, { years: 1 }), 'yy')}`,
           start: year,
           end: add(year, { months: 12, seconds: -1 }),
           type: t(`date_format.year.${dateFormat.type}`, { lng: locale }),
@@ -413,12 +426,12 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: string[
     switch (dateFormat.dateFormat) {
       case 'dd/MM/yyyy':
       case 'DD/MM/YYYY':
-        parsedDate = parse(value, 'dd/MM/yyyy', new Date());
+        parsedDate = parseAsUTC(value, 'dd/MM/yyyy');
         break;
 
       case 'dd-MM-yyyy':
       case 'DD-MM-YYYY':
-        parsedDate = parse(value, 'dd-MM-yyyy', new Date());
+        parsedDate = parseAsUTC(value, 'dd-MM-yyyy');
         break;
 
       case 'yyyy-MM-dd':
@@ -446,7 +459,7 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: string[
       referenceTable.push({
         dateCode: value,
         lang: locale.toLowerCase(),
-        description: format(parsedDate, 'dd/MM/yyyy'),
+        description: formatUTC(parsedDate, 'dd/MM/yyyy'),
         start: parsedDate,
         end: sub(add(parsedDate, { days: 1 }), { seconds: 1 }),
         type: 'specific_day',
@@ -473,19 +486,19 @@ function periodDateTableCreator(dateFormat: DateExtractor, dataColumn: string[])
     let year: string;
     switch (dateFormat.dateFormat?.toUpperCase()) {
       case 'DD/MM/YYYY':
-        parsedDate = parse(value, 'dd/MM/yyyy', new Date());
+        parsedDate = parseAsUTC(value, 'dd/MM/yyyy');
         break;
       case 'DD-MM-YYYY':
-        parsedDate = parse(value, 'dd-MM-yyyy', new Date());
+        parsedDate = parseAsUTC(value, 'dd-MM-yyyy');
         break;
       case 'YYYY-MM-DD':
-        parsedDate = parse(value, 'yyyy-MM-dd', new Date());
+        parsedDate = parseISO(`${value}T00:00:00Z`);
         break;
       case 'YYYYMMDD':
         year = value.substring(0, 4);
         month = value.substring(4, 6);
         day = value.substring(6, 8);
-        parsedDate = parse(`${year}-${month}-${day}`, 'yyyy-MM-dd', new Date());
+        parsedDate = parseISO(`${year}-${month}-${day}T00:00:00Z`);
         break;
 
       default:
@@ -498,7 +511,7 @@ function periodDateTableCreator(dateFormat: DateExtractor, dataColumn: string[])
     }
 
     for (const locale of SUPPORTED_LOCALES) {
-      const fullDate = `${parsedDate.getDate()} ${t(`months.${parsedDate.getMonth() + 1}`, { lng: locale })} ${parsedDate.getFullYear()}`;
+      const fullDate = `${parsedDate.getUTCDate()} ${t(`months.${parsedDate.getUTCMonth() + 1}`, { lng: locale })} ${parsedDate.getUTCFullYear()}`;
       const startDate = sub(add(parsedDate, { days: 1 }), type.increment);
       const endDate = add(parsedDate, { days: 1, seconds: -1 });
       logger.debug(`Start Date = ${startDate}, EndDate = ${endDate}`);

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -42,8 +42,8 @@ export const createDatePeriodTableQuery = (
         %I %s,
         language VARCHAR(5),
         description VARCHAR,
-        start_date TIMESTAMP WITHOUT TIME ZONE,
-        end_date TIMESTAMP WITHOUT TIME ZONE,
+        start_date DATE,
+        end_date DATE,
         date_type VARCHAR,
         sort_order BIGINT,
         hierarchy %s
@@ -291,7 +291,7 @@ function periodTableCreator(
   const type = yearType(dateFormat.type, dateFormat.startDay, dateFormat.startMonth);
 
   let year = parseISO(`${startYear}-${type.start}T00:00:00Z`);
-  const end = add(parseISO(`${endYear}-${type.start}T00:00:00Z`), { years: 1, seconds: -1 });
+  const end = add(parseISO(`${endYear}-${type.start}T00:00:00Z`), { years: 1 });
   // Quarters and month numbers are different depending on the type of year
   let quarterIndex = 1;
   let monthIndex = 1;
@@ -353,7 +353,7 @@ function periodTableCreator(
         lang: locale.toLowerCase(),
         description,
         start: year,
-        end: add(year, { months: formatObj.increment, seconds: -1 }),
+        end: sub(add(year, { months: formatObj.increment }), { days: 1 }),
         type: t(`date_format.${subType}.${dateFormat.type}`, { lng: locale }),
         hierarchy: parent
       });
@@ -376,7 +376,7 @@ function periodTableCreator(
               ? formatUTC(displayYear, 'yyyy')
               : `${formatUTC(displayYear, 'yyyy')}-${formatUTC(add(displayYear, { years: 1 }), 'yy')}`,
           start: year,
-          end: add(year, { months: 12, seconds: -1 }),
+          end: sub(add(year, { months: 12 }), { days: 1 }),
           type: t(`date_format.year.${dateFormat.type}`, { lng: locale }),
           hierarchy: null
         });
@@ -461,7 +461,7 @@ function specificDateTableCreator(dateFormat: DateExtractor, dataColumn: string[
         lang: locale.toLowerCase(),
         description: formatUTC(parsedDate, 'dd/MM/yyyy'),
         start: parsedDate,
-        end: sub(add(parsedDate, { days: 1 }), { seconds: 1 }),
+        end: parsedDate,
         type: 'specific_day',
         hierarchy: null
       });
@@ -513,7 +513,7 @@ function periodDateTableCreator(dateFormat: DateExtractor, dataColumn: string[])
     for (const locale of SUPPORTED_LOCALES) {
       const fullDate = `${parsedDate.getUTCDate()} ${t(`months.${parsedDate.getUTCMonth() + 1}`, { lng: locale })} ${parsedDate.getUTCFullYear()}`;
       const startDate = sub(add(parsedDate, { days: 1 }), type.increment);
-      const endDate = add(parsedDate, { days: 1, seconds: -1 });
+      const endDate = parsedDate;
       logger.debug(`Start Date = ${startDate}, EndDate = ${endDate}`);
       referenceTable.push({
         dateCode: row.toString(),

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -754,8 +754,8 @@ async function getDatePreviewWithExtractor(
       SELECT
           %I.%I as %I,
           %I.description,
-          to_char(%I.start_date, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as start_date,
-          to_char(%I.end_date, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as end_date,
+          to_char(%I.start_date, 'YYYY-MM-DD') as start_date,
+          to_char(%I.end_date, 'YYYY-MM-DD') as end_date,
           %I.date_type
       FROM %I.%I
       WHERE %I.language = %L

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -556,8 +556,8 @@ export const createDateDimensionLookup = async (
           reference: row.dateCode,
           language: row.lang,
           description: row.description,
-          start_date: row.start,
-          end_date: row.end,
+          start_date: row.start.toISOString().split('T')[0],
+          end_date: row.end.toISOString().split('T')[0],
           type: row.type,
           sort_order: row.end.getTime(),
           hierarchy: row.hierarchy
@@ -591,8 +591,8 @@ export const createDateDimensionLookup = async (
         row.dateCode,
         row.lang,
         row.description,
-        row.start,
-        row.end,
+        row.start.toISOString().split('T')[0],
+        row.end.toISOString().split('T')[0],
         row.type,
         row.end.getTime(),
         row.hierarchy

--- a/test/dtos/consumer-revision-dto.test.ts
+++ b/test/dtos/consumer-revision-dto.test.ts
@@ -81,11 +81,11 @@ describe('ConsumerRevisionDTO', () => {
       expect(dto.approved_at).toBeUndefined();
     });
 
-    it('should map coverage start and end dates to ISO strings', () => {
+    it('should map coverage start and end dates to date-only strings', () => {
       const dto = ConsumerRevisionDTO.fromRevision(makeRevision());
 
-      expect(dto.coverage_start_date).toBe('2020-01-01T00:00:00.000Z');
-      expect(dto.coverage_end_date).toBe('2024-12-31T00:00:00.000Z');
+      expect(dto.coverage_start_date).toBe('2020-01-01');
+      expect(dto.coverage_end_date).toBe('2024-12-31');
     });
 
     it('should handle null coverage dates', () => {

--- a/test/services/date-matching.test.ts
+++ b/test/services/date-matching.test.ts
@@ -29,8 +29,8 @@ describe('date-matching', () => {
     test('includes required fixed columns with correct types', () => {
       const sql = createDatePeriodTableQuery(col, 'public', 'date_lookup');
       expect(sql).toContain('language VARCHAR(5)');
-      expect(sql).toContain('start_date TIMESTAMP WITHOUT TIME ZONE');
-      expect(sql).toContain('end_date TIMESTAMP WITHOUT TIME ZONE');
+      expect(sql).toContain('start_date DATE');
+      expect(sql).toContain('end_date DATE');
       expect(sql).toContain('sort_order BIGINT');
     });
 
@@ -103,7 +103,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.Calendar, yearFormat: 'YYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023' }]);
       const expectedStart = parseISO('2023-01-01T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -112,7 +112,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.Financial, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
       const expectedStart = parseISO('2023-04-01T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -121,7 +121,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.Tax, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
       const expectedStart = parseISO('2023-04-06T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -130,7 +130,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.Academic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
       const expectedStart = parseISO('2023-09-01T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -139,7 +139,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.HigherAcademic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
       const expectedStart = parseISO('2023-08-01T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -148,7 +148,7 @@ describe('date-matching', () => {
       const extractor: DateExtractor = { type: YearType.Meteorological, yearFormat: 'YYYY-YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023-24' }]);
       const expectedStart = parseISO('2023-03-01T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -162,7 +162,7 @@ describe('date-matching', () => {
       };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
       const expectedStart = parseISO('2023-06-15T00:00:00Z');
-      const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
+      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
@@ -297,7 +297,7 @@ describe('date-matching', () => {
     function expectedDates(increment: Duration) {
       return {
         start: sub(add(parsedEndDate, { days: 1 }), increment),
-        end: add(parsedEndDate, { days: 1, seconds: -1 })
+        end: parsedEndDate
       };
     }
 

--- a/test/services/date-matching.test.ts
+++ b/test/services/date-matching.test.ts
@@ -1,4 +1,4 @@
-import { Duration, add, parse, sub } from 'date-fns';
+import { Duration, add, parseISO, sub } from 'date-fns';
 
 import { YearType } from '../../src/enums/year-type';
 import { createDatePeriodTableQuery, dateDimensionReferenceTableCreator } from '../../src/services/date-matching';
@@ -102,7 +102,7 @@ describe('date-matching', () => {
     test('Calendar year starts Jan 1 and ends Dec 31', () => {
       const extractor: DateExtractor = { type: YearType.Calendar, yearFormat: 'YYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023' }]);
-      const expectedStart = parse('2023-01-01', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-01-01T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -111,7 +111,7 @@ describe('date-matching', () => {
     test('Financial year starts Apr 1 and ends Mar 31', () => {
       const extractor: DateExtractor = { type: YearType.Financial, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parse('2023-04-01', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-04-01T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -120,7 +120,7 @@ describe('date-matching', () => {
     test('Tax year starts Apr 6 and ends Apr 5', () => {
       const extractor: DateExtractor = { type: YearType.Tax, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parse('2023-04-06', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-04-06T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -129,16 +129,16 @@ describe('date-matching', () => {
     test('Academic year starts Sep 1 and ends Aug 31', () => {
       const extractor: DateExtractor = { type: YearType.Academic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
-      const expectedStart = parse('2023-09-01', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-09-01T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
     });
 
-    test('Higher Academic year starts Sep 1 and ends Aug 31', () => {
+    test('Higher Academic year starts Aug 1 and ends Jul 31', () => {
       const extractor: DateExtractor = { type: YearType.HigherAcademic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
-      const expectedStart = parse('2023-08-01', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-08-01T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -147,7 +147,7 @@ describe('date-matching', () => {
     test('Meteorological year starts Mar 1 and ends Feb 28/29', () => {
       const extractor: DateExtractor = { type: YearType.Meteorological, yearFormat: 'YYYY-YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023-24' }]);
-      const expectedStart = parse('2023-03-01', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-03-01T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -161,7 +161,7 @@ describe('date-matching', () => {
         startMonth: 6
       };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parse('2023-06-15', 'yyyy-MM-dd', new Date());
+      const expectedStart = parseISO('2023-06-15T00:00:00Z');
       const expectedEnd = add(expectedStart, { months: 12, seconds: -1 });
       expect(result[0].start).toEqual(expectedStart);
       expect(result[0].end).toEqual(expectedEnd);
@@ -269,7 +269,7 @@ describe('date-matching', () => {
       expect(result.length).toBe(2);
       expect(result[0].dateCode).toBe('01-12-2023');
       expect(result[0].type).toBe('specific_day');
-      const expectedDate = parse('01-12-2023', 'dd-MM-yyyy', new Date());
+      const expectedDate = parseISO('2023-12-01T00:00:00Z');
       expect(result[0].start).toEqual(expectedDate);
     });
 
@@ -292,7 +292,7 @@ describe('date-matching', () => {
   describe('dateDimensionReferenceTableCreator - rolling / period-ending dates', () => {
     const extractor: DateExtractor = { type: YearType.Rolling, dateFormat: 'dd/MM/yyyy' };
     const endDateStr = '31/03/2024';
-    const parsedEndDate = parse(endDateStr, 'dd/MM/yyyy', new Date());
+    const parsedEndDate = parseISO('2024-03-31T00:00:00Z');
 
     function expectedDates(increment: Duration) {
       return {

--- a/test/services/date-matching.test.ts
+++ b/test/services/date-matching.test.ts
@@ -1,8 +1,14 @@
 import { Duration, add, parseISO, sub } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
 
 import { YearType } from '../../src/enums/year-type';
 import { createDatePeriodTableQuery, dateDimensionReferenceTableCreator } from '../../src/services/date-matching';
 import { DateExtractor } from '../../src/extractors/date-extractor';
+
+// Helper to create a UTC TZDate, matching production code behaviour.
+function utc(iso: string): TZDate {
+  return new TZDate(parseISO(iso), 'UTC');
+}
 import { FactTableColumn } from '../../src/entities/dataset/fact-table-column';
 
 jest.mock('../../src/utils/logger', () => ({
@@ -102,55 +108,43 @@ describe('date-matching', () => {
     test('Calendar year starts Jan 1 and ends Dec 31', () => {
       const extractor: DateExtractor = { type: YearType.Calendar, yearFormat: 'YYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023' }]);
-      const expectedStart = parseISO('2023-01-01T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-01-01T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2023-12-31T00:00:00Z'));
     });
 
     test('Financial year starts Apr 1 and ends Mar 31', () => {
       const extractor: DateExtractor = { type: YearType.Financial, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parseISO('2023-04-01T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-04-01T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-03-31T00:00:00Z'));
     });
 
     test('Tax year starts Apr 6 and ends Apr 5', () => {
       const extractor: DateExtractor = { type: YearType.Tax, yearFormat: 'YYYYYY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parseISO('2023-04-06T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-04-06T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-04-05T00:00:00Z'));
     });
 
     test('Academic year starts Sep 1 and ends Aug 31', () => {
       const extractor: DateExtractor = { type: YearType.Academic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
-      const expectedStart = parseISO('2023-09-01T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-09-01T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-08-31T00:00:00Z'));
     });
 
     test('Higher Academic year starts Aug 1 and ends Jul 31', () => {
       const extractor: DateExtractor = { type: YearType.HigherAcademic, yearFormat: 'YYYY/YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023/24' }]);
-      const expectedStart = parseISO('2023-08-01T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-08-01T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-07-31T00:00:00Z'));
     });
 
     test('Meteorological year starts Mar 1 and ends Feb 28/29', () => {
       const extractor: DateExtractor = { type: YearType.Meteorological, yearFormat: 'YYYY-YY' };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '2023-24' }]);
-      const expectedStart = parseISO('2023-03-01T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-03-01T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-02-29T00:00:00Z'));
     });
 
     test('Rolling year uses custom startDay and startMonth', () => {
@@ -161,10 +155,8 @@ describe('date-matching', () => {
         startMonth: 6
       };
       const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
-      const expectedStart = parseISO('2023-06-15T00:00:00Z');
-      const expectedEnd = sub(add(expectedStart, { months: 12 }), { days: 1 });
-      expect(result[0].start).toEqual(expectedStart);
-      expect(result[0].end).toEqual(expectedEnd);
+      expect(result[0].start).toEqual(utc('2023-06-15T00:00:00Z'));
+      expect(result[0].end).toEqual(utc('2024-06-14T00:00:00Z'));
     });
   });
 
@@ -269,8 +261,7 @@ describe('date-matching', () => {
       expect(result.length).toBe(2);
       expect(result[0].dateCode).toBe('01-12-2023');
       expect(result[0].type).toBe('specific_day');
-      const expectedDate = parseISO('2023-12-01T00:00:00Z');
-      expect(result[0].start).toEqual(expectedDate);
+      expect(result[0].start).toEqual(utc('2023-12-01T00:00:00Z'));
     });
 
     test('yyyy-MM-dd format parses correctly', () => {
@@ -292,7 +283,7 @@ describe('date-matching', () => {
   describe('dateDimensionReferenceTableCreator - rolling / period-ending dates', () => {
     const extractor: DateExtractor = { type: YearType.Rolling, dateFormat: 'dd/MM/yyyy' };
     const endDateStr = '31/03/2024';
-    const parsedEndDate = parseISO('2024-03-31T00:00:00Z');
+    const parsedEndDate = utc('2024-03-31T00:00:00Z');
 
     function expectedDates(increment: Duration) {
       return {
@@ -429,5 +420,50 @@ describe('date-matching', () => {
       const q1 = result.find((item) => item.dateCode === '202324Q1');
       expect(q1?.hierarchy).toBeNull();
     });
+  });
+
+  describe('dateDimensionReferenceTableCreator - timezone independence', () => {
+    const originalTZ = process.env.TZ;
+
+    afterEach(() => {
+      if (originalTZ === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTZ;
+      }
+    });
+
+    test.each(['America/New_York', 'Asia/Kolkata', 'Pacific/Auckland'])(
+      'Financial year dates are identical under TZ=%s',
+      (tz) => {
+        process.env.TZ = tz;
+        const extractor: DateExtractor = { type: YearType.Financial, yearFormat: 'YYYYYY' };
+        const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '202324' }]);
+        expect(result[0].start.getTime()).toBe(Date.UTC(2023, 3, 1));
+        expect(result[0].end.getTime()).toBe(Date.UTC(2024, 2, 31));
+      }
+    );
+
+    test.each(['America/New_York', 'Asia/Kolkata', 'Pacific/Auckland'])(
+      'Point-in-time dates are identical under TZ=%s',
+      (tz) => {
+        process.env.TZ = tz;
+        const extractor: DateExtractor = { type: YearType.PointInTime, dateFormat: 'dd/MM/yyyy' };
+        const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: '01/04/2023' }]);
+        expect(result[0].start.getTime()).toBe(Date.UTC(2023, 3, 1));
+        expect(result[0].end.getTime()).toBe(Date.UTC(2023, 3, 1));
+      }
+    );
+
+    test.each(['America/New_York', 'Asia/Kolkata', 'Pacific/Auckland'])(
+      'Rolling period-ending dates are identical under TZ=%s',
+      (tz) => {
+        process.env.TZ = tz;
+        const extractor: DateExtractor = { type: YearType.Rolling, dateFormat: 'dd/MM/yyyy' };
+        const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode: 'YE31/03/2024' }]);
+        expect(result[0].start.getTime()).toBe(Date.UTC(2023, 3, 1));
+        expect(result[0].end.getTime()).toBe(Date.UTC(2024, 2, 31));
+      }
+    );
   });
 });

--- a/test/services/dimension-processor.test.ts
+++ b/test/services/dimension-processor.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 
 import { parseISO } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
 
 import { logger } from '../../src/utils/logger';
 import { YearType } from '../../src/enums/year-type';
@@ -323,12 +324,12 @@ describe('Date matching table generation', () => {
       const refTable = dateDimensionReferenceTableCreator(extractor, input);
       expect(refTable.length).toBe(26);
       expect(refTable[0].dateCode).toBe('20231201');
-      expect(refTable[0].start).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
-      expect(refTable[0].end).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
+      expect(refTable[0].start).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
+      expect(refTable[0].end).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
       expect(refTable[0].type).toBe('specific_day');
       expect(refTable[2].dateCode).toBe('20240101');
-      expect(refTable[2].start).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
-      expect(refTable[2].end).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
+      expect(refTable[2].start).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
+      expect(refTable[2].end).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
       expect(refTable[1].type).toBe('specific_day');
     });
 
@@ -355,12 +356,12 @@ describe('Date matching table generation', () => {
       const refTable = dateDimensionReferenceTableCreator(extractor, input);
       expect(refTable.length).toBe(26);
       expect(refTable[0].dateCode).toBe('01/12/2023');
-      expect(refTable[0].start).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
-      expect(refTable[0].end).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
+      expect(refTable[0].start).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
+      expect(refTable[0].end).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
       expect(refTable[0].type).toBe('specific_day');
       expect(refTable[2].dateCode).toBe('01/01/2024');
-      expect(refTable[2].start).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
-      expect(refTable[2].end).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
+      expect(refTable[2].start).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
+      expect(refTable[2].end).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
       expect(refTable[2].type).toBe('specific_day');
     });
 

--- a/test/services/dimension-processor.test.ts
+++ b/test/services/dimension-processor.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { add, parseISO, sub } from 'date-fns';
+import { parseISO } from 'date-fns';
 
 import { logger } from '../../src/utils/logger';
 import { YearType } from '../../src/enums/year-type';
@@ -324,15 +324,11 @@ describe('Date matching table generation', () => {
       expect(refTable.length).toBe(26);
       expect(refTable[0].dateCode).toBe('20231201');
       expect(refTable[0].start).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
-      expect(refTable[0].end).toStrictEqual(
-        sub(add(parseISO('2023-12-01T00:00:00.000Z'), { days: 1 }), { seconds: 1 })
-      );
+      expect(refTable[0].end).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
       expect(refTable[0].type).toBe('specific_day');
       expect(refTable[2].dateCode).toBe('20240101');
       expect(refTable[2].start).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
-      expect(refTable[2].end).toStrictEqual(
-        sub(add(parseISO('2024-01-01T00:00:00.000Z'), { days: 1 }), { seconds: 1 })
-      );
+      expect(refTable[2].end).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
       expect(refTable[1].type).toBe('specific_day');
     });
 
@@ -360,15 +356,11 @@ describe('Date matching table generation', () => {
       expect(refTable.length).toBe(26);
       expect(refTable[0].dateCode).toBe('01/12/2023');
       expect(refTable[0].start).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
-      expect(refTable[0].end).toStrictEqual(
-        sub(add(parseISO('2023-12-01T00:00:00.000Z'), { days: 1 }), { seconds: 1 })
-      );
+      expect(refTable[0].end).toStrictEqual(parseISO('2023-12-01T00:00:00.000Z'));
       expect(refTable[0].type).toBe('specific_day');
       expect(refTable[2].dateCode).toBe('01/01/2024');
       expect(refTable[2].start).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
-      expect(refTable[2].end).toStrictEqual(
-        sub(add(parseISO('2024-01-01T00:00:00.000Z'), { days: 1 }), { seconds: 1 })
-      );
+      expect(refTable[2].end).toStrictEqual(parseISO('2024-01-01T00:00:00.000Z'));
       expect(refTable[2].type).toBe('specific_day');
     });
 


### PR DESCRIPTION
## Summary

Fixes SW-1109: financial year time period dates were displaying incorrectly due to timezone pollution.

**Root cause:** `date-fns/parse` created dates in the server's local timezone. When stored in `timestamp without time zone` columns, the UTC representation was timezone-shifted. The `pg` driver then reinterpreted values using local time on read, compounding the problem.

**Fix:**
- All date creation in `date-matching.ts` now uses UTC-explicit parsing (`parseISO` with `Z` suffix, `parseAsUTC` helper)
- All `format()` calls replaced with `formatUTC()` using `TZDate` from `@date-fns/tz` to ensure timezone-safe formatting regardless of server timezone
- Revision `start_date`/`end_date` columns migrated from `timestamp without time zone` to `date` — these are calendar dates, not moments in time
- Lookup table schema also changed to `DATE` columns
- Removed the `seconds: -1` hack for end dates — end dates are now clean calendar dates (e.g. `2024-03-31` instead of `2024-03-31 23:59:59`)
- Added TypeORM column transformers on `revision` and `dataset` entities so `date` columns are read back as proper Date objects (pg driver returns them as strings)
- Cleaned up the `typeof` guard in `consumer-dataset-dto.ts` that was working around this

## Test plan

- [ ] All 922 backend unit tests pass
- [ ] Rebuild a financial year dataset and verify `year_lookup` table has correct dates (e.g. `2001-04-01` not `2001-03-31 23:00:00`)
- [ ] Verify `revision.start_date` and `end_date` are correct after migration
- [ ] Check publisher dimension preview shows "1st April" for financial year start dates
- [ ] Check consumer About tab shows correct coverage period (e.g. "April 2013 to March 2024")
