### PR TITLE
SW-1233: groundwork for switching to pg_bouncer transaction mode

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -17,8 +17,10 @@ JWT_SECRET=
 JWT_EXPIRES_IN=
 
 # app database
+# Use port 5432 for direct Postgres access, or 6432 to connect via the local PgBouncer
+# container (transaction mode, mirrors prod). Migrations are safe on either port.
 DB_HOST=localhost
-DB_PORT=5432
+DB_PORT=6432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE=statswales-backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,22 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: statswales-backend
 
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    ports:
+      - "6432:5432"
+    environment:
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: db-dev
+      DB_PORT: 5432
+      DB_NAME: statswales-backend
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 100
+      AUTH_TYPE: scram-sha-256
+    depends_on:
+      - db-dev
+
   db-test:
     image: postgres:17
     ports:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest --coverage",
     "test:ci": "jest --ci --coverage --config=jest.config.ts --maxWorkers=2",
     "check": "npm-run-all prettier:fix lint:fix test clean build",
-    "predev": "docker-compose up -d blobstorage db-dev valkey clamav",
+    "predev": "docker-compose up -d blobstorage db-dev pgbouncer valkey clamav",
     "dev:check": "npm-run-all check dev",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts | pino-colada",
     "start": "node dist/server.js",

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -62,7 +62,7 @@ export const getDefaultConfig = (): AppConfig => {
       database: process.env.DB_DATABASE!,
       ssl: true,
       synchronize: false,
-      poolSize: parseInt(process.env.DB_POOL_SIZE || '10', 10),
+      poolSize: parseInt(process.env.DB_POOL_SIZE || '25', 10),
       maxUses: parseInt(process.env.DB_MAX_USES || '7500', 10),
       idleTimeoutMs: parseInt(process.env.DB_IDLE_TIMEOUT_MS || '10000', 10),
       connectionTimeoutMs: parseInt(process.env.DB_CONNECTION_TIMEOUT_MS || '2000', 10),

--- a/src/repositories/dataset-stats.ts
+++ b/src/repositories/dataset-stats.ts
@@ -322,15 +322,16 @@ export const DatasetStatsRepository = dataSource.getRepository(Dataset).extend({
       WITH latest_revisions AS (
         ${latestPublishedRevisionsQuery}
       )
-      SELECT similarity(rm1.title, rm2.title) AS similarity_score, rm1.title AS title_1, rm2.title AS title_2
+      SELECT s.similarity_score, rm1.title AS title_1, rm2.title AS title_2
       FROM revision_metadata rm1
       JOIN revision_metadata rm2 ON rm1.revision_id <> rm2.revision_id
-      AND similarity(rm1.title, rm2.title) >= 0.6
-      WHERE LOWER(rm1.language) = $1
+      CROSS JOIN LATERAL (SELECT similarity(rm1.title, rm2.title)) AS s(similarity_score)
+      WHERE s.similarity_score >= 0.6
+        AND LOWER(rm1.language) = $1
         AND LOWER(rm2.language) = $1
         AND rm1.revision_id IN (SELECT id FROM latest_revisions)
         AND rm2.revision_id IN (SELECT id FROM latest_revisions)
-      ORDER  BY similarity_score DESC`,
+      ORDER BY s.similarity_score DESC`,
       [lang]
     );
 

--- a/src/repositories/dataset-stats.ts
+++ b/src/repositories/dataset-stats.ts
@@ -317,8 +317,6 @@ export const DatasetStatsRepository = dataSource.getRepository(Dataset).extend({
   async similarTitles(locale: Locale): Promise<SimilarTitlesResult[]> {
     const lang = locale.includes('en') ? 'en-gb' : 'cy-gb';
 
-    await this.query(`SET pg_trgm.similarity_threshold = 0.6`);
-
     const results: SimilarTitlesResult[] = await this.query(
       `
       WITH latest_revisions AS (
@@ -327,7 +325,7 @@ export const DatasetStatsRepository = dataSource.getRepository(Dataset).extend({
       SELECT similarity(rm1.title, rm2.title) AS similarity_score, rm1.title AS title_1, rm2.title AS title_2
       FROM revision_metadata rm1
       JOIN revision_metadata rm2 ON rm1.revision_id <> rm2.revision_id
-      AND rm1.title % rm2.title
+      AND similarity(rm1.title, rm2.title) >= 0.6
       WHERE LOWER(rm1.language) = $1
         AND LOWER(rm2.language) = $1
         AND rm1.revision_id IN (SELECT id FROM latest_revisions)

--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -350,10 +350,6 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
     const lang = locale.includes('en') ? Locale.EnglishGb : Locale.WelshGb;
     const offset = page && limit ? (page - 1) * limit : undefined;
     const baseQuery = getBaseSearchQuery(lang);
-    const similarityThreshold = 0.7;
-
-    await this.query(`SET pg_trgm.similarity_threshold = ${similarityThreshold}`);
-
     if (locale.includes('en') && !forceSimple) {
       baseQuery.andWhere(`pr.fts @@ websearch_to_tsquery('english', :keywords)`);
     } else {

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -30,6 +30,7 @@ export async function sendCsv(query: string, queryStore: QueryStore, res: Respon
   let hasData = false;
 
   try {
+    await cubeDBConn.query('BEGIN');
     dbStream = cubeDBConn.query(new QueryStream(query, [], { highWaterMark: HIGH_WATER_MARK }));
     dbStream.on('data', () => (hasData = true));
 
@@ -40,11 +41,13 @@ export async function sendCsv(query: string, queryStore: QueryStore, res: Respon
 
     await pipeline(dbStream, csvStream, res, { end: false });
 
+    await cubeDBConn.query('COMMIT');
     if (!hasData) {
       res.write('\n'); // Write a newline for empty CSV to avoid zero-byte file issues in some clients
     }
     res.end();
   } catch (err) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(err, `Error sending CSV for query id ${queryStore.id}`);
     dbStream?.destroy();
     if (!res.headersSent) {
@@ -62,6 +65,7 @@ export async function sendExcel(query: string, queryStore: QueryStore, res: Resp
   let dbStream: QueryStream | null = null;
 
   try {
+    await cubeDBConn.query('BEGIN');
     dbStream = cubeDBConn.query(new QueryStream(query, [], { highWaterMark: HIGH_WATER_MARK }));
 
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
@@ -106,7 +110,9 @@ export async function sendExcel(query: string, queryStore: QueryStore, res: Resp
 
     worksheet.commit();
     await workbook.commit();
+    await cubeDBConn.query('COMMIT');
   } catch (err) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(err, `Error sending Excel for query id ${queryStore.id}`);
     dbStream?.destroy();
     if (!res.headersSent) {
@@ -124,6 +130,7 @@ export async function sendJson(query: string, queryStore: QueryStore, res: Respo
   let dbStream: QueryStream | null = null;
 
   try {
+    await cubeDBConn.query('BEGIN');
     dbStream = cubeDBConn.query(new QueryStream(query, [], { highWaterMark: HIGH_WATER_MARK }));
 
     res.setHeader('Content-Type', 'application/json');
@@ -142,8 +149,10 @@ export async function sendJson(query: string, queryStore: QueryStore, res: Respo
     }
 
     res.write(']');
+    await cubeDBConn.query('COMMIT');
     res.end();
   } catch (err) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(err, `Error sending JSON for query id ${queryStore.id}`);
     dbStream?.destroy();
     if (!res.headersSent) {
@@ -161,6 +170,7 @@ export async function sendHtml(query: string, queryStore: QueryStore, res: Respo
   let dbStream: QueryStream | null = null;
 
   try {
+    await cubeDBConn.query('BEGIN');
     dbStream = cubeDBConn.query(new QueryStream(query, [], { highWaterMark: HIGH_WATER_MARK }));
 
     res.setHeader('Content-Type', 'text/html');
@@ -207,8 +217,10 @@ export async function sendHtml(query: string, queryStore: QueryStore, res: Respo
       res.write(`</tbody>`);
     }
     res.write(`</table></body></html>`);
+    await cubeDBConn.query('COMMIT');
     res.end();
   } catch (err) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(err, `Error sending HTML for query id ${queryStore.id}`);
     dbStream?.destroy();
     if (!res.headersSent) {

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -338,12 +338,12 @@ export const createStreamingJSONFilteredView = async (
   const lang = locale.split('-')[0];
   const viewName = checkAvailableViews(view);
   const [cubeDBConn] = (await dbManager.getCubeDataSource().driver.obtainMasterConnection()) as [PoolClient];
-  const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
-    pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
-  );
 
   try {
     await cubeDBConn.query('BEGIN');
+    const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
+      pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
+    );
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -379,6 +379,11 @@ export const createStreamingJSONFilteredView = async (
   } catch (error) {
     await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
+    if (!res.headersSent) {
+      res.status(500).end();
+    } else if (!res.writableEnded) {
+      res.destroy(error instanceof Error ? error : undefined);
+    }
   } finally {
     cubeDBConn.release();
   }
@@ -396,12 +401,12 @@ export const createStreamingCSVFilteredView = async (
   const lang = locale.split('-')[0];
   const viewName = checkAvailableViews(view);
   const [cubeDBConn] = (await dbManager.getCubeDataSource().driver.obtainMasterConnection()) as [PoolClient];
-  const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
-    pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
-  );
 
   try {
     await cubeDBConn.query('BEGIN');
+    const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
+      pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
+    );
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -435,6 +440,11 @@ export const createStreamingCSVFilteredView = async (
   } catch (error) {
     await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
+    if (!res.headersSent) {
+      res.status(500).end();
+    } else if (!res.writableEnded) {
+      res.destroy(error instanceof Error ? error : undefined);
+    }
   } finally {
     cubeDBConn.release();
   }
@@ -452,12 +462,12 @@ export const createStreamingExcelFilteredView = async (
   const lang = locale.split('-')[0];
   const viewName = checkAvailableViews(view);
   const [cubeDBConn] = (await dbManager.getCubeDataSource().driver.obtainMasterConnection()) as [PoolClient];
-  const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
-    pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
-  );
 
   try {
     await cubeDBConn.query('BEGIN');
+    const filterTableColumnQueryResult: QueryResult<FactTableToDimensionName> = await cubeDBConn.query(
+      pgformat('SELECT DISTINCT fact_table_column, dimension_name, language FROM %I.filter_table;', revisionId)
+    );
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -514,6 +524,11 @@ export const createStreamingExcelFilteredView = async (
   } catch (error) {
     await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
+    if (!res.headersSent) {
+      res.status(500).end();
+    } else if (!res.writableEnded) {
+      res.destroy(error instanceof Error ? error : undefined);
+    }
   } finally {
     cubeDBConn.release();
   }
@@ -683,6 +698,11 @@ export const createStreamingPostgresPivotView = async (
   } catch (error) {
     await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
+    if (!res.headersSent) {
+      res.status(500).json({ messages: 'Something went wrong trying to read from the view of the cube' });
+    } else if (!res.writableEnded) {
+      res.destroy(error instanceof Error ? error : undefined);
+    }
   } finally {
     cubeDBConn.release();
   }

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -343,6 +343,7 @@ export const createStreamingJSONFilteredView = async (
   );
 
   try {
+    await cubeDBConn.query('BEGIN');
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -373,8 +374,10 @@ export const createStreamingJSONFilteredView = async (
       rows = await cursor.read(CURSOR_ROW_LIMIT);
     }
     res.write(']');
+    await cubeDBConn.query('COMMIT');
     res.end();
   } catch (error) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
   } finally {
     cubeDBConn.release();
@@ -398,6 +401,7 @@ export const createStreamingCSVFilteredView = async (
   );
 
   try {
+    await cubeDBConn.query('BEGIN');
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -426,8 +430,10 @@ export const createStreamingCSVFilteredView = async (
     } else {
       res.write('\n');
     }
+    await cubeDBConn.query('COMMIT');
     res.end();
   } catch (error) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
   } finally {
     cubeDBConn.release();
@@ -451,6 +457,7 @@ export const createStreamingExcelFilteredView = async (
   );
 
   try {
+    await cubeDBConn.query('BEGIN');
     const coreView = await coreViewChooser(lang, revisionId);
     const selectColumns = await getColumns(revisionId, lang, viewName);
     const baseQuery = createBaseQuery(
@@ -503,7 +510,9 @@ export const createStreamingExcelFilteredView = async (
     }
     worksheet.commit();
     await workbook.commit();
+    await cubeDBConn.query('COMMIT');
   } catch (error) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
   } finally {
     cubeDBConn.release();
@@ -629,6 +638,7 @@ export const createStreamingPostgresPivotView = async (
   // queryRunner.query() does not support Cursor so we need to obtain underlying PostgreSQL connection
   const [cubeDBConn] = (await dbManager.getCubeDataSource().driver.obtainMasterConnection()) as [PoolClient];
   try {
+    await cubeDBConn.query('BEGIN');
     const coreView = await coreViewChooser(lang, revisionId);
     const pivotQuery = createSQLStandardPivotQuery(
       revisionId,
@@ -668,8 +678,10 @@ export const createStreamingPostgresPivotView = async (
     res.write('],');
     res.write(`"Performance" : ${JSON.stringify(performanceObject)}`);
     res.write('}');
+    await cubeDBConn.query('COMMIT');
     res.end();
   } catch (error) {
+    await cubeDBConn.query('ROLLBACK').catch(() => {});
     logger.error(error, 'Something went wrong trying to read from the view of the cube');
   } finally {
     cubeDBConn.release();

--- a/test/integration/repositories/dataset-stats.test.ts
+++ b/test/integration/repositories/dataset-stats.test.ts
@@ -1,14 +1,14 @@
-import { dbManager } from '../../src/db/database-manager';
-import { Dataset } from '../../src/entities/dataset/dataset';
-import { Revision } from '../../src/entities/dataset/revision';
-import { RevisionMetadata } from '../../src/entities/dataset/revision-metadata';
-import { DatasetStatsRepository } from '../../src/repositories/dataset-stats';
-import { getTestUser } from '../helpers/get-test-user';
-import { User } from '../../src/entities/user/user';
-import { uuidV4 } from '../../src/utils/uuid';
-import { Locale } from '../../src/enums/locale';
+import { dbManager } from '../../../src/db/database-manager';
+import { Dataset } from '../../../src/entities/dataset/dataset';
+import { Revision } from '../../../src/entities/dataset/revision';
+import { RevisionMetadata } from '../../../src/entities/dataset/revision-metadata';
+import { DatasetStatsRepository } from '../../../src/repositories/dataset-stats';
+import { getTestUser } from '../../helpers/get-test-user';
+import { User } from '../../../src/entities/user/user';
+import { uuidV4 } from '../../../src/utils/uuid';
+import { Locale } from '../../../src/enums/locale';
 
-jest.mock('../../src/services/blob-storage', () => {
+jest.mock('../../../src/services/blob-storage', () => {
   return function BlobStorage() {
     return {
       getContainerClient: jest.fn().mockReturnValue({

--- a/test/integration/repositories/dataset-stats.test.ts
+++ b/test/integration/repositories/dataset-stats.test.ts
@@ -1,0 +1,210 @@
+import { dbManager } from '../../src/db/database-manager';
+import { Dataset } from '../../src/entities/dataset/dataset';
+import { Revision } from '../../src/entities/dataset/revision';
+import { RevisionMetadata } from '../../src/entities/dataset/revision-metadata';
+import { DatasetStatsRepository } from '../../src/repositories/dataset-stats';
+import { getTestUser } from '../helpers/get-test-user';
+import { User } from '../../src/entities/user/user';
+import { uuidV4 } from '../../src/utils/uuid';
+import { Locale } from '../../src/enums/locale';
+
+jest.mock('../../src/services/blob-storage', () => {
+  return function BlobStorage() {
+    return {
+      getContainerClient: jest.fn().mockReturnValue({
+        createIfNotExists: jest.fn().mockResolvedValue(true)
+      })
+    };
+  };
+});
+
+const user: User = getTestUser('ds-stats-test');
+
+function pastDate(hoursAgo: number): Date {
+  return new Date(Date.now() - hoursAgo * 60 * 60 * 1000);
+}
+
+async function createDataset(createdBy: User, overrides: Partial<Dataset> = {}): Promise<Dataset> {
+  const ds = new Dataset();
+  ds.id = uuidV4();
+  ds.createdBy = createdBy;
+  Object.assign(ds, overrides);
+  return ds.save();
+}
+
+async function createRevision(
+  dataset: Dataset,
+  createdBy: User,
+  revisionIndex: number,
+  overrides: Partial<Revision> = {}
+): Promise<Revision> {
+  const rev = new Revision();
+  rev.id = uuidV4();
+  rev.datasetId = dataset.id;
+  rev.createdBy = createdBy;
+  rev.revisionIndex = revisionIndex;
+  rev.publishAt = null;
+  rev.approvedAt = null;
+  rev.unpublishedAt = null;
+  Object.assign(rev, overrides);
+  return rev.save();
+}
+
+async function createRevisionWithMetadata(
+  dataset: Dataset,
+  createdBy: User,
+  revisionIndex: number,
+  title: string,
+  language: string,
+  overrides: Partial<Revision> = {}
+): Promise<Revision> {
+  const rev = await createRevision(dataset, createdBy, revisionIndex, overrides);
+  const meta = new RevisionMetadata();
+  meta.id = rev.id;
+  meta.language = language;
+  meta.title = title;
+  await meta.save();
+  return rev;
+}
+
+describe('DatasetStatsRepository', () => {
+  beforeAll(async () => {
+    try {
+      await dbManager.initDataSources();
+      await dbManager.getAppDataSource().dropDatabase();
+      await dbManager.getAppDataSource().runMigrations();
+      await user.save();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to initialise test database', err);
+      await dbManager.getAppDataSource().dropDatabase();
+      await dbManager.destroyDataSources();
+      process.exit(1);
+    }
+  });
+
+  afterAll(async () => {
+    await dbManager.getAppDataSource().dropDatabase();
+    await dbManager.destroyDataSources();
+  });
+
+  describe('similarTitles', () => {
+    it('returns default empty result when no published datasets exist', async () => {
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+      expect(result).toEqual([{ similarity_score: 0, title_1: '', title_2: '' }]);
+    });
+
+    it('returns similar English titles for published revisions', async () => {
+      const ds1 = await createDataset(user);
+      const ds2 = await createDataset(user);
+
+      await createRevisionWithMetadata(ds1, user, 1, 'Population Statistics Wales 2023', Locale.EnglishGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+      await createRevisionWithMetadata(ds2, user, 1, 'Population Statistics Wales 2024', Locale.EnglishGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+
+      expect(result.length).toBeGreaterThan(0);
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).toContain('Population Statistics Wales 2023');
+      expect(titles).toContain('Population Statistics Wales 2024');
+      result.forEach((r) => expect(r.similarity_score).toBeGreaterThanOrEqual(0.6));
+    });
+
+    it('excludes pairs where similarity is below 0.6', async () => {
+      const ds1 = await createDataset(user);
+      const ds2 = await createDataset(user);
+
+      await createRevisionWithMetadata(ds1, user, 1, 'Completely Unrelated Agriculture Report', Locale.EnglishGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+      await createRevisionWithMetadata(ds2, user, 1, 'Totally Different Housing Survey', Locale.EnglishGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).not.toContain('Completely Unrelated Agriculture Report');
+      expect(titles).not.toContain('Totally Different Housing Survey');
+    });
+
+    it('excludes unpublished revisions (no approvedAt)', async () => {
+      const ds1 = await createDataset(user);
+      const ds2 = await createDataset(user);
+
+      await createRevisionWithMetadata(ds1, user, 1, 'Draft Similar Title Alpha 2023', Locale.EnglishGb, {
+        approvedAt: null,
+        publishAt: null
+      });
+      await createRevisionWithMetadata(ds2, user, 1, 'Draft Similar Title Alpha 2024', Locale.EnglishGb, {
+        approvedAt: null,
+        publishAt: null
+      });
+
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).not.toContain('Draft Similar Title Alpha 2023');
+      expect(titles).not.toContain('Draft Similar Title Alpha 2024');
+    });
+
+    it('excludes unpublished revisions (unpublishedAt set)', async () => {
+      const ds1 = await createDataset(user);
+      const ds2 = await createDataset(user);
+
+      await createRevisionWithMetadata(ds1, user, 1, 'Withdrawn Similar Report Beta 2023', Locale.EnglishGb, {
+        approvedAt: pastDate(72),
+        publishAt: pastDate(48),
+        unpublishedAt: pastDate(1)
+      });
+      await createRevisionWithMetadata(ds2, user, 1, 'Withdrawn Similar Report Beta 2024', Locale.EnglishGb, {
+        approvedAt: pastDate(72),
+        publishAt: pastDate(48),
+        unpublishedAt: pastDate(1)
+      });
+
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).not.toContain('Withdrawn Similar Report Beta 2023');
+      expect(titles).not.toContain('Withdrawn Similar Report Beta 2024');
+    });
+
+    it('returns Welsh similar titles for Welsh locale', async () => {
+      const ds1 = await createDataset(user);
+      const ds2 = await createDataset(user);
+
+      await createRevisionWithMetadata(ds1, user, 1, 'Ystadegau Poblogaeth Cymru 2023', Locale.WelshGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+      await createRevisionWithMetadata(ds2, user, 1, 'Ystadegau Poblogaeth Cymru 2024', Locale.WelshGb, {
+        approvedAt: pastDate(48),
+        publishAt: pastDate(24)
+      });
+
+      const result = await DatasetStatsRepository.similarTitles(Locale.WelshGb);
+
+      expect(result.length).toBeGreaterThan(0);
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).toContain('Ystadegau Poblogaeth Cymru 2023');
+      expect(titles).toContain('Ystadegau Poblogaeth Cymru 2024');
+    });
+
+    it('does not return Welsh titles for English locale', async () => {
+      const result = await DatasetStatsRepository.similarTitles(Locale.EnglishGb);
+
+      const titles = result.flatMap((r) => [r.title_1, r.title_2]);
+      expect(titles).not.toContain('Ystadegau Poblogaeth Cymru 2023');
+      expect(titles).not.toContain('Ystadegau Poblogaeth Cymru 2024');
+    });
+  });
+});

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -151,7 +151,10 @@ function createMockDbStream(rows: Record<string, unknown>[]): Readable {
 // Helper to create a mock pool client
 function createMockPoolClient(stream: Readable) {
   return {
-    query: jest.fn().mockReturnValue(stream),
+    query: jest.fn().mockImplementation((q: string) => {
+      if (q === 'BEGIN' || q === 'COMMIT' || q === 'ROLLBACK') return Promise.resolve();
+      return stream;
+    }),
     release: mockRelease
   };
 }


### PR DESCRIPTION
Fixes any queries that would cause issues with using transaction mode in pg_bouncer.

Adds a local container running pg_bouncer so we can catch issues in dev before they're deployed.

Bumps the default pool size back to 25.