### PR TITLE
SW-1235 fix cube preview 404 for datasets with a draft update

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -308,14 +308,19 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
 
   try {
     const endRevision = await RevisionRepository.findOneBy({ id: dataset.endRevisionId });
-    if (!endRevision?.dataTableId) return next(new NotFoundException('errors.no_data_table'));
+
+    // A fresh draft update revision has no dataTable of its own until the user uploads a new file;
+    // preview the currently-published revision in that case so update-in-progress datasets still render.
+    const previewRevisionId = endRevision?.dataTableId ? dataset.endRevisionId : dataset.publishedRevisionId;
+
+    if (!previewRevisionId) return next(new NotFoundException('errors.no_data_table'));
 
     const pageOptions = await parsePageOptions(req);
     const dataOptions = pageOptions.format === OutputFormats.Frontend ? FRONTEND_DATA_OPTIONS : DEFAULT_DATA_OPTIONS;
 
     const queryStore = filterId
       ? await QueryStoreRepository.getById(filterId)
-      : await QueryStoreRepository.getByRequest(dataset.id, dataset.endRevisionId, dataOptions);
+      : await QueryStoreRepository.getByRequest(dataset.id, previewRevisionId, dataOptions);
 
     const query = await buildDataQuery(queryStore, pageOptions);
     await sendFormattedResponse(query, queryStore, pageOptions, res);

--- a/test/unit/controllers/dataset.test.ts
+++ b/test/unit/controllers/dataset.test.ts
@@ -826,7 +826,7 @@ describe('Dataset controller', () => {
       expect(mockNext).toHaveBeenCalledWith(expect.any(BadRequestException));
     });
 
-    it('should return 404 when revision has no data table', async () => {
+    it('should return 404 when end revision has no data table and there is no published revision', async () => {
       const datasetId = uuidV4();
       const endRevisionId = uuidV4();
       const dataset = createMockDataset(datasetId);
@@ -844,7 +844,7 @@ describe('Dataset controller', () => {
       expect((mockNext.mock.calls[0][0] as unknown as NotFoundException).message).toBe('errors.no_data_table');
     });
 
-    it('should return 404 when revision is not found', async () => {
+    it('should return 404 when revision is not found and there is no published revision', async () => {
       const datasetId = uuidV4();
       const endRevisionId = uuidV4();
       const dataset = createMockDataset(datasetId);
@@ -859,6 +859,29 @@ describe('Dataset controller', () => {
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(NotFoundException));
       expect((mockNext.mock.calls[0][0] as unknown as NotFoundException).message).toBe('errors.no_data_table');
+    });
+
+    it('should preview the published revision when a draft update has no data table yet', async () => {
+      const datasetId = uuidV4();
+      const endRevisionId = uuidV4();
+      const publishedRevisionId = uuidV4();
+      const dataset = createMockDataset(datasetId);
+      dataset.endRevisionId = endRevisionId;
+      dataset.publishedRevisionId = publishedRevisionId;
+
+      mockRevisionFindOneBy.mockResolvedValue({ id: endRevisionId, dataTableId: null });
+      mockParsePageOptions.mockResolvedValue({ format: OutputFormats.Frontend });
+      mockQueryStoreGetByRequest.mockResolvedValue({ id: 'qs-1' });
+      mockBuildDataQuery.mockResolvedValue('SELECT 1');
+      mockSendFrontendView.mockResolvedValue(undefined);
+
+      const req = createMockRequest();
+      const res = createMockResponse({ locals: { datasetId, dataset } });
+
+      await datasetPreview(req, res, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockQueryStoreGetByRequest).toHaveBeenCalledWith(datasetId, publishedRevisionId, expect.anything());
     });
 
     it('should proceed when revision has data table', async () => {


### PR DESCRIPTION
## Summary

Fixes SW-1235 — the cube preview page 404s ("You cannot preview this dataset until you have uploaded a data table") as soon as a user starts an update on a published dataset, even if no data has changed.

- `datasetPreview` (`src/controllers/dataset.ts`) resolved the preview against `dataset.endRevisionId`, which points at the just-created draft update revision. Draft revisions are cloned via `RevisionRepository.deepCloneRevision`, which intentionally does not copy `dataTableId` (sharing would break `replaceDataTable`'s delete-on-replace), so the draft has no data table until the user uploads a new file.
- Commit `a2d99aa6` ("404 the preview when no datatable available") then introduced a hard guard that 404s whenever `endRevision.dataTableId` is missing — correct for a brand-new first revision, but wrong while an update is in progress on a dataset that still has a published revision with data.
- Fix: when the draft has no data table of its own, fall back to `dataset.publishedRevisionId` and preview that. Only 404 when neither side has a data table (preserves the original guard for first-revision, pre-upload datasets).

## Test plan

- [x] `npm run check` (format, build, 1011 unit tests) passes locally.
- [x] New unit test: draft `endRevision` with no `dataTableId` + `publishedRevisionId` set → preview proceeds against the published revision id.
- [x] Existing 404 tests kept (renamed for clarity) — no published revision + no data table still returns 404 `errors.no_data_table`.
- [x] Manual: open `/en-GB/publish/<dataset-with-draft-update>/cube-preview` on the publisher — expect the previously-published preview to render instead of the not-found page.
- [ ] Regression: on a brand-new dataset whose first revision has no uploaded data, the same route should still render the not-found / "upload a data table" state.
