### PR TITLE
SW-1227 Validate lookup hierarchies

### DIFF
--- a/src/enums/cube-validation-type.ts
+++ b/src/enums/cube-validation-type.ts
@@ -12,5 +12,6 @@ export enum CubeValidationType {
   NoFirstRevision = 'no_first_revision',
   CubeCreationFailed = 'cube_creation_failed',
   UnknownFileType = 'unknown_file_type',
+  HierarchyError = 'hierarchy_error',
   UnknownError = 'unknown_error'
 }

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -13,7 +13,7 @@ import { FilterTable } from '../interfaces/filter-table';
 import { dbManager } from '../db/database-manager';
 import { QueryStore } from '../entities/query-store';
 import { BadRequestException } from '../exceptions/bad-request.exception';
-import { transformHierarchy } from '../utils/consumer';
+import { flattenHierarchy, transformHierarchy } from '../utils/consumer';
 import { DatasetRepository } from '../repositories/dataset';
 import { PageOptions } from '../interfaces/page-options';
 import { logger } from '../utils/logger';
@@ -258,6 +258,16 @@ export async function sendFilters(query: string, res: Response): Promise<void> {
         continue;
       }
       const hierarchy = transformHierarchy(data[0].fact_table_column, data[0].dimension_name, data);
+      const flattenedHierarchy = flattenHierarchy(hierarchy.values);
+      // If there's a problem with the hierarchy, bin it off
+      if (data.length != flattenedHierarchy.length) {
+        hierarchy.values = data.map((val) => {
+          return {
+            reference: val.reference,
+            description: val.description
+          };
+        });
+      }
       filterData.push(hierarchy);
     }
     res.json(filterData);

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -9,6 +9,7 @@ import {
   columnIdentification,
   convertDataTableToLookupTable,
   lookForPossibleJoinColumn,
+  validateLookupTableHierarchyValues,
   validateLookupTableLanguages
 } from '../utils/lookup-table-utils';
 import { Dataset } from '../entities/dataset/dataset';
@@ -154,6 +155,20 @@ export const validateLookupTable = async (
     return viewErrorGenerators(500, dataset.id, 'patch', 'errors.dimension_validation.lookup_table_loading_failed', {
       mismatch: false
     });
+  }
+
+  const hierarchyTestResult = await validateLookupTableHierarchyValues(
+    mockCubeId,
+    dataset,
+    factTableColumn.columnName,
+    lookupTable.id,
+    'lookup_table'
+  );
+  if (hierarchyTestResult) {
+    void cleanUpPostgresValidationSchema(mockCubeId, lookupTable.id).catch((err) => {
+      logger.error(err, 'Something went wrong trying to clean up the mock cube');
+    });
+    return hierarchyTestResult;
   }
 
   const languageErrors = await validateLookupTableLanguages(

--- a/src/services/lookup-table-handler.ts
+++ b/src/services/lookup-table-handler.ts
@@ -157,18 +157,18 @@ export const validateLookupTable = async (
     });
   }
 
