### PR TITLE
SW-1205 remove indexes from validation cube

### DIFF
--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -596,11 +596,7 @@ function setFactCountInCube(buildId: string): string {
 }
 
 export function createValidationTableQuery(schemaId: string): string {
-  return pgformat(
-    `CREATE TABLE %I.%I (reference TEXT, fact_table_column TEXT, PRIMARY KEY (reference, fact_table_column));`,
-    schemaId,
-    VALIDATION_TABLE_NAME
-  );
+  return pgformat(`CREATE TABLE %I.%I (reference TEXT, fact_table_column TEXT);`, schemaId, VALIDATION_TABLE_NAME);
 }
 
 export function setupValidationTableFromDataset(buildId: string, dataset: Dataset): TransactionBlock {
@@ -616,8 +612,6 @@ export function setupValidationTableFromDataset(buildId: string, dataset: Datase
     unionParts.push(createValidationTableEntries(buildId, dimColumnName));
   }
   statements.push(pgformat('INSERT INTO %I.%I %s;', buildId, VALIDATION_TABLE_NAME, unionParts.join(' UNION ALL ')));
-  statements.push(pgformat(`CREATE INDEX ON %I.%I (reference);`, buildId, VALIDATION_TABLE_NAME));
-  statements.push(pgformat(`CREATE INDEX ON %I.%I (fact_table_column);`, buildId, VALIDATION_TABLE_NAME));
   statements.push(setFactCountInCube(buildId));
   statements.push('COMMIT;');
 

--- a/test/unit/services/cube-builder.test.ts
+++ b/test/unit/services/cube-builder.test.ts
@@ -220,11 +220,6 @@ describe('createValidationTableQuery', () => {
     expect(sql).toContain('reference TEXT');
     expect(sql).toContain('fact_table_column TEXT');
   });
-
-  it('has a composite PRIMARY KEY covering both columns', () => {
-    const sql = createValidationTableQuery('build-123');
-    expect(sql).toMatch(/PRIMARY KEY\s*\(\s*reference\s*,\s*fact_table_column\s*\)/i);
-  });
 });
 
 // ===========================================================================
@@ -281,18 +276,6 @@ describe('setupValidationTableFromDataset', () => {
     expect(insertStmt).toBeDefined();
     expect(insertStmt).toContain('region');
     expect(insertStmt).not.toContain('UNION ALL');
-  });
-
-  it('includes CREATE INDEX statements for reference and fact_table_column', () => {
-    const dataset = makeDataset({ measure: { factTableColumn: 'measure_col' }, dimensions: [] });
-    const result = setupValidationTableFromDataset(buildId, dataset);
-    const indexStmts = result.statements.filter(
-      (s) => s.toUpperCase().includes('CREATE INDEX') && s.includes('validation_table')
-    );
-    expect(indexStmts).toHaveLength(2);
-    const indexText = indexStmts.join(' ');
-    expect(indexText).toContain('reference');
-    expect(indexText).toContain('fact_table_column');
   });
 
   it('includes an INSERT for fact_count in metadata', () => {


### PR DESCRIPTION
Removed the indexes and primary key from the validation cube which allows the cube to build with incomplete or duplicate facts.  This allows the validation code to run properly during the rest of the update journey.