### PR TITLE
SW-1230 fix missing variable assignment

### DIFF
--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -569,8 +569,8 @@ export const validateMeasureLookupTable = async (
     for (const row of measureTable) {
       let caseStatement = postgresMeasureFormats().get(row.format.toLowerCase())?.method;
       if (caseStatement) {
-        caseStatement
-          .replace('WHEN measure.reference = |REF| THEN ', '')
+        caseStatement = caseStatement
+          .replace('WHEN measure.reference = |REF| THEN', '')
           .replace('|DEC|', row.decimal ? `${row.decimal}` : '0')
           .replace('|ZEROS|', row.decimal ? `.${'0'.repeat(row.decimal)}` : '')
           .replace('|COL|', pgformat('%I.%I', FACT_TABLE_NAME, dataValuesColumn.columnName));


### PR DESCRIPTION
The string was changed but never assigned back to the caseStatement variable to pass through to the select.