-  const hierarchyTestResult = await validateLookupTableHierarchyValues(
+  const hierarchyErrors = await validateLookupTableHierarchyValues(
     mockCubeId,
     dataset,
     factTableColumn.columnName,
     lookupTable.id,
     'lookup_table'
   );
-  if (hierarchyTestResult) {
+  if (hierarchyErrors) {
     void cleanUpPostgresValidationSchema(mockCubeId, lookupTable.id).catch((err) => {
       logger.error(err, 'Something went wrong trying to clean up the mock cube');
     });
-    return hierarchyTestResult;
+    return hierarchyErrors;
   }
 
   const languageErrors = await validateLookupTableLanguages(

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -12,6 +12,7 @@ import {
   convertDataTableToLookupTable,
   languageMatcherCaseStatement,
   lookForJoinColumn,
+  validateLookupTableHierarchyValues,
   validateLookupTableLanguages,
   validateLookupTableReferenceValues,
   validateMeasureTableContent
@@ -555,6 +556,18 @@ export const validateMeasureLookupTable = async (
   if (referenceErrors) {
     await lookupTable.remove();
     return referenceErrors;
+  }
+
+  const hierarchyErrors = await validateLookupTableHierarchyValues(
+    draftRevision.id,
+    dataset,
+    'reference',
+    actionId,
+    'measure'
+  );
+  if (hierarchyErrors) {
+    await lookupTable.remove();
+    return hierarchyErrors;
   }
 
   const dataValuesColumn = dataset.factTable?.find((val) => val.columnType === FactTableColumnType.DataValues);

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -558,18 +558,6 @@ export const validateMeasureLookupTable = async (
     return referenceErrors;
   }
 
-  const hierarchyErrors = await validateLookupTableHierarchyValues(
-    draftRevision.id,
-    dataset,
-    'reference',
-    actionId,
-    'measure'
-  );
-  if (hierarchyErrors) {
-    await lookupTable.remove();
-    return hierarchyErrors;
-  }
-
   const dataValuesColumn = dataset.factTable?.find((val) => val.columnType === FactTableColumnType.DataValues);
   if (!dataValuesColumn) {
     return viewErrorGenerators(500, dataset.id, 'patch', `errors.measure_validation.unknown_error`, {
@@ -628,6 +616,18 @@ export const validateMeasureLookupTable = async (
   if (languageErrors) {
     await lookupTable.remove();
     return languageErrors;
+  }
+
+  const hierarchyErrors = await validateLookupTableHierarchyValues(
+    draftRevision.id,
+    dataset,
+    'reference',
+    actionId,
+    'measure'
+  );
+  if (hierarchyErrors) {
+    await lookupTable.remove();
+    return hierarchyErrors;
   }
 
   const tableValidationErrors = await validateMeasureTableContent(dataset.id, draftRevision.id, actionId, extractor);

--- a/src/services/revision.ts
+++ b/src/services/revision.ts
@@ -28,7 +28,7 @@ import {
 import { CubeBuildType } from '../enums/cube-build-type';
 import { Dimension } from '../entities/dataset/dimension';
 import { Dataset } from '../entities/dataset/dataset';
-import { validateLookupTableReferenceValues } from '../utils/lookup-table-utils';
+import { validateLookupTableHierarchyValues, validateLookupTableReferenceValues } from '../utils/lookup-table-utils';
 import { MeasureRow } from '../entities/dataset/measure-row';
 import { DateExtractor } from '../extractors/date-extractor';
 import { config } from '../config';
@@ -273,6 +273,19 @@ async function validateMeasure(
     err.type = CubeValidationType.MeasureNonMatchedRows;
     throw err;
   }
+
+  const hierarchyErrors = await validateLookupTableHierarchyValues(
+    buildId,
+    dataset,
+    'reference',
+    `measure`,
+    'dimension'
+  );
+  if (hierarchyErrors) {
+    const err = new CubeValidationException('Validation failed');
+    err.type = CubeValidationType.HierarchyError;
+    throw err;
+  }
 }
 
 export async function createDateTableInValidationCube(
@@ -324,6 +337,18 @@ async function validateDimension(
   if (referenceErrors) {
     const err = new CubeValidationException('Validation failed');
     err.type = CubeValidationType.DimensionNonMatchedRows;
+    throw err;
+  }
+  const hierarchyErrors = await validateLookupTableHierarchyValues(
+    buildId,
+    dataset,
+    joinColumn,
+    lookupTableName,
+    'dimension'
+  );
+  if (hierarchyErrors) {
+    const err = new CubeValidationException('Validation failed');
+    err.type = CubeValidationType.HierarchyError;
     throw err;
   }
 }

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -10,6 +10,10 @@ import { Locale } from '../enums/locale';
 import { t } from 'i18next';
 import { DataOptionsDTO } from '../dtos/data-options-dto';
 
+export function flattenHierarchy(nodes: FilterValues[]): FilterValues[] {
+  return nodes.flatMap((node) => [node, ...(node.children ? flattenHierarchy(node.children) : [])]);
+}
+
 export function transformHierarchy(factTableColumn: string, columnName: string, input: FilterRow[]): FilterTable {
   const nodeMap = new Map<string, FilterValues>(); // reference → node
   const childrenMap = new Map<string, FilterValues[]>(); // parentRef → children

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -300,7 +300,7 @@ export const validateLookupTableHierarchyValues = async (
   let lookup: FilterRow[];
   try {
     const lookupQuery = pgformat(
-      `SELECT %I as reference, language, %L, %L, %I as description, hierarchy FROM %I.%I where language = 'en-gb';`,
+      `SELECT %I as reference, language, %L as fact_table_column, %L as dimension_name, description, hierarchy FROM %I.%I where language = 'en-gb';`,
       joinColumn,
       joinColumn,
       joinColumn,

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -304,10 +304,10 @@ export const validateLookupTableHierarchyValues = async (
       joinColumn,
       joinColumn,
       joinColumn,
-      joinColumn,
       schemaID,
       lookupTableName
     );
+    logger.trace(`Creating fake filter table by running query: ${lookupQuery}`);
     lookup = await cubeDB.query(lookupQuery);
   } catch (error) {
     logger.error(error, 'Something went wrong trying to get the references and hierarchy from the lookup table');

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -319,7 +319,7 @@ export const validateLookupTableHierarchyValues = async (
   logger.debug(`Hierarchy Length = ${flattenedHierarchyTree.length}, Lookup length = ${lookup.length}`);
   if (flattenedHierarchyTree.length != lookup.length) {
     logger.debug('Flattened hierarchy length does not match table length.  Hierarchy validation failed.');
-    return viewErrorGenerators(400, dataset.id, 'patch', `${validationType}_validation.bad_hierarchy`, {
+    return viewErrorGenerators(400, dataset.id, 'patch', `errors.${validationType}_validation.bad_hierarchy`, {
       mismatch: false
     });
   }

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -29,6 +29,8 @@ import { Dimension } from '../entities/dataset/dimension';
 import { revisionStartAndEndDateFinder } from './revision';
 import { DateDimensionTypes, LookupTableTypes } from '../enums/dimension-type';
 import { RevisionRepository } from '../repositories/revision';
+import { flattenHierarchy, transformHierarchy } from './consumer';
+import { FilterRow } from '../interfaces/filter-row';
 
 export function convertDataTableToLookupTable(dataTable: DataTable): LookupTable {
   const lookupTable = new LookupTable();
@@ -285,6 +287,42 @@ export const validateLookupTableLanguages = async (
     return viewErrorGenerators(500, dataset.id, 'patch', `errors.${validationType}_validation.unknown_error`, {});
   }
   return undefined;
+};
+
+export const validateLookupTableHierarchyValues = async (
+  schemaID: string,
+  dataset: Dataset,
+  joinColumn: string,
+  lookupTableName: string,
+  validationType: string
+): Promise<ViewErrDTO | undefined> => {
+  const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
+  let lookup: FilterRow[];
+  try {
+    const lookupQuery = pgformat(
+      `SELECT %I as reference, language, %L, %L, %I as description, hierarchy FROM %I.%I where language = 'en-gb';`,
+      joinColumn,
+      joinColumn,
+      joinColumn,
+      joinColumn,
+      schemaID,
+      lookupTableName
+    );
+    lookup = await cubeDB.query(lookupQuery);
+  } catch (error) {
+    logger.error(error, 'Something went wrong trying to get the references and hierarchy from the lookup table');
+    return viewErrorGenerators(500, dataset.id, 'patch', 'errors.unknown_error', {});
+  } finally {
+    await cubeDB.release();
+  }
+  const flattenedHierarchyTree = flattenHierarchy(transformHierarchy(joinColumn, joinColumn, lookup).values);
+  logger.debug(`Hierarchy Length = ${flattenedHierarchyTree.length}, Lookup length = ${lookup.length}`);
+  if (flattenedHierarchyTree.length != lookup.length) {
+    logger.debug('Flattened hierarchy length does not match table length.  Hierarchy validation failed.');
+    return viewErrorGenerators(400, dataset.id, 'patch', `${validationType}_validation.bad_hierarchy`, {
+      mismatch: false
+    });
+  }
 };
 
 export const validateLookupTableReferenceValues = async (

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -45,7 +45,15 @@ jest.mock('../../../src/repositories/dataset', () => ({
 
 // Mock consumer utils
 jest.mock('../../../src/utils/consumer', () => ({
-  transformHierarchy: jest.fn((col, dim, data) => ({ column: col, dimension: dim, data }))
+  transformHierarchy: jest.fn((col, dim, data) => ({
+    column: col,
+    dimension: dim,
+    values: data.map((r: { reference: string; description: string }) => ({
+      reference: r.reference,
+      description: r.description
+    }))
+  })),
+  flattenHierarchy: jest.fn((nodes) => nodes ?? [])
 }));
 
 // Mock column headers

--- a/test/unit/services/lookup-table-handler.test.ts
+++ b/test/unit/services/lookup-table-handler.test.ts
@@ -48,6 +48,7 @@ jest.mock('../../../src/utils/lookup-table-utils', () => ({
   convertDataTableToLookupTable: jest.fn(),
   lookForPossibleJoinColumn: jest.fn(),
   validateLookupTableLanguages: jest.fn().mockResolvedValue(null),
+  validateLookupTableHierarchyValues: jest.fn().mockResolvedValue(undefined),
   columnIdentification: jest.fn().mockImplementation((info: { columnName: string }) => ({
     name: info.columnName,
     lang: info.columnName.toLowerCase().includes('cy') ? 'cy-gb' : 'en-gb'

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -99,6 +99,7 @@ jest.mock('../../../src/utils/lookup-table-utils', () => ({
   convertDataTableToLookupTable: jest.fn(),
   lookForJoinColumn: jest.fn(),
   validateLookupTableReferenceValues: jest.fn().mockResolvedValue(null),
+  validateLookupTableHierarchyValues: jest.fn().mockResolvedValue(undefined),
   validateLookupTableLanguages: jest.fn().mockResolvedValue(null),
   validateMeasureTableContent: jest.fn().mockResolvedValue(null),
   columnIdentification: jest.fn().mockImplementation((info: { columnName: string }) => ({


### PR DESCRIPTION
Adds validation code to validate lookup table hierachies.  It does this by gettting the reference values and hierarchy values from the lookup table and turns these in to the hierarchy.  It then proceeds to flatten the hierarchy and compare the length of the result with the original table length.  If they are different it rejects the hierarchy.

Additionally code has been added to the consimer view code which handles the hierarchy with the same length test.  If the lengths are different it returns the filters without a hierarchy.