### PR TITLE
SW-1191: Remove 'ar' from Welsh rolling year translations

### DIFF
--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -196,22 +196,22 @@
       "rolling": "Mis Treigl"
     },
     "rolling": {
-      "10_year_ending": "10 mlynedd yn gorffen ar {{date}}",
-      "9_year_ending": "9 mlynedd yn gorffen ar {{date}}",
-      "8_year_ending": "8 mlynedd yn gorffen ar {{date}}",
-      "7_year_ending": "7 mlynedd yn gorffen ar {{date}}",
-      "6_year_ending": "6 mlynedd yn gorffen ar {{date}}",
-      "5_year_ending": "5 mlynedd yn gorffen ar {{date}}",
-      "4_year_ending": "4 blynedd yn gorffen ar {{date}}",
-      "3_year_ending": "3 blynedd yn gorffen ar {{date}}",
-      "2_year_ending": "2 flynedd yn gorffen ar {{date}}",
-      "1_year_ending": "Blwyddyn yn gorffen ar {{date}}",
-      "year_ending": "Blwyddyn yn gorffen ar {{date}}",
-      "half_year_ending": "Hanner blwyddyn yn gorffen ar {{date}}",
-      "quarter_ending": "Chwarter yn gorffen ar {{date}}",
-      "month_ending": "Mis yn gorffen ar {{date}}",
-      "fortnight_ending": "Pythefnos yn gorffen ar {{date}}",
-      "week_ending": "Wythnos yn gorffen ar {{date}}"
+      "10_year_ending": "10 mlynedd yn gorffen {{date}}",
+      "9_year_ending": "9 mlynedd yn gorffen {{date}}",
+      "8_year_ending": "8 mlynedd yn gorffen {{date}}",
+      "7_year_ending": "7 mlynedd yn gorffen {{date}}",
+      "6_year_ending": "6 blynedd yn gorffen {{date}}",
+      "5_year_ending": "5 mlynedd yn gorffen {{date}}",
+      "4_year_ending": "4 blynedd yn gorffen {{date}}",
+      "3_year_ending": "3 blynedd yn gorffen {{date}}",
+      "2_year_ending": "2 flynedd yn gorffen {{date}}",
+      "1_year_ending": "Blwyddyn yn gorffen {{date}}",
+      "year_ending": "Blwyddyn yn gorffen {{date}}",
+      "half_year_ending": "Hanner blwyddyn yn gorffen {{date}}",
+      "quarter_ending": "Chwarter yn gorffen {{date}}",
+      "month_ending": "Mis yn gorffen {{date}}",
+      "fortnight_ending": "Pythefnos yn gorffen {{date}}",
+      "week_ending": "Wythnos yn gorffen {{date}}"
     }
   },
   "months": {


### PR DESCRIPTION
## Summary

- SW-1191: Welsh language review confirmed `gorffen` should not be followed by `ar` before a date.
- Removes `ar` from all 16 `date_format.rolling.*` strings in `cy.json` (e.g. `10 mlynedd yn gorffen ar {{date}}` → `10 mlynedd yn gorffen {{date}}`).
- Also fixes the 6-year mutation: `6 mlynedd` → `6 blynedd` (spotted during the same review).
- No code changes — consumers in `src/services/date-matching.ts` already look these up via the `date_format.rolling.*` keys.

## Test plan

- [x] `npm run check` passes (prettier, lint, 937 tests, build).
- [ ] After deploy, view any rolling-period dataset in Welsh (`cy-GB`) and confirm labels read `N mlynedd/blynedd/flynedd yn gorffen <date>` with no `ar`, and that 6-year rolling shows `6 blynedd yn gorffen …`.
