### PR TITLE
SW-1215: scope session middleware to auth routes, improve Redis error handling

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,10 +14,10 @@ const config: Config = {
   // add threshold to ensure we don't drop below the current level of coverage
   coverageThreshold: {
     global: {
-      statements: 57,
-      branches: 43,
-      functions: 52,
-      lines: 56,
+      statements: 61,
+      branches: 49,
+      functions: 57,
+      lines: 61,
     },
   },
   coveragePathIgnorePatterns: [

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,6 @@ app.set('trust proxy', 1);
 app.use(httpLogger);
 app.use(i18nextMiddleware.handle(i18next));
 app.use(cookieParser());
-app.use(session);
 app.use(requestContext);
 app.use(strictTransport);
 app.use(initServices);
@@ -53,7 +52,7 @@ app.get('/', rateLimiter, (req: Request, res: Response) => {
   res.json({ message: 'success' }); // prevent 404s on root path (avoids logs being flooded with 404s)
 });
 
-app.use('/auth', rateLimiter, authRouter);
+app.use('/auth', rateLimiter, session, authRouter);
 app.use('/healthcheck', rateLimiter, healthcheckRouter);
 app.use('/docs', rateLimiter, combinedDocRouter);
 app.use('/v1/docs', rateLimiter, apiDocRouter);

--- a/src/middleware/session.ts
+++ b/src/middleware/session.ts
@@ -1,5 +1,6 @@
 import { RedisStore } from 'connect-redis';
 import session, { MemoryStore, Store } from 'express-session';
+import { NextFunction, Request, Response } from 'express';
 import { createClient } from 'redis';
 
 import { config } from '../config';
@@ -7,11 +8,13 @@ import { logger } from '../utils/logger';
 import { SessionStore } from '../config/session-store.enum';
 
 let store: Store;
+let redisClient: ReturnType<typeof createClient> | undefined;
+const usingRedis = config.session.store === SessionStore.Redis;
 
-if (config.session.store === SessionStore.Redis) {
+if (usingRedis) {
   logger.debug('Initializing Redis session store...');
 
-  const redisClient = createClient({
+  redisClient = createClient({
     url: config.session.redisUrl,
     password: config.session.redisPassword,
     disableOfflineQueue: true,
@@ -35,7 +38,7 @@ if (config.session.store === SessionStore.Redis) {
   store = new MemoryStore({});
 }
 
-export default session({
+const sessionMiddleware = session({
   secret: config.session.secret,
   name: 'statswales.backend',
   store,
@@ -47,3 +50,28 @@ export default session({
     maxAge: config.session.maxAge
   }
 });
+
+export interface SessionStoreStatus {
+  type: 'redis' | 'memory';
+  connected: boolean;
+}
+
+export const getSessionStoreStatus = (): SessionStoreStatus => {
+  return {
+    type: usingRedis ? 'redis' : 'memory',
+    connected: redisClient ? redisClient.isReady : true
+  };
+};
+
+export default (req: Request, res: Response, next: NextFunction): void => {
+  sessionMiddleware(req, res, (err?: unknown) => {
+    if (err) {
+      const sessionError = Object.assign(new Error('errors.session_store_unavailable'), {
+        status: 503,
+        cause: err
+      });
+      return next(sessionError);
+    }
+    next();
+  });
+};

--- a/src/middleware/session.ts
+++ b/src/middleware/session.ts
@@ -30,7 +30,7 @@ if (usingRedis) {
 
   redisClient.on('connect', () => logger.info('Redis session store initialized'));
   redisClient.on('error', (err) => logger.error(err, `Redis error`));
-  redisClient.connect();
+  redisClient.connect().catch((err) => logger.error(err, 'Redis initial connection failed, will retry'));
 
   store = new RedisStore({ client: redisClient, prefix: 'sw3b:' });
 } else {
@@ -66,11 +66,14 @@ export const getSessionStoreStatus = (): SessionStoreStatus => {
 export default (req: Request, res: Response, next: NextFunction): void => {
   sessionMiddleware(req, res, (err?: unknown) => {
     if (err) {
-      const sessionError = Object.assign(new Error('errors.session_store_unavailable'), {
-        status: 503,
-        cause: err
-      });
-      return next(sessionError);
+      if (redisClient && !redisClient.isReady) {
+        const sessionError = Object.assign(new Error('errors.session_store_unavailable'), {
+          status: 503,
+          cause: err
+        });
+        return next(sessionError);
+      }
+      return next(err);
     }
     next();
   });

--- a/src/routes/error-handler.ts
+++ b/src/routes/error-handler.ts
@@ -31,6 +31,11 @@ export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: R
       res.status(404);
       break;
 
+    case 503:
+      logger.warn(err, `503 service unavailable for ${req.originalUrl}: ${message}`);
+      res.status(503);
+      break;
+
     case 500:
     default:
       logger.error(err, `unknown error detected for ${req.originalUrl}: ${message}`);

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -6,6 +6,7 @@ import { User } from '../entities/user/user';
 import { dbManager } from '../db/database-manager';
 import { logger } from '../utils/logger';
 import { SUPPORTED_LOCALES } from '../middleware/translation';
+import { getSessionStoreStatus } from '../middleware/session';
 import { StorageService } from '../interfaces/storage-service';
 import { Locale } from '../enums/locale';
 import { UserDTO } from '../dtos/user/user-dto';
@@ -91,7 +92,7 @@ const checkConnections = async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
-  res.json({ message: 'success' });
+  res.json({ message: 'success', sessionStore: getSessionStoreStatus() });
 };
 
 healthcheck.get('/', (req: Request, res: Response) => {

--- a/test/middleware/session-redis.test.ts
+++ b/test/middleware/session-redis.test.ts
@@ -1,0 +1,126 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+jest.mock('../../src/config', () => ({
+  config: {
+    session: {
+      store: 'redis',
+      secret: 'test-secret',
+      secure: false,
+      maxAge: 86400000,
+      redisUrl: 'redis://localhost',
+      redisPassword: ''
+    }
+  }
+}));
+
+// Control the fake Redis client from tests
+const fakeRedisClient = {
+  isReady: true,
+  on: jest.fn(),
+  connect: jest.fn().mockResolvedValue(undefined)
+};
+
+jest.mock('redis', () => ({
+  createClient: jest.fn(() => fakeRedisClient)
+}));
+
+// Control what error (if any) the session middleware calls back with
+let storeError: Error | null = null;
+
+jest.mock('express-session', () => {
+  // Return a factory that produces controllable middleware
+  const factory = (): express.RequestHandler => {
+    return (_req, _res, cb) => {
+      if (storeError) {
+        cb(storeError);
+      } else {
+        cb();
+      }
+    };
+  };
+  factory.MemoryStore = jest.fn();
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  return { __esModule: true, default: factory, MemoryStore: factory.MemoryStore };
+});
+
+jest.mock('connect-redis', () => ({
+  RedisStore: jest.fn()
+}));
+
+import sessionMiddleware, { getSessionStoreStatus } from '../../src/middleware/session';
+
+function createApp(): express.Express {
+  const errorCapture = jest.fn();
+  const app = express();
+  app.use(sessionMiddleware);
+  app.get('/test', (_req: Request, res: Response) => {
+    res.status(200).json({ message: 'ok' });
+  });
+  app.use((err: any, _req: Request, res: Response, _next: express.NextFunction) => {
+    errorCapture(err);
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  (app as any).errorCapture = errorCapture;
+  return app;
+}
+
+describe('session middleware (redis store)', () => {
+  afterEach(() => {
+    storeError = null;
+    fakeRedisClient.isReady = true;
+  });
+
+  test('passes requests through when Redis is healthy', async () => {
+    const app = createApp();
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'ok' });
+  });
+
+  test('returns 503 when Redis is not ready and store errors', async () => {
+    fakeRedisClient.isReady = false;
+    storeError = new Error('ECONNREFUSED');
+
+    const app = createApp();
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('errors.session_store_unavailable');
+    expect((app as any).errorCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 503,
+        message: 'errors.session_store_unavailable'
+      })
+    );
+  });
+
+  test('forwards error as-is when Redis is ready but store errors', async () => {
+    fakeRedisClient.isReady = true;
+    storeError = new Error('unexpected store error');
+
+    const app = createApp();
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('unexpected store error');
+    expect((app as any).errorCapture).not.toHaveBeenCalledWith(expect.objectContaining({ status: 503 }));
+  });
+
+  test('getSessionStoreStatus reports redis type with live isReady state', () => {
+    fakeRedisClient.isReady = true;
+    expect(getSessionStoreStatus()).toEqual({ type: 'redis', connected: true });
+
+    fakeRedisClient.isReady = false;
+    expect(getSessionStoreStatus()).toEqual({ type: 'redis', connected: false });
+  });
+});

--- a/test/middleware/session.test.ts
+++ b/test/middleware/session.test.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { Request, Response } from 'express';
 import request from 'supertest';
 
 jest.mock('../../src/utils/logger', () => ({
@@ -10,8 +10,6 @@ jest.mock('../../src/utils/logger', () => ({
   }
 }));
 
-// Mock the config before importing session — CI uses MemoryStore,
-// so we test the wrapper behaviour with a custom failing store.
 jest.mock('../../src/config', () => ({
   config: {
     session: {
@@ -25,75 +23,21 @@ jest.mock('../../src/config', () => ({
 
 import sessionMiddleware, { getSessionStoreStatus, SessionStoreStatus } from '../../src/middleware/session';
 
-function createApp(
-  middleware: (req: Request, res: Response, next: NextFunction) => void,
-  errorHandler?: express.ErrorRequestHandler
-): express.Express {
-  const app = express();
-  app.use(middleware);
-  app.get('/test', (_req: Request, res: Response) => {
-    res.status(200).json({ message: 'ok' });
-  });
-  if (errorHandler) {
-    app.use(errorHandler);
-  }
-  return app;
-}
-
-describe('session middleware', () => {
-  describe('with memory store', () => {
-    test('passes requests through when store is healthy', async () => {
-      const app = createApp(sessionMiddleware);
-      const res = await request(app).get('/test');
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ message: 'ok' });
+describe('session middleware (memory store)', () => {
+  test('passes requests through when store is healthy', async () => {
+    const app = express();
+    app.use(sessionMiddleware);
+    app.get('/test', (_req: Request, res: Response) => {
+      res.status(200).json({ message: 'ok' });
     });
 
-    test('getSessionStoreStatus returns memory type with connected true', () => {
-      const status: SessionStoreStatus = getSessionStoreStatus();
-      expect(status).toEqual({ type: 'memory', connected: true });
-    });
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'ok' });
   });
 
-  describe('store error handling', () => {
-    test('returns 503 when session store errors', async () => {
-      // Create a middleware that simulates a store error by wrapping
-      // the session callback with an error
-      const failingMiddleware = (_req: Request, _res: Response, next: NextFunction): void => {
-        next(new Error('ECONNREFUSED'));
-      };
-
-      const errorCapture = jest.fn();
-      const errorHandler: express.ErrorRequestHandler = (err, _req, res, _next) => {
-        errorCapture(err);
-        res.status(err.status || 500).json({ error: err.message });
-      };
-
-      // Simulate what the session wrapper does: intercept store errors and convert to 503
-      const wrapperMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-        failingMiddleware(req, res, (err?: unknown) => {
-          if (err) {
-            const sessionError = Object.assign(new Error('errors.session_store_unavailable'), {
-              status: 503,
-              cause: err
-            });
-            return next(sessionError);
-          }
-          next();
-        });
-      };
-
-      const wrappedApp = createApp(wrapperMiddleware, errorHandler);
-      const res = await request(wrappedApp).get('/test');
-
-      expect(res.status).toBe(503);
-      expect(res.body.error).toBe('errors.session_store_unavailable');
-      expect(errorCapture).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: 503,
-          message: 'errors.session_store_unavailable'
-        })
-      );
-    });
+  test('getSessionStoreStatus returns memory type with connected true', () => {
+    const status: SessionStoreStatus = getSessionStoreStatus();
+    expect(status).toEqual({ type: 'memory', connected: true });
   });
 });

--- a/test/middleware/session.test.ts
+++ b/test/middleware/session.test.ts
@@ -1,0 +1,99 @@
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Mock the config before importing session — CI uses MemoryStore,
+// so we test the wrapper behaviour with a custom failing store.
+jest.mock('../../src/config', () => ({
+  config: {
+    session: {
+      store: 'memory',
+      secret: 'test-secret',
+      secure: false,
+      maxAge: 86400000
+    }
+  }
+}));
+
+import sessionMiddleware, { getSessionStoreStatus, SessionStoreStatus } from '../../src/middleware/session';
+
+function createApp(
+  middleware: (req: Request, res: Response, next: NextFunction) => void,
+  errorHandler?: express.ErrorRequestHandler
+): express.Express {
+  const app = express();
+  app.use(middleware);
+  app.get('/test', (_req: Request, res: Response) => {
+    res.status(200).json({ message: 'ok' });
+  });
+  if (errorHandler) {
+    app.use(errorHandler);
+  }
+  return app;
+}
+
+describe('session middleware', () => {
+  describe('with memory store', () => {
+    test('passes requests through when store is healthy', async () => {
+      const app = createApp(sessionMiddleware);
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ message: 'ok' });
+    });
+
+    test('getSessionStoreStatus returns memory type with connected true', () => {
+      const status: SessionStoreStatus = getSessionStoreStatus();
+      expect(status).toEqual({ type: 'memory', connected: true });
+    });
+  });
+
+  describe('store error handling', () => {
+    test('returns 503 when session store errors', async () => {
+      // Create a middleware that simulates a store error by wrapping
+      // the session callback with an error
+      const failingMiddleware = (_req: Request, _res: Response, next: NextFunction): void => {
+        next(new Error('ECONNREFUSED'));
+      };
+
+      const errorCapture = jest.fn();
+      const errorHandler: express.ErrorRequestHandler = (err, _req, res, _next) => {
+        errorCapture(err);
+        res.status(err.status || 500).json({ error: err.message });
+      };
+
+      // Simulate what the session wrapper does: intercept store errors and convert to 503
+      const wrapperMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+        failingMiddleware(req, res, (err?: unknown) => {
+          if (err) {
+            const sessionError = Object.assign(new Error('errors.session_store_unavailable'), {
+              status: 503,
+              cause: err
+            });
+            return next(sessionError);
+          }
+          next();
+        });
+      };
+
+      const wrappedApp = createApp(wrapperMiddleware, errorHandler);
+      const res = await request(wrappedApp).get('/test');
+
+      expect(res.status).toBe(503);
+      expect(res.body.error).toBe('errors.session_store_unavailable');
+      expect(errorCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 503,
+          message: 'errors.session_store_unavailable'
+        })
+      );
+    });
+  });
+});

--- a/test/routes/healthcheck.test.ts
+++ b/test/routes/healthcheck.test.ts
@@ -45,10 +45,11 @@ describe('Healthcheck', () => {
   });
 
   describe('Server readiness', () => {
-    test('/healthcheck/ready returns success', async () => {
+    test('/healthcheck/ready returns success with session store status', async () => {
       const res = await request(app).get('/healthcheck/ready');
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ message: 'success' });
+      expect(res.body.message).toBe('success');
+      expect(res.body.sessionStore).toEqual({ type: 'memory', connected: true });
     });
   });
 


### PR DESCRIPTION
## Summary

- Session middleware was applied globally to all routes but is only needed by `/auth` (for the EntraID OAuth PKCE flow via `openid-client`). Moved it from global middleware to the `/auth` route only, so a Redis outage no longer affects the public API, healthcheck, or JWT-authenticated routes.
- Wrapped the session middleware to catch Redis store errors and return a 503 with `errors.session_store_unavailable` instead of a generic 500.
- Added 503 handling to the error handler.
- Added session store status (`type` + `connected`) to the `/healthcheck/ready` response as an informational field (does not gate readiness).
- Uses `redisClient.isReady` for live connection status — correctly reflects state during transient outages and after recovery.

## Test plan

- [x] New unit tests for session middleware wrapper (memory store passthrough, 503 on store error, status reporting)
- [x] Updated healthcheck test to expect `sessionStore` field
- [x] Manual: stop Valkey, confirm public API routes still respond
- [x] Manual: with Valkey stopped, hit `/auth/entraid` — expect 503
- [x] Manual: restart Valkey, confirm `/healthcheck/ready` shows `connected: true`

Closes SW-1215
