### PR TITLE
SW-1235 fallback filters to published revision during draft updates

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -70,6 +70,7 @@ import { DataOptionsDTO, DEFAULT_DATA_OPTIONS, FRONTEND_DATA_OPTIONS } from '../
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { QueryStoreRepository } from '../repositories/query-store';
 import { parsePageOptions } from '../utils/parse-page-options';
+import { resolvePreviewRevisionId } from '../utils/revision';
 import { OutputFormats } from '../enums/output-formats';
 import { buildDataQuery, sendCsv, sendExcel, sendFrontendView, sendJson } from '../services/consumer-view-v2';
 import { QueryStore } from '../entities/query-store';
@@ -308,10 +309,7 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
 
   try {
     const endRevision = await RevisionRepository.findOneBy({ id: dataset.endRevisionId });
-
-    // A fresh draft update revision has no dataTable of its own until the user uploads a new file;
-    // preview the currently-published revision in that case so update-in-progress datasets still render.
-    const previewRevisionId = endRevision?.dataTableId ? dataset.endRevisionId : dataset.publishedRevisionId;
+    const previewRevisionId = resolvePreviewRevisionId(endRevision, dataset);
 
     if (!previewRevisionId) return next(new NotFoundException('errors.no_data_table'));
 

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -41,6 +41,7 @@ import { TempFile } from '../interfaces/temp-file';
 import { DEFAULT_PAGE_SIZE } from '../utils/page-defaults';
 import { attachUpdateDataTableToRevision } from '../services/revision';
 import { performanceReporting } from '../utils/performance-reporting';
+import { resolvePreviewRevisionId } from '../utils/revision';
 import { CubeBuildResult } from '../dtos/cube-build-result';
 import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
 import { BuiltLogEntryDto } from '../dtos/build-log';
@@ -148,12 +149,19 @@ export const getRevisionPreview = async (req: Request, res: Response, next: Next
 
 export const getRevisionPreviewFilters = async (req: Request, res: Response): Promise<void> => {
   const revision: Revision = res.locals.revision;
+  const dataset: Dataset = res.locals.dataset;
   const lang = req.language.length < 5 ? `${req.language}-gb` : req.language.toLowerCase();
   if (!revision) {
     throw new NotFoundException('errors.no_revision');
   }
 
-  const filters = await getFilters(revision.id, lang);
+  const filtersRevisionId = resolvePreviewRevisionId(revision, dataset);
+
+  if (!filtersRevisionId) {
+    throw new NotFoundException('errors.no_data_table');
+  }
+
+  const filters = await getFilters(filtersRevisionId, lang);
   res.json(filters);
 };
 

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -1,4 +1,5 @@
 import { ConsumerRevisionDTO } from '../dtos/consumer-revision-dto';
+import { Dataset } from '../entities/dataset/dataset';
 import { Revision } from '../entities/dataset/revision';
 import { Dimension } from '../entities/dataset/dimension';
 import { DateExtractor } from '../extractors/date-extractor';
@@ -8,6 +9,18 @@ export interface CoverageRange {
   startDate: Date | null;
   endDate: Date | null;
 }
+
+// Fresh draft update revisions (cloned from the published revision via deepCloneRevision) have no data table id
+// yet, so anything that queries the per-revision schema must use the previously-published revision id until the draft
+// has its own data. Use this helper to decide which revision id to query; it returns undefined only when neither side
+// has a cube.
+export const resolvePreviewRevisionId = (
+  revision: Pick<Revision, 'id' | 'dataTableId'> | null | undefined,
+  dataset: Pick<Dataset, 'publishedRevisionId'> | null | undefined
+): string | undefined => {
+  if (revision?.dataTableId) return revision.id;
+  return dataset?.publishedRevisionId;
+};
 
 export const isPublished = (rev: Revision | ConsumerRevisionDTO): boolean => {
   const now = new Date();

--- a/test/unit/controllers/revision.test.ts
+++ b/test/unit/controllers/revision.test.ts
@@ -156,7 +156,8 @@ import {
   getDataTablePreview,
   removeFactTableFromRevision,
   getRevisionBuildLog,
-  getRevisionPreview
+  getRevisionPreview,
+  getRevisionPreviewFilters
 } from '../../../src/controllers/revision';
 import { DataTable } from '../../../src/entities/dataset/data-table';
 import { getFilePreview } from '../../../src/services/incoming-file-processor';
@@ -673,6 +674,56 @@ describe('Revision controller', () => {
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(NotFoundException));
       expect((mockNext.mock.calls[0][0] as unknown as NotFoundException).message).toBe('errors.no_data_table');
+    });
+  });
+
+  describe('getRevisionPreviewFilters', () => {
+    const mockGetFilters = jest.requireMock('../../../src/services/consumer-view').getFilters;
+
+    beforeEach(() => {
+      mockGetFilters.mockReset();
+    });
+
+    it('should return filters against the requested revision when it has a data table', async () => {
+      const revision = createMockRevision({ dataTableId: uuidV4() });
+      const filters = [{ columnName: 'year' }];
+      mockGetFilters.mockResolvedValue(filters);
+
+      const req = createMockRequest();
+      const res = createMockResponse({ locals: { dataset: createMockDataset(), revision } });
+
+      await getRevisionPreviewFilters(req, res);
+
+      expect(mockGetFilters).toHaveBeenCalledWith(revision.id, expect.any(String));
+      expect(res.json).toHaveBeenCalledWith(filters);
+    });
+
+    it('should fall back to the published revision filters when the draft has no data table', async () => {
+      const dataset = createMockDataset();
+      dataset.publishedRevisionId = uuidV4();
+      const revision = createMockRevision({ dataTableId: undefined });
+      const filters = [{ columnName: 'year' }];
+      mockGetFilters.mockResolvedValue(filters);
+
+      const req = createMockRequest();
+      const res = createMockResponse({ locals: { dataset, revision } });
+
+      await getRevisionPreviewFilters(req, res);
+
+      expect(mockGetFilters).toHaveBeenCalledWith(dataset.publishedRevisionId, expect.any(String));
+      expect(res.json).toHaveBeenCalledWith(filters);
+    });
+
+    it('should throw NotFoundException when neither the revision nor a published revision has a data table', async () => {
+      const revision = createMockRevision({ dataTableId: undefined });
+      const req = createMockRequest();
+      const res = createMockResponse({ locals: { dataset: createMockDataset(), revision } });
+
+      await expect(getRevisionPreviewFilters(req, res)).rejects.toMatchObject({
+        name: 'NotFoundException',
+        message: 'errors.no_data_table'
+      });
+      expect(mockGetFilters).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to `#649` (SW-1235 preview fix). The cube-preview page calls `getRevisionFilters(datasetId, endRevisionId)` in the same `Promise.all` as the preview itself, so the same "draft update revision has no cube yet" condition produced an unhandled Postgres `42P01` → 500 on `/dataset/:id/revision/by-id/:revisionId/preview/filters`. With the preview now falling back to the published revision, the filters needed the same treatment to stay consistent and to stop the Promise.all rejecting.

Changes:

- `src/utils/revision.ts` — new `resolvePreviewRevisionId(revision, dataset)` helper encoding the single policy "use the revision's own id if it has a data table, otherwise fall back to `dataset.publishedRevisionId`, otherwise undefined". Comment lives on the helper, not at each call site.
- `src/controllers/revision.ts:149-165` (`getRevisionPreviewFilters`) — uses the helper; returns `errors.no_data_table` only when neither side has a data table.
- `src/controllers/dataset.ts:303-331` (`datasetPreview`) — collapsed onto the same helper, keeping behaviour unchanged.

One named concept, one place to change if the rule shifts later.

## Test plan

- [x] `npm run check` — 57 suites, 1014 tests, build OK.
- [x] New unit tests in `test/unit/controllers/revision.test.ts` for `getRevisionPreviewFilters`: requested revision has data → queries it; draft has no data + published revision exists → queries the published revision; neither has data → 404.
- [x] Frontend e2e (`update-dataset.spec.ts` + `preview-without-data.spec.ts`) pass end-to-end; the `Preview before any changes are made to the update` test remains the active regression guard.
