### PR TITLE
SW-1238 extra test coverage for rolling period-ending codes

### DIFF
--- a/test/unit/controllers/dimension.test.ts
+++ b/test/unit/controllers/dimension.test.ts
@@ -170,16 +170,25 @@ function createMockDimension(overrides: Record<string, unknown> = {}) {
   };
 }
 
+type MockDraftRevision = {
+  id: string;
+  revisionIndex: number;
+  tasks: RevisionTask | null;
+  dataTable: { dataTableDescriptions: unknown[] };
+  save: jest.Mock;
+};
+
 function createMockDataset(id?: string) {
+  const draftRevision: MockDraftRevision = {
+    id: uuidV4(),
+    revisionIndex: 1,
+    tasks: null,
+    dataTable: { dataTableDescriptions: [] },
+    save: jest.fn().mockResolvedValue(undefined)
+  };
   return {
     id: id || uuidV4(),
-    draftRevision: {
-      id: uuidV4(),
-      revisionIndex: 1,
-      tasks: null as RevisionTask | null,
-      dataTable: { dataTableDescriptions: [] },
-      save: jest.fn().mockResolvedValue(undefined)
-    },
+    draftRevision,
     factTable: [{ columnName: 'col1', columnType: 'dimension' }]
   };
 }

--- a/test/unit/controllers/dimension.test.ts
+++ b/test/unit/controllers/dimension.test.ts
@@ -3,6 +3,7 @@ import { Readable } from 'node:stream';
 
 import { UnknownException } from '../../../src/exceptions/unknown.exception';
 import { DimensionType } from '../../../src/enums/dimension-type';
+import { RevisionTask } from '../../../src/interfaces/revision-task';
 import { uuidV4 } from '../../../src/utils/uuid';
 
 // Mock logger
@@ -175,7 +176,7 @@ function createMockDataset(id?: string) {
     draftRevision: {
       id: uuidV4(),
       revisionIndex: 1,
-      tasks: null,
+      tasks: null as RevisionTask | null,
       dataTable: { dataTableDescriptions: [] },
       save: jest.fn().mockResolvedValue(undefined)
     },

--- a/test/unit/services/date-matching.test.ts
+++ b/test/unit/services/date-matching.test.ts
@@ -370,6 +370,64 @@ describe('date-matching', () => {
     });
   });
 
+  // Period-ending codes are supported across four date formats. Parameterise across
+  // format × code so any regression in parseAsUTC/parseISOasUTC or the substring(2)
+  // value extraction fails loudly for every combination.
+  describe('dateDimensionReferenceTableCreator - rolling codes across all 4 date formats', () => {
+    const endDate = utc('2024-03-31T00:00:00Z');
+
+    const formats: Array<{ dateFormat: string; encode: (end: typeof endDate) => string }> = [
+      { dateFormat: 'dd/MM/yyyy', encode: () => '31/03/2024' },
+      { dateFormat: 'dd-MM-yyyy', encode: () => '31-03-2024' },
+      { dateFormat: 'yyyy-MM-dd', encode: () => '2024-03-31' },
+      { dateFormat: 'yyyyMMdd', encode: () => '20240331' }
+    ];
+
+    const rollingCodes: Array<{ code: string; increment: Duration }> = [
+      { code: 'YE', increment: { years: 1 } },
+      { code: 'HE', increment: { months: 6 } },
+      { code: 'QE', increment: { months: 3 } },
+      { code: 'ME', increment: { months: 1 } },
+      { code: 'FE', increment: { weeks: 2 } },
+      { code: 'WE', increment: { weeks: 1 } },
+      { code: '1Y', increment: { years: 1 } },
+      { code: '2Y', increment: { years: 2 } },
+      { code: '5Y', increment: { years: 5 } },
+      { code: '9Y', increment: { years: 9 } },
+      { code: 'XY', increment: { years: 10 } }
+    ];
+
+    for (const { dateFormat, encode } of formats) {
+      describe(`format=${dateFormat}`, () => {
+        const extractor: DateExtractor = { type: YearType.Rolling, dateFormat };
+        const dateStr = encode(endDate);
+
+        test.each(rollingCodes)('$code produces correct span', ({ code, increment }) => {
+          const dateCode = `${code}${dateStr}`;
+          const result = dateDimensionReferenceTableCreator(extractor, [{ dateCode }]);
+          expect(result[0].dateCode).toBe(dateCode);
+          expect(result[0].end).toEqual(endDate);
+          expect(result[0].start).toEqual(sub(add(endDate, { days: 1 }), increment));
+        });
+      });
+    }
+
+    // Negative: separator-joined variants (e.g. YE-2024-03-31) are NOT
+    // supported. Pinning this behaviour so any future change to
+    // substring(2) / value extraction is a deliberate decision.
+    describe('unsupported separator variants', () => {
+      test.each([
+        ['dd/MM/yyyy', 'YE-31/03/2024'],
+        ['dd-MM-yyyy', 'YE-31-03-2024'],
+        ['yyyy-MM-dd', 'YE-2024-03-31'],
+        ['yyyyMMdd', 'YE-20240331']
+      ])('format=%s rejects dash-separated value %s', (dateFormat, dateCode) => {
+        const extractor: DateExtractor = { type: YearType.Rolling, dateFormat };
+        expect(() => dateDimensionReferenceTableCreator(extractor, [{ dateCode }])).toThrow();
+      });
+    });
+  });
+
   describe('dateDimensionReferenceTableCreator - hierarchy linking', () => {
     test('quarter entries link to their parent year code', () => {
       const extractor: DateExtractor = {


### PR DESCRIPTION
## Summary

Background coverage work triggered by SW-1238. The existing `rolling / period-ending dates` tests in `date-matching.test.ts` only exercised the `dd/MM/yyyy` format — the other three supported formats (`dd-MM-yyyy`, `yyyy-MM-dd`, `yyyyMMdd`) had zero coverage against rolling codes, even though `periodDateTableCreator` has switch cases for all four.

- `test/unit/services/date-matching.test.ts` — new `dateDimensionReferenceTableCreator - rolling codes across all 4 date formats` block:
  - **44 positive tests**: 11 rolling codes (YE/HE/QE/ME/FE/WE/1Y/2Y/5Y/9Y/XY) × 4 date formats. Asserts the correct start/end span for each combination.
  - **4 negative tests** pinning current behaviour: dash-separated variants (e.g. `YE-2024-03-31`) are rejected across all 4 formats. Value extraction uses `substring(2)` with no separator-aware handling — and has done since rolling support was introduced — so this guards against an accidental change there.
- `test/unit/controllers/dimension.test.ts` — fixture type widening: `draftRevision.tasks` was inferred as `null`, which made existing tests that assign a real task object fail typecheck. Explicitly annotate as `RevisionTask | null`.

No production code changes.

## Test plan

- [x] `npm run check` passes — 1059 unit tests, build clean, lint clean.
- [x] New tests alone: `npx jest date-matching.test.ts -t "rolling codes across all 4"` — 48 passed.
