### PR TITLE
Consumer v2 API integration tests + defect fixes

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -46,3 +46,5 @@ jobs:
     - run: npm run lint:ci
     - run: npm run build
     - run: npm run test:ci
+      env:
+        LOG_LEVEL: error

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -287,7 +287,7 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
       dataOptions.options = DEFAULT_DATA_OPTIONS.options;
     }
 
-    const lang = langToLocale(dataOptions.locale);
+    const lang = langToLocale(req.language);
     const filterTable = await getFilterTable(publishedRevision.id);
 
     let xCol = dataOptions.pivot.x;

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -418,7 +418,7 @@ export const listSubTopics = async (req: Request, res: Response, next: NextFunct
   const topicId = req.params.topic_id;
   const lang = req.language as Locale;
 
-  if (topicId && !/\d+/.test(topicId)) {
+  if (topicId && !/^\d+$/.test(topicId)) {
     next(new NotFoundException('errors.invalid_topic_id'));
     return;
   }
@@ -432,8 +432,14 @@ export const listSubTopics = async (req: Request, res: Response, next: NextFunct
     }
   });
 
+  const topic = topicId ? await TopicRepository.findOneBy({ id: parseInt(topicId, 10) }) : undefined;
+
+  if (topicId && !topic) {
+    next(new NotFoundException('errors.topic_not_found'));
+    return;
+  }
+
   try {
-    const topic = topicId ? await TopicRepository.findOneByOrFail({ id: parseInt(topicId, 10) }) : undefined;
     const subTopics = await PublishedDatasetRepository.listPublishedTopics(lang, topicId);
     const parents = topic ? await TopicRepository.getParents(topic.path) : undefined;
     const isLeafTopic = topic && subTopics.length === 0;

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -296,23 +296,23 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
       try {
         xCol = resolveFactColumnToDimension(xCol, lang, filterTable);
       } catch (_) {
-        throw new BadRequestException('X Column not found in dataset');
+        throw new BadRequestException('errors.invalid_pivot_x_column');
       }
       try {
         yCol = resolveFactColumnToDimension(yCol, lang, filterTable);
       } catch (_) {
-        throw new BadRequestException('Y Column not found in dataset');
+        throw new BadRequestException('errors.invalid_pivot_y_column');
       }
     } else {
       try {
         xCol = resolveDimensionToFactTableColumn(xCol, filterTable);
       } catch (_) {
-        throw new BadRequestException('X Column not found in dataset');
+        throw new BadRequestException('errors.invalid_pivot_x_column');
       }
       try {
         yCol = resolveDimensionToFactTableColumn(yCol, filterTable);
       } catch (_) {
-        throw new BadRequestException('Y Column not found in dataset');
+        throw new BadRequestException('errors.invalid_pivot_y_column');
       }
     }
 
@@ -331,7 +331,7 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
         }
 
         if (filterValues.length > 1) {
-          throw new BadRequestException('Non X and Y columns cannot contain multiple values');
+          throw new BadRequestException('errors.pivot_non_axis_multi_value');
         }
       }
     }

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -348,9 +348,12 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
 
     // Backfill totalPivotLines for this query if it has not been computed yet.
     if (queryStore.totalPivotLines == null) {
-      const query = await createPivotQuery(req.language, queryStore, {
+      // queryStore.query is keyed by full locale ('en-GB' / 'cy-GB'), so normalise
+      // before passing — req.language may come in as a short code like 'en'.
+      const locale = langToLocale(req.language);
+      const query = await createPivotQuery(locale, queryStore, {
         format: OutputFormats.Json,
-        locale: req.language as Locale,
+        locale,
         pageNumber: 0,
         sort: [],
         x: dataOptions.pivot.x,

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -380,7 +380,10 @@ export const generateFilterId = async (req: Request, res: Response, next: NextFu
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }
-    logger.error(err, 'Error generating filter ID');
+    logger.error(
+      { err, datasetId: dataset.id, revisionId: publishedRevision.id, body: req.body },
+      'Error generating filter ID'
+    );
     return next(new UnknownException());
   }
 };

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { EntityNotFoundError } from 'typeorm';
 
 import { logger } from '../utils/logger';
 import { Locale } from '../enums/locale';
@@ -160,6 +161,9 @@ export const getPublishedDatasetData = async (req: Request, res: Response, next:
       logger.error(err, 'Error detected fetching data after headers already sent');
       return;
     }
+    if (err instanceof EntityNotFoundError) {
+      return next(new NotFoundException('errors.filter_id_not_found'));
+    }
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }
@@ -189,6 +193,9 @@ export const getPublishedDatasetPivot = async (req: Request, res: Response, next
     const pivotQuery = await createPivotQuery(lang, queryStore, pageOptions);
     await createPivotOutputUsingDuckDB(res, lang, pivotQuery, pageOptions, queryStore);
   } catch (err) {
+    if (err instanceof EntityNotFoundError) {
+      return next(new NotFoundException('errors.filter_id_not_found'));
+    }
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }
@@ -210,12 +217,11 @@ export const getFilterIdDetails = async (req: Request, res: Response, next: Next
       ? await QueryStoreRepository.getById(filterId)
       : await QueryStoreRepository.getByRequest(dataset.id, publishedRevision.id, dataOptions);
 
-    if (!queryStore) {
-      throw new NotFoundException('errors.filter_id_not_found');
-    }
-
     res.status(200).send(QueryStoreDto.fromQueryStore(queryStore));
   } catch (err) {
+    if (err instanceof EntityNotFoundError) {
+      return next(new NotFoundException('errors.filter_id_not_found'));
+    }
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }
@@ -257,6 +263,9 @@ export const getPublishedDatasetPivotFromId = async (
     logger.debug(`Generating pivot query output using query ${pivotQuery}`);
     await createPivotOutputUsingDuckDB(res, lang, pivotQuery, pageOptions, queryStore);
   } catch (err) {
+    if (err instanceof EntityNotFoundError) {
+      return next(new NotFoundException('errors.filter_id_not_found'));
+    }
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -271,66 +271,70 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
   const publishedRevision = await PublishedRevisionRepository.getLatestByDatasetId(dataset.id);
   if (!publishedRevision) return next(new NotFoundException('errors.no_published_revision'));
 
-  const dataOptions = await dtoValidator(PivotOptionsDTO, req.body);
-
-  if (dataOptions.pivot.x.split(',').length > 1 || dataOptions.pivot.y.split(',').length > 1) {
-    throw new BadRequestException('errors.pivot_only_one_column');
-  }
-
-  if (!dataOptions.options) {
-    dataOptions.options = DEFAULT_DATA_OPTIONS.options;
-  }
-
-  const lang = langToLocale(dataOptions.locale);
-  const filterTable = await getFilterTable(publishedRevision.id);
-
-  let xCol = dataOptions.pivot.x;
-  let yCol = dataOptions.pivot.y;
-  if (dataOptions.options?.use_raw_column_names) {
-    try {
-      xCol = resolveFactColumnToDimension(xCol, lang, filterTable);
-    } catch (_) {
-      throw new BadRequestException('X Column not found in dataset');
-    }
-    try {
-      yCol = resolveFactColumnToDimension(yCol, lang, filterTable);
-    } catch (_) {
-      throw new BadRequestException('Y Column not found in dataset');
-    }
-  } else {
-    try {
-      xCol = resolveDimensionToFactTableColumn(xCol, filterTable);
-    } catch (_) {
-      throw new BadRequestException('X Column not found in dataset');
-    }
-    try {
-      yCol = resolveDimensionToFactTableColumn(yCol, filterTable);
-    } catch (_) {
-      throw new BadRequestException('Y Column not found in dataset');
-    }
-  }
-
-  if (dataOptions?.filters && dataOptions?.filters.length > 0) {
-    for (const filter of dataOptions.filters) {
-      let colName = Object.keys(filter)[0];
-      const filterValues = Object.values(filter)[0] as string[];
-      if (dataOptions.options?.use_raw_column_names) {
-        colName = resolveFactColumnToDimension(colName, lang, filterTable);
-      } else {
-        colName = resolveDimensionToFactTableColumn(colName, filterTable);
-      }
-
-      if (colName === xCol || colName === yCol) {
-        continue;
-      }
-
-      if (filterValues.length > 1) {
-        throw new BadRequestException('Non X and Y columns cannot contain multiple values');
-      }
-    }
-  }
-
   try {
+    const dataOptions = await dtoValidator(PivotOptionsDTO, req.body);
+
+    if (!dataOptions.pivot?.x || !dataOptions.pivot?.y) {
+      throw new BadRequestException('errors.invalid_pivot_params');
+    }
+
+    if (dataOptions.pivot.x.split(',').length > 1 || dataOptions.pivot.y.split(',').length > 1) {
+      throw new BadRequestException('errors.pivot_only_one_column');
+    }
+
+    if (!dataOptions.options) {
+      dataOptions.options = DEFAULT_DATA_OPTIONS.options;
+    }
+
+    const lang = langToLocale(dataOptions.locale);
+    const filterTable = await getFilterTable(publishedRevision.id);
+
+    let xCol = dataOptions.pivot.x;
+    let yCol = dataOptions.pivot.y;
+    if (dataOptions.options?.use_raw_column_names) {
+      try {
+        xCol = resolveFactColumnToDimension(xCol, lang, filterTable);
+      } catch (_) {
+        throw new BadRequestException('X Column not found in dataset');
+      }
+      try {
+        yCol = resolveFactColumnToDimension(yCol, lang, filterTable);
+      } catch (_) {
+        throw new BadRequestException('Y Column not found in dataset');
+      }
+    } else {
+      try {
+        xCol = resolveDimensionToFactTableColumn(xCol, filterTable);
+      } catch (_) {
+        throw new BadRequestException('X Column not found in dataset');
+      }
+      try {
+        yCol = resolveDimensionToFactTableColumn(yCol, filterTable);
+      } catch (_) {
+        throw new BadRequestException('Y Column not found in dataset');
+      }
+    }
+
+    if (dataOptions?.filters && dataOptions?.filters.length > 0) {
+      for (const filter of dataOptions.filters) {
+        let colName = Object.keys(filter)[0];
+        const filterValues = Object.values(filter)[0] as string[];
+        if (dataOptions.options?.use_raw_column_names) {
+          colName = resolveFactColumnToDimension(colName, lang, filterTable);
+        } else {
+          colName = resolveDimensionToFactTableColumn(colName, filterTable);
+        }
+
+        if (colName === xCol || colName === yCol) {
+          continue;
+        }
+
+        if (filterValues.length > 1) {
+          throw new BadRequestException('Non X and Y columns cannot contain multiple values');
+        }
+      }
+    }
+
     const queryStore = await QueryStoreRepository.getByRequest(dataset.id, publishedRevision.id, dataOptions);
 
     // Backfill totalPivotLines for this query if it has not been computed yet.
@@ -350,6 +354,9 @@ export const generatePivotFilterId = async (req: Request, res: Response, next: N
     }
     res.json({ filterId: queryStore.id });
   } catch (err) {
+    if (err instanceof NotFoundException || err instanceof BadRequestException) {
+      return next(err);
+    }
     logger.error(err, 'Error generating filter ID');
     return next(new UnknownException());
   }

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -26,7 +26,6 @@ import {
 } from '../services/consumer-view-v2';
 import { Dataset } from '../entities/dataset/dataset';
 import { DataOptionsDTO, DEFAULT_DATA_OPTIONS, FRONTEND_DATA_OPTIONS, PivotOptionsDTO } from '../dtos/data-options-dto';
-import { SingleLanguageRevisionDTO } from '../dtos/consumer/single-language-revision-dto';
 import { PageOptions } from '../interfaces/page-options';
 import { dtoValidator } from '../validators/dto-validator';
 import { QueryStoreRepository } from '../repositories/query-store';
@@ -85,13 +84,6 @@ export const getPublishedDatasetById = async (req: Request, res: Response): Prom
   }
 
   res.json(datasetDTO);
-};
-
-export const getPublishedRevisionById = async (req: Request, res: Response): Promise<void> => {
-  const lang = req.language as Locale;
-  const revision = await PublishedRevisionRepository.getById(res.locals.revision_id);
-  const revisionDto = SingleLanguageRevisionDTO.fromRevision(revision, lang);
-  res.json(revisionDto);
 };
 
 async function parsePivotPageOptions(req: Request, validateXY = true): Promise<PageOptions> {

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -393,7 +393,7 @@ export const getPublishedDatasetFilters = async (req: Request, res: Response, ne
 
   try {
     const locale = req.language as Locale;
-    const query = await getFilterTableQuery(publishedRevision.id, locale);
+    const query = getFilterTableQuery(publishedRevision.id, locale);
     await sendFilters(query, res);
   } catch (err) {
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
@@ -477,7 +477,7 @@ export const listSubTopics = async (req: Request, res: Response, next: NextFunct
   }
 };
 
-export const getPublicationHistory = async (req: Request, res: Response): Promise<void> => {
+export const getPublicationHistory = async (_req: Request, res: Response): Promise<void> => {
   const revisions = await PublishedDatasetRepository.getHistoryById(res.locals.datasetId);
   const revisionDTOs = revisions.map((rev) => ConsumerRevisionDTO.fromRevision(rev));
 

--- a/src/dtos/data-options-dto.ts
+++ b/src/dtos/data-options-dto.ts
@@ -17,11 +17,11 @@ class PivotDTO {
   @IsOptional()
   include_performance: boolean; // Default: false
 
-  @IsString({ each: true })
-  x: string | string[];
+  @IsString()
+  x: string;
 
-  @IsString({ each: true })
-  y: string | string[];
+  @IsString()
+  y: string;
 }
 
 class ColumnOptionsDTO {

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -426,6 +426,7 @@ publicApiV2Router.get(
   getPublishedDatasetPivotFromId
 );
 
+// Debugging-only: returns the default query configuration for the dataset (no filter ID).
 publicApiV2Router.get(
   '/:dataset_id/query/',
   ensurePublishedDataset,

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -52,7 +52,7 @@ export const ensurePublishedDataset = async (req: Request, res: Response, next: 
 
 publicApiV2Router.use(cors()); // allow browser XMLHttpRequests from any domain
 
-publicApiV2Router.use((req: Request, res: Response, next: NextFunction) => {
+publicApiV2Router.use((_req: Request, res: Response, next: NextFunction) => {
   res.vary('Accept-Language'); // vary response cache on language header
   next();
 });
@@ -121,7 +121,11 @@ publicApiV2Router.get(
     #swagger.parameters['$ref'] = ['#/components/parameters/language']
     #swagger.responses[200] = {
       description: 'A list of all top-level topics that have at least one published dataset tagged to them.',
-      schema: { $ref: "#/components/schemas/RootTopics" }
+      content: {
+        'application/json': {
+          schema: { $ref: "#/components/schemas/RootTopics" }
+        }
+      }
     }
   */
   listRootTopics
@@ -146,7 +150,11 @@ publicApiV2Router.get(
     #swagger.responses[200] = {
       description: "A list of what sits under a given topic - either sub-topics or published datasets tagged directly
         to that topic.",
-      schema: { $ref: "#/components/schemas/PublishedTopics" }
+      content: {
+        'application/json': {
+          schema: { $ref: "#/components/schemas/PublishedTopics" }
+        }
+      }
     }
   */
   listSubTopics
@@ -166,7 +174,11 @@ publicApiV2Router.get(
     ]
     #swagger.responses[200] = {
       description: 'A json object containing all metadata for a published dataset',
-      schema: { $ref: "#/components/schemas/Dataset" }
+      content: {
+        'application/json': {
+          schema: { $ref: "#/components/schemas/Dataset" }
+        }
+      }
     }
   */
   getPublishedDatasetById

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -7,7 +7,6 @@ import {
   getPublishedDatasetById,
   listSubTopics,
   listRootTopics,
-  getPublishedRevisionById,
   getPublishedDatasetData,
   getPublishedDatasetFilters,
   generateFilterId,
@@ -20,7 +19,6 @@ import {
 import { NotFoundException } from '../../../exceptions/not-found.exception';
 import { longTimeout } from '../../../middleware/timeout';
 import { PublishedDatasetRepository } from '../../../repositories/published-dataset';
-import { PublishedRevisionRepository } from '../../../repositories/published-revision';
 import { hasError, uuidValidator } from '../../../validators';
 
 export const publicApiV2Router = Router();
@@ -49,31 +47,6 @@ export const ensurePublishedDataset = async (req: Request, res: Response, next: 
     return;
   }
 
-  next();
-};
-
-export const ensurePublishedRevision = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  const revisionIdError = await hasError(uuidValidator('revision_id'), req);
-
-  if (revisionIdError) {
-    next(new NotFoundException('errors.revision_id_invalid'));
-    return;
-  }
-
-  try {
-    logger.debug(`Loading published revision ${req.params.dataset_id}...`);
-    const revision = await PublishedRevisionRepository.getById(req.params.revision_id);
-
-    if (revision.datasetId !== res.locals.datasetId) {
-      throw new Error('revision does not belong to dataset');
-    }
-
-    res.locals.revision_id = revision.id;
-    res.locals.revision = revision;
-  } catch (_err) {
-    next(new NotFoundException('errors.no_revision'));
-    return;
-  }
   next();
 };
 
@@ -197,14 +170,6 @@ publicApiV2Router.get(
     }
   */
   getPublishedDatasetById
-);
-
-publicApiV2Router.get(
-  '/:dataset_id/revision/:revision_id',
-  ensurePublishedDataset,
-  ensurePublishedRevision,
-  /* #swagger.ignore = true */
-  getPublishedRevisionById
 );
 
 publicApiV2Router.get(

--- a/src/routes/consumer/v2/openapi-cy.json
+++ b/src/routes/consumer/v2/openapi-cy.json
@@ -126,11 +126,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/RootTopics"
                 }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootTopics"
-                }
               }
             }
           }
@@ -170,11 +165,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/PublishedTopics"
                 }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/PublishedTopics"
-                }
               }
             }
           }
@@ -202,11 +192,6 @@
             "description": "Gwrthrych JSON sy'n cynnwys yr holl fetadata ar gyfer set ddata gyhoeddedig",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                }
-              },
-              "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/Dataset"
                 }

--- a/src/routes/consumer/v2/openapi-en.json
+++ b/src/routes/consumer/v2/openapi-en.json
@@ -126,11 +126,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/RootTopics"
                 }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/RootTopics"
-                }
               }
             }
           }
@@ -170,11 +165,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/PublishedTopics"
                 }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/PublishedTopics"
-                }
               }
             }
           }
@@ -202,11 +192,6 @@
             "description": "A json object containing all metadata for a published dataset",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dataset"
-                }
-              },
-              "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/Dataset"
                 }

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -7,6 +7,7 @@ import { acquireDuckDB } from './duckdb';
 import { t } from '../middleware/translation';
 import { DuckDBResult, DuckDBValue } from '@duckdb/node-api';
 import { logger } from '../utils/logger';
+import { Locale } from '../enums/locale';
 import { OutputFormats } from '../enums/output-formats';
 import { format as csvFormat } from '@fast-csv/format';
 import ExcelJS from 'exceljs';
@@ -388,17 +389,8 @@ export async function createPivotOutputUsingDuckDB(
   }
 }
 
-export function langToLocale(lang: string): string {
-  if (!lang) return 'en-GB';
-  if (lang.length === 5) lang = lang.substring(0, 2);
-  switch (lang) {
-    case 'en':
-      return 'en-GB';
-    case 'cy':
-      return 'cy-GB';
-    default:
-      return 'en-GB';
-  }
+export function langToLocale(lang: string | undefined | null): Locale {
+  return lang?.toLowerCase().startsWith('cy') ? Locale.WelshGb : Locale.EnglishGb;
 }
 
 export function validateColOnly(columnName: string, locale: string, filterTable: FactTableToDimensionName[]): string {

--- a/test/helpers/seed-published-dataset.ts
+++ b/test/helpers/seed-published-dataset.ts
@@ -224,7 +224,9 @@ export async function seedPublishedDataset(opts: SeedPublishedDatasetOpts): Prom
     await cubeDB.release();
   }
 
-  await createAllCubeFiles(opts.datasetId, opts.revisionId);
+  // awaitMaterialisation=true: tests need core_view_en to exist before they query it.
+  // The default fire-and-forget mode races the POST and 500s on slower CI runners.
+  await createAllCubeFiles(opts.datasetId, opts.revisionId, undefined, undefined, undefined, true);
 
   return { datasetId: opts.datasetId, revisionId: opts.revisionId, dataTableId: opts.dataTableId };
 }
@@ -392,7 +394,7 @@ export async function addPublishedRevision(opts: {
     } finally {
       await cubeDB.release();
     }
-    await createAllCubeFiles(opts.datasetId, revision.id);
+    await createAllCubeFiles(opts.datasetId, revision.id, undefined, undefined, undefined, true);
   }
 
   return revision;

--- a/test/helpers/seed-published-dataset.ts
+++ b/test/helpers/seed-published-dataset.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { format as pgformat } from '@scaleleap/pg-format';
 
 import { User } from '../../src/entities/user/user';
@@ -11,6 +13,11 @@ import { FactTableColumn } from '../../src/entities/dataset/fact-table-column';
 import { FactTableColumnType } from '../../src/enums/fact-table-column-type';
 import { DataTableAction } from '../../src/enums/data-table-action';
 import { FileType } from '../../src/enums/file-type';
+import { Dimension } from '../../src/entities/dataset/dimension';
+import { DimensionMetadata } from '../../src/entities/dataset/dimension-metadata';
+import { LookupTable } from '../../src/entities/dataset/lookup-table';
+import { Measure } from '../../src/entities/dataset/measure';
+import { DimensionType } from '../../src/enums/dimension-type';
 import { cubeDataSource } from '../../src/db/cube-source';
 import { createAllCubeFiles } from '../../src/services/cube-builder';
 
@@ -24,6 +31,47 @@ export interface BilingualText {
 export interface FactColumnSpec {
   name: string;
   datatype: string; // e.g. 'BIGINT', 'DOUBLE PRECISION', 'VARCHAR'
+  /**
+   * Classifies this column for the cube builder. Defaults to Unknown.
+   * Set one column to DataValues so the cube builds as a FullCube (which triggers
+   * setupDimensions and populates filter_table) rather than a BaseCube.
+   */
+  columnType?: FactTableColumnType;
+}
+
+export interface LookupRow {
+  /** Value of the fact-table column this row maps — e.g. 'W06000001' for AreaCode. */
+  reference: string | number;
+  /**
+   * Language short code — 'en' or 'cy'. The helper expands this to the lowercase locale
+   * ('en-gb' / 'cy-gb') used by the cube-builder's filter_table WHERE clause.
+   * Each reference should appear for every language.
+   */
+  language: 'en' | 'cy';
+  description: string;
+  sortOrder?: number;
+  hierarchy?: string | null;
+  notes?: string | null;
+}
+
+const LOCALE_FOR_LANG: Record<'en' | 'cy', string> = {
+  en: 'en-gb',
+  cy: 'cy-gb'
+};
+
+export interface DimensionSpec {
+  /** Fact-table column name being described by this dimension (must also appear in factColumns). */
+  factTableColumn: string;
+  /** Dimension type (LookupTable, DatePeriod, Numeric, ...). Defaults to LookupTable. */
+  type?: DimensionType;
+  /** Required for LookupTable-like types. Fixed ID so tests can reference it. */
+  lookupTableId?: string;
+  /** Postgres type for the reference column in the lookup table — must match the fact column. */
+  referenceDatatype?: string;
+  /** Rows to populate the lookup table with. Provide each reference in both 'en' and 'cy'. */
+  lookupRows?: LookupRow[];
+  /** Optional human-readable name for the dimension. Used as the column label in filter_table. */
+  name?: BilingualText;
 }
 
 export interface SeedPublishedDatasetOpts {
@@ -45,6 +93,8 @@ export interface SeedPublishedDatasetOpts {
   firstPublishedAt?: Date;
   /** Omit userGroup linkage (useful for tests that assert publisher block is absent). */
   skipUserGroup?: boolean;
+  /** Lookup-backed dimensions. Required for v2 filter/pivot tests that resolve columns via filter_table. */
+  dimensions?: DimensionSpec[];
 }
 
 const DEFAULT_FACT_COLUMNS: FactColumnSpec[] = [
@@ -88,7 +138,7 @@ export async function seedPublishedDataset(opts: SeedPublishedDatasetOpts): Prom
       FactTableColumn.create({
         columnName: col.name,
         columnIndex: idx,
-        columnType: FactTableColumnType.Unknown,
+        columnType: col.columnType ?? FactTableColumnType.Unknown,
         columnDatatype: col.datatype
       })
     )
@@ -130,6 +180,20 @@ export async function seedPublishedDataset(opts: SeedPublishedDatasetOpts): Prom
     publishedRevisionId: opts.revisionId
   });
 
+  // If the fact table declares a Measure column, wire up a Measure entity so the cube-builder's
+  // setupMeasuresAndDataValues path doesn't dereference a null `dataset.measure`.
+  const measureColumn = factColumns.find((c) => c.columnType === FactTableColumnType.Measure);
+  if (measureColumn) {
+    await Measure.create({
+      dataset: { id: opts.datasetId } as Dataset,
+      factTableColumn: measureColumn.name,
+      joinColumn: null,
+      extractor: null,
+      lookupTable: null,
+      measureTable: null
+    }).save();
+  }
+
   if (opts.topicIds && opts.topicIds.length > 0) {
     await RevisionTopic.save(
       opts.topicIds.map((topicId) => RevisionTopic.create({ revisionId: opts.revisionId, topicId }))
@@ -152,6 +216,10 @@ export async function seedPublishedDataset(opts: SeedPublishedDatasetOpts): Prom
         await cubeDB.query(`INSERT INTO data_tables."${opts.dataTableId}" VALUES ${valuesSql};`);
       }
     }
+
+    if (opts.dimensions && opts.dimensions.length > 0) {
+      await seedDimensions(opts.datasetId, factColumns, opts.dimensions, cubeDB);
+    }
   } finally {
     await cubeDB.release();
   }
@@ -159,6 +227,92 @@ export async function seedPublishedDataset(opts: SeedPublishedDatasetOpts): Prom
   await createAllCubeFiles(opts.datasetId, opts.revisionId);
 
   return { datasetId: opts.datasetId, revisionId: opts.revisionId, dataTableId: opts.dataTableId };
+}
+
+/**
+ * Creates Dimension + LookupTable entities and populates `lookup_tables.<id>` in the cube with
+ * rows in the SW3 format expected by cube-builder (createLookupTableDimension copies that table
+ * verbatim into the build schema and then INSERTs into filter_table from it).
+ *
+ * Must be invoked BEFORE createAllCubeFiles so the build reads the dimensions from the dataset
+ * and the lookup_tables.<id> rows are in place when the cube is materialised.
+ */
+async function seedDimensions(
+  datasetId: string,
+  factColumns: FactColumnSpec[],
+  dimensions: DimensionSpec[],
+  cubeDB: { query: (sql: string) => Promise<unknown> }
+): Promise<void> {
+  for (const spec of dimensions) {
+    const factCol = factColumns.find((c) => c.name === spec.factTableColumn);
+    if (!factCol) {
+      throw new Error(
+        `seedDimensions: dimension.factTableColumn "${spec.factTableColumn}" is not declared in factColumns`
+      );
+    }
+    const type = spec.type ?? DimensionType.LookupTable;
+    const lookupTableId = spec.lookupTableId ?? randomUUID();
+    const referenceDatatype = spec.referenceDatatype ?? factCol.datatype;
+
+    const lookupTable = await LookupTable.create({
+      id: lookupTableId,
+      filename: `${lookupTableId}.csv`,
+      originalFilename: 'test-lookup.csv',
+      hash: `test-hash-${lookupTableId}`,
+      mimeType: 'text/csv',
+      fileType: FileType.Csv,
+      isStatsWales2Format: false
+    }).save();
+
+    const dimension = await Dimension.create({
+      datasetId,
+      type,
+      factTableColumn: spec.factTableColumn,
+      joinColumn: null,
+      isSliceDimension: false,
+      extractor: null,
+      lookupTable
+    }).save();
+
+    const name = spec.name ?? { en: spec.factTableColumn, cy: spec.factTableColumn };
+    await DimensionMetadata.save([
+      DimensionMetadata.create({ id: dimension.id, language: 'en-GB', name: name.en }),
+      DimensionMetadata.create({ id: dimension.id, language: 'cy-GB', name: name.cy })
+    ]);
+
+    await cubeDB.query(
+      pgformat(
+        `CREATE TABLE lookup_tables.%I (
+           %I ${referenceDatatype},
+           language VARCHAR(5),
+           description TEXT,
+           hierarchy VARCHAR,
+           sort_order INTEGER,
+           notes TEXT
+         );`,
+        lookupTableId,
+        spec.factTableColumn
+      )
+    );
+
+    const rows = spec.lookupRows ?? [];
+    if (rows.length > 0) {
+      const valuesSql = rows
+        .map((r) =>
+          pgformat(
+            '(%L, %L, %L, %L, %L, %L)',
+            r.reference,
+            LOCALE_FOR_LANG[r.language],
+            r.description,
+            r.hierarchy ?? null,
+            r.sortOrder ?? null,
+            r.notes ?? null
+          )
+        )
+        .join(',');
+      await cubeDB.query(pgformat('INSERT INTO lookup_tables.%I VALUES ', lookupTableId) + valuesSql + ';');
+    }
+  }
 }
 
 /**

--- a/test/integration/routes/consumer-v2/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v2/cross-cutting.test.ts
@@ -1,0 +1,151 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 cross-cutting test user');
+let userGroup = getTestUserGroup('V2 Cross Cutting Test Group');
+
+const DATASET_ID = 'dddddddd-dddd-4ddd-8dd2-dddddddddddd';
+const REVISION_ID = 'dddddddd-dddd-4ddd-8dd2-eeeeeeeeeeee';
+const DATA_TABLE_ID = 'dddddddd-dddd-4ddd-8dd2-ffffffffffff';
+
+const MISSING_ID = '99999999-9999-4999-8999-999999999999';
+const MISSING_FILTER = '88888888-8888-4888-8888-888888888888';
+
+// Endpoints that accept a :dataset_id path param — used for the "invalid UUID" and
+// "non-existent dataset" sweeps. For POST endpoints we exercise them via request.post().
+const GET_DATASET_ENDPOINTS = [
+  (id: string) => `/v2/${id}`,
+  (id: string) => `/v2/${id}/filters`,
+  (id: string) => `/v2/${id}/data`,
+  (id: string) => `/v2/${id}/data/${MISSING_FILTER}`,
+  (id: string) => `/v2/${id}/pivot/${MISSING_FILTER}`,
+  (id: string) => `/v2/${id}/query/${MISSING_FILTER}`,
+  (id: string) => `/v2/${id}/revision/${MISSING_ID}`
+];
+
+const POST_DATASET_ENDPOINTS = [(id: string) => `/v2/${id}/data`, (id: string) => `/v2/${id}/pivot`];
+
+describe('Consumer V2 — cross-cutting behaviour (CORS, Vary, 404 sweeps)', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REVISION_ID,
+      dataTableId: DATA_TABLE_ID
+    });
+  }, 120_000);
+
+  describe('CORS (api.ts:80)', () => {
+    it('OPTIONS preflight sets Access-Control-Allow-Origin: *', async () => {
+      const res = await request(app).options('/v2/').set('Origin', 'https://example.com');
+      expect(res.status).toBeLessThan(300);
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+    });
+
+    it('GET responses include Access-Control-Allow-Origin for cross-origin callers', async () => {
+      const res = await request(app).get('/v2/').set('Origin', 'https://example.com');
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+    });
+  });
+
+  describe('Accept-Language caching (api.ts:82-85)', () => {
+    it('GET /v2/ sets Vary: Accept-Language', async () => {
+      const res = await request(app).get('/v2/');
+      const vary = (res.headers.vary ?? '').split(',').map((v) => v.trim().toLowerCase());
+      expect(vary).toContain('accept-language');
+    });
+
+    it('GET /v2/topic sets Vary: Accept-Language', async () => {
+      const res = await request(app).get('/v2/topic');
+      const vary = (res.headers.vary ?? '').split(',').map((v) => v.trim().toLowerCase());
+      expect(vary).toContain('accept-language');
+    });
+  });
+
+  describe('Dataset ID validation — malformed UUID returns 404 across every /:dataset_id endpoint', () => {
+    for (const build of GET_DATASET_ENDPOINTS) {
+      const url = build('not-a-uuid');
+      it(`GET ${url} → 404`, async () => {
+        const res = await request(app).get(url);
+        expect(res.status).toBe(404);
+      });
+    }
+
+    for (const build of POST_DATASET_ENDPOINTS) {
+      const url = build('not-a-uuid');
+      it(`POST ${url} → 404`, async () => {
+        const res = await request(app).post(url).send({});
+        expect(res.status).toBe(404);
+      });
+    }
+  });
+
+  describe('Dataset ID validation — well-formed UUID of a non-existent dataset returns 404 across every /:dataset_id endpoint', () => {
+    for (const build of GET_DATASET_ENDPOINTS) {
+      const url = build(MISSING_ID);
+      it(`GET ${url} → 404`, async () => {
+        const res = await request(app).get(url);
+        expect(res.status).toBe(404);
+      });
+    }
+
+    for (const build of POST_DATASET_ENDPOINTS) {
+      const url = build(MISSING_ID);
+      it(`POST ${url} → 404`, async () => {
+        const res = await request(app).post(url).send({});
+        expect(res.status).toBe(404);
+      });
+    }
+  });
+
+  describe('Error response shape', () => {
+    it('404 responses for malformed dataset UUIDs return JSON, not HTML', async () => {
+      const res = await request(app).get('/v2/not-a-uuid');
+      expect(res.status).toBe(404);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+    });
+  });
+
+  describe('Method guard (missing in v2 — recorded for comparison with v1)', () => {
+    // v1 has an explicit 405 guard at src/routes/consumer/v1/api.ts:51-55.
+    // v2 has no equivalent — unmapped methods fall through to Express default 404.
+    // Flag for the user: is 405 desired here, for consistency with v1?
+    it('POST /v2/ has no handler so Express returns 404 (no 405 guard in v2)', async () => {
+      const res = await request(app).post('/v2/');
+      expect(res.status).toBe(404);
+    });
+
+    it('PUT /v2/:dataset_id has no handler → 404', async () => {
+      const res = await request(app).put(`/v2/${DATASET_ID}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('DELETE /v2/:dataset_id has no handler → 404', async () => {
+      const res = await request(app).delete(`/v2/${DATASET_ID}`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v2/cross-cutting.test.ts
@@ -34,8 +34,7 @@ const GET_DATASET_ENDPOINTS = [
   (id: string) => `/v2/${id}/data`,
   (id: string) => `/v2/${id}/data/${MISSING_FILTER}`,
   (id: string) => `/v2/${id}/pivot/${MISSING_FILTER}`,
-  (id: string) => `/v2/${id}/query/${MISSING_FILTER}`,
-  (id: string) => `/v2/${id}/revision/${MISSING_ID}`
+  (id: string) => `/v2/${id}/query/${MISSING_FILTER}`
 ];
 
 const POST_DATASET_ENDPOINTS = [(id: string) => `/v2/${id}/data`, (id: string) => `/v2/${id}/pivot`];

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -1,0 +1,267 @@
+import request from 'supertest';
+// eslint-disable-next-line import/no-unresolved
+import { parse as parseCsv } from 'csv-parse/sync';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import { FactTableColumnType } from '../../../../src/enums/fact-table-column-type';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 data test user');
+let userGroup = getTestUserGroup('V2 Data Test Group');
+
+const DATASET_ID = 'fffffff1-ffff-4fff-8ff2-ffffffffffff';
+const REVISION_ID = 'fffffff1-ffff-4fff-8ff2-aaaaaaaaaaaa';
+const DATA_TABLE_ID = 'fffffff1-ffff-4fff-8ff2-bbbbbbbbbbbb';
+
+const AREAS = ['W06000001', 'W06000002', 'W06000003'];
+const YEARS = [2020, 2021, 2022, 2023];
+// One row per (Area, Year) combination.
+const ROW_COUNT = AREAS.length * YEARS.length;
+
+const AREA_LOOKUP_ID = 'abcdef00-0000-4000-8000-000000000011';
+const YEAR_LOOKUP_ID = 'abcdef00-0000-4000-8000-000000000012';
+
+const AREA_LABELS: Record<string, { en: string; cy: string }> = {
+  W06000001: { en: 'Isle of Anglesey', cy: 'Ynys Môn' },
+  W06000002: { en: 'Gwynedd', cy: 'Gwynedd' },
+  W06000003: { en: 'Conwy', cy: 'Conwy' }
+};
+
+const areaLookupRows = AREAS.flatMap((ref, idx) => [
+  { reference: ref, language: 'en' as const, description: AREA_LABELS[ref].en, sortOrder: idx },
+  { reference: ref, language: 'cy' as const, description: AREA_LABELS[ref].cy, sortOrder: idx }
+]);
+
+const yearLookupRows = YEARS.flatMap((year, idx) => [
+  { reference: year, language: 'en' as const, description: String(year), sortOrder: idx },
+  { reference: year, language: 'cy' as const, description: String(year), sortOrder: idx }
+]);
+
+const rowBuilder = (i: number): unknown[] => {
+  const area = AREAS[Math.floor(i / YEARS.length) % AREAS.length];
+  const year = YEARS[i % YEARS.length];
+  return [area, year, 'count', Math.round((i + 1) * 10.5 * 100) / 100, null];
+};
+
+describe('Consumer V2 — data + pivot endpoints', () => {
+  let dataFilterId: string;
+  let pivotFilterId: string;
+
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REVISION_ID,
+      dataTableId: DATA_TABLE_ID,
+      factColumns: [
+        { name: 'AreaCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'YearCode', datatype: 'BIGINT', columnType: FactTableColumnType.Dimension },
+        { name: 'MeasureCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Measure },
+        { name: 'Data', datatype: 'DOUBLE PRECISION', columnType: FactTableColumnType.DataValues },
+        { name: 'NoteCode', datatype: 'VARCHAR', columnType: FactTableColumnType.NoteCodes }
+      ],
+      rowBuilder,
+      rowCount: ROW_COUNT,
+      dimensions: [
+        {
+          factTableColumn: 'AreaCode',
+          lookupTableId: AREA_LOOKUP_ID,
+          name: { en: 'Area', cy: 'Ardal' },
+          lookupRows: areaLookupRows
+        },
+        {
+          factTableColumn: 'YearCode',
+          lookupTableId: YEAR_LOOKUP_ID,
+          referenceDatatype: 'BIGINT',
+          name: { en: 'Year', cy: 'Blwyddyn' },
+          lookupRows: yearLookupRows
+        }
+      ]
+    });
+
+    // Create a regular (non-pivot) filter for /data/:filter_id.
+    const dRes = await request(app)
+      .post(`/v2/${DATASET_ID}/data`)
+      .send({ filters: [{ YearCode: ['2020'] }], options: { use_raw_column_names: true } });
+    dataFilterId = dRes.body.filterId;
+
+    // Create a pivot filter for /pivot/:filter_id. We set Accept-Language here to work
+    // around a known v2 defect where generatePivotFilterId accesses queryStore.query[req.language]
+    // without normalising req.language → locale. Without the explicit header this POST 500s
+    // on `totalPivotLines` backfill because queryStore.query['en'] is undefined.
+    const pRes = await request(app)
+      .post(`/v2/${DATASET_ID}/pivot`)
+      .set('Accept-Language', 'en-GB')
+      .send({ pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } });
+    pivotFilterId = pRes.body.filterId;
+  }, 120_000);
+
+  describe('GET /v2/:dataset_id/data — unfiltered', () => {
+    it('default response is JSON with data and page_info', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('page_info');
+      expect(Number(res.body.page_info.total_records)).toBe(ROW_COUNT);
+    });
+
+    it('CSV download returns all rows with attachment header', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'csv' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/text\/csv/);
+      expect(res.headers['content-disposition']).toMatch(/attachment/);
+      const rows = parseCsv(res.text, { columns: true });
+      expect(rows.length).toBe(ROW_COUNT);
+    });
+
+    it('JSON download returns all rows with attachment header', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'json' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.headers['content-disposition']).toMatch(/attachment/);
+      const data = JSON.parse(res.text);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(ROW_COUNT);
+    });
+
+    it('XLSX download returns a spreadsheetml zip', async () => {
+      const res = await request(app)
+        .get(`/v2/${DATASET_ID}/data`)
+        .query({ format: 'xlsx' })
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (c: Buffer) => chunks.push(c));
+          response.on('end', () => callback(null, Buffer.concat(chunks)));
+        });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/spreadsheetml/);
+      expect(res.headers['content-disposition']).toMatch(/attachment/);
+      const buf = res.body as Buffer;
+      expect(buf.subarray(0, 2).toString('utf8')).toBe('PK');
+    });
+
+    it('HTML format returns text/html', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'html' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/text\/html/);
+    });
+
+    it('invalid format → 400', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'pdf' });
+      expect(res.status).toBe(400);
+    });
+
+    it('frontend format honours page_size + page_number', async () => {
+      const res = await request(app)
+        .get(`/v2/${DATASET_ID}/data`)
+        .query({ format: 'frontend', page_size: 5, page_number: 1 });
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(5);
+      expect(res.body.page_info.page_size).toBe(5);
+    });
+
+    it('sort_by on a valid dimension name changes the ordering', async () => {
+      // v2 validates sort_by column against dimension_name in columnMapping — use the
+      // human-readable dimension label ('Year') not the raw fact-table column name.
+      const asc = await request(app)
+        .get(`/v2/${DATASET_ID}/data`)
+        .query({ format: 'frontend', sort_by: 'Year:ASC', page_size: 5 });
+      const desc = await request(app)
+        .get(`/v2/${DATASET_ID}/data`)
+        .query({ format: 'frontend', sort_by: 'Year:DESC', page_size: 5 });
+      expect(asc.status).toBe(200);
+      expect(desc.status).toBe(200);
+      expect(JSON.stringify(asc.body.data)).not.toBe(JSON.stringify(desc.body.data));
+    });
+
+    it('returns 404 for a non-existent dataset', async () => {
+      const res = await request(app).get('/v2/99999999-9999-4999-8999-999999999999/data');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /v2/:dataset_id/data/:filter_id — filtered', () => {
+    it('applies the stored filter and returns a reduced row count', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data/${dataFilterId}`).query({ format: 'frontend' });
+      expect(res.status).toBe(200);
+      // YearCode=2020 → one row per Area → AREAS.length rows (3)
+      expect(Number(res.body.page_info.total_records)).toBe(AREAS.length);
+    });
+
+    it('returns 404 for a non-existent filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data/88888888-8888-4888-8888-888888888888`);
+      // A missing filter_id results in QueryStoreRepository.getById throwing —
+      // the controller logs and returns UnknownException (500). Intended: 404.
+      expect([404, 500]).toContain(res.status);
+      if (res.status !== 404) {
+        // Flag — this is a likely defect.
+        expect(res.status).toBe(404);
+      }
+    });
+
+    it('returns 404 for a malformed filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data/not-a-uuid`);
+      expect([400, 404, 500]).toContain(res.status);
+    });
+  });
+
+  describe('GET /v2/:dataset_id/pivot/:filter_id — pivoted', () => {
+    it('returns a pivot view for a pivot-capable filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/${pivotFilterId}`).query({ format: 'json' });
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 (errors.not_a_pivot_filter) when filter_id was not created with pivot', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/${dataFilterId}`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a non-existent filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/88888888-8888-4888-8888-888888888888`);
+      expect([404, 500]).toContain(res.status);
+      if (res.status !== 404) {
+        expect(res.status).toBe(404);
+      }
+    });
+  });
+
+  describe('GET /v2/:dataset_id/data/:filter_id/pivot — experimental (undocumented)', () => {
+    // NOTE: hidden at src/routes/consumer/v2/api.ts:501 and commented as not-for-consumers.
+    // This test exercises the happy path to capture current behaviour; decision on whether to
+    // keep/document/remove is for the user (same conversation as v1 /pivot/postgres removal).
+    it('missing x/y → 400', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data/${dataFilterId}/pivot`);
+      expect(res.status).toBe(400);
+    });
+
+    it('valid x + y returns 200 with a pivot payload', async () => {
+      const res = await request(app)
+        .get(`/v2/${DATASET_ID}/data/${dataFilterId}/pivot`)
+        .query({ x: 'AreaCode', y: 'YearCode', format: 'json' });
+      expect([200, 400]).toContain(res.status);
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -219,18 +219,12 @@ describe('Consumer V2 — data + pivot endpoints', () => {
 
     it('returns 404 for a non-existent filter_id', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/data/88888888-8888-4888-8888-888888888888`);
-      // A missing filter_id results in QueryStoreRepository.getById throwing —
-      // the controller logs and returns UnknownException (500). Intended: 404.
-      expect([404, 500]).toContain(res.status);
-      if (res.status !== 404) {
-        // Flag — this is a likely defect.
-        expect(res.status).toBe(404);
-      }
+      expect(res.status).toBe(404);
     });
 
     it('returns 404 for a malformed filter_id', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/data/not-a-uuid`);
-      expect([400, 404, 500]).toContain(res.status);
+      expect(res.status).toBe(404);
     });
   });
 
@@ -247,17 +241,14 @@ describe('Consumer V2 — data + pivot endpoints', () => {
 
     it('returns 404 for a non-existent filter_id', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/pivot/88888888-8888-4888-8888-888888888888`);
-      expect([404, 500]).toContain(res.status);
-      if (res.status !== 404) {
-        expect(res.status).toBe(404);
-      }
+      expect(res.status).toBe(404);
     });
   });
 
   describe('GET /v2/:dataset_id/data/:filter_id/pivot — experimental (undocumented)', () => {
     // NOTE: hidden at src/routes/consumer/v2/api.ts:501 and commented as not-for-consumers.
-    // This test exercises the happy path to capture current behaviour; decision on whether to
-    // keep/document/remove is for the user (same conversation as v1 /pivot/postgres removal).
+    // Exercised here to capture current behaviour; decision on whether to keep/document/remove
+    // is for the user (same conversation as v1 /pivot/postgres removal).
     it('missing x/y → 400', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/data/${dataFilterId}/pivot`);
       expect(res.status).toBe(400);
@@ -267,7 +258,7 @@ describe('Consumer V2 — data + pivot endpoints', () => {
       const res = await request(app)
         .get(`/v2/${DATASET_ID}/data/${dataFilterId}/pivot`)
         .query({ x: 'AreaCode', y: 'YearCode', format: 'json' });
-      expect([200, 400]).toContain(res.status);
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -106,13 +106,9 @@ describe('Consumer V2 — data + pivot endpoints', () => {
       .send({ filters: [{ YearCode: ['2020'] }], options: { use_raw_column_names: true } });
     dataFilterId = dRes.body.filterId;
 
-    // Create a pivot filter for /pivot/:filter_id. We set Accept-Language here to work
-    // around a known v2 defect where generatePivotFilterId accesses queryStore.query[req.language]
-    // without normalising req.language → locale. Without the explicit header this POST 500s
-    // on `totalPivotLines` backfill because queryStore.query['en'] is undefined.
+    // Create a pivot filter for /pivot/:filter_id.
     const pRes = await request(app)
       .post(`/v2/${DATASET_ID}/pivot`)
-      .set('Accept-Language', 'en-GB')
       .send({ pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } });
     pivotFilterId = pRes.body.filterId;
   }, 120_000);

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -104,12 +104,22 @@ describe('Consumer V2 — data + pivot endpoints', () => {
     const dRes = await request(app)
       .post(`/v2/${DATASET_ID}/data`)
       .send({ filters: [{ YearCode: ['2020'] }], options: { use_raw_column_names: true } });
+    if (dRes.status !== 200 || typeof dRes.body.filterId !== 'string') {
+      throw new Error(
+        `Failed to create dataFilterId in beforeAll: status=${dRes.status}, body=${JSON.stringify(dRes.body)}`
+      );
+    }
     dataFilterId = dRes.body.filterId;
 
     // Create a pivot filter for /pivot/:filter_id.
     const pRes = await request(app)
       .post(`/v2/${DATASET_ID}/pivot`)
       .send({ pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } });
+    if (pRes.status !== 200 || typeof pRes.body.filterId !== 'string') {
+      throw new Error(
+        `Failed to create pivotFilterId in beforeAll: status=${pRes.status}, body=${JSON.stringify(pRes.body)}`
+      );
+    }
     pivotFilterId = pRes.body.filterId;
   }, 120_000);
 

--- a/test/integration/routes/consumer-v2/dataset-metadata.test.ts
+++ b/test/integration/routes/consumer-v2/dataset-metadata.test.ts
@@ -1,0 +1,209 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { addPublishedRevision, seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 metadata test user');
+let userGroup = getTestUserGroup('V2 Metadata Test Group');
+
+const DATASET_ID = 'aaaaaaaa-aaaa-4aaa-8aa2-aaaaaaaaaaaa';
+const REV_1_ID = 'aaaaaaaa-aaaa-4aaa-8aa2-aaaaaaaa0001';
+const REV_2_ID = 'aaaaaaaa-aaaa-4aaa-8aa2-aaaaaaaa0002';
+const DT_1_ID = 'aaaaaaaa-aaaa-4aaa-8aa2-dddddddd0001';
+const DT_2_ID = 'aaaaaaaa-aaaa-4aaa-8aa2-dddddddd0002';
+
+// Second dataset without a user group — exercises the absent-publisher branch.
+const LOOSE_DATASET_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-bbbbbbbbbbbb';
+const LOOSE_REV_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-aaaaaaaaaaaa';
+const LOOSE_DT_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-bbbbbbbbbbbb';
+
+// A third dataset, used to prove that a revision that doesn't belong to the URL's dataset
+// is rejected by ensurePublishedRevision.
+const OTHER_DATASET_ID = 'cccccccc-cccc-4ccc-8cc2-cccccccccccc';
+const OTHER_REV_ID = 'cccccccc-cccc-4ccc-8cc2-aaaaaaaaaaaa';
+const OTHER_DT_ID = 'cccccccc-cccc-4ccc-8cc2-bbbbbbbbbbbb';
+
+const DAYS = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+describe('Consumer V2 — dataset metadata (/:dataset_id, /:dataset_id/revision/:revision_id)', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REV_1_ID,
+      dataTableId: DT_1_ID,
+      title: { en: 'Population estimates', cy: 'Amcangyfrifon poblogaeth' },
+      summary: { en: 'Annual estimates for Wales', cy: 'Amcangyfrifon blynyddol ar gyfer Cymru' },
+      publishAt: DAYS(10),
+      firstPublishedAt: DAYS(10)
+    });
+
+    await addPublishedRevision({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REV_2_ID,
+      dataTableId: DT_2_ID,
+      previousRevisionId: REV_1_ID,
+      revisionIndex: 2,
+      title: { en: 'Population estimates (updated)', cy: 'Amcangyfrifon poblogaeth (wedi diweddaru)' },
+      summary: { en: 'Annual estimates for Wales — 2024 update', cy: 'Diweddariad 2024' },
+      publishAt: DAYS(2)
+    });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: LOOSE_DATASET_ID,
+      revisionId: LOOSE_REV_ID,
+      dataTableId: LOOSE_DT_ID,
+      skipUserGroup: true,
+      publishAt: DAYS(1),
+      firstPublishedAt: DAYS(1)
+    });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: OTHER_DATASET_ID,
+      revisionId: OTHER_REV_ID,
+      dataTableId: OTHER_DT_ID,
+      publishAt: DAYS(5),
+      firstPublishedAt: DAYS(5)
+    });
+  }, 120_000);
+
+  describe('GET /v2/:dataset_id — dataset metadata', () => {
+    it('returns 200 with the top-level keys documented in ConsumerDatasetDTO', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}`);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body.id).toBe(DATASET_ID);
+      expect(res.body).toHaveProperty('first_published_at');
+      expect(res.body).toHaveProperty('published_revision');
+      // v2's Dataset DTO intentionally omits the full revisions[] array that v1 includes —
+      // the OpenAPI schema (src/routes/consumer/v2/openapi-en.json) only defines
+      // published_revision. History is available via the (hidden) /revision/:revision_id.
+      expect(res.body).not.toHaveProperty('revisions');
+    });
+
+    it('published_revision points at the latest (REV_2_ID)', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}`);
+      expect(res.body.published_revision.id).toBe(REV_2_ID);
+      expect(res.body.published_revision.revision_index).toBe(2);
+    });
+
+    it('published_revision.metadata contains both en-GB and cy-GB entries', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}`);
+      const meta = res.body.published_revision.metadata as Array<{ language: string; title: string }>;
+      const en = meta.find((m) => m.language.toLowerCase().startsWith('en'));
+      const cy = meta.find((m) => m.language.toLowerCase().startsWith('cy'));
+      expect(en?.title).toBe('Population estimates (updated)');
+      expect(cy?.title).toBe('Amcangyfrifon poblogaeth (wedi diweddaru)');
+    });
+
+    it('dataset with linked user group returns a `publisher` block', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}`);
+      expect(res.body.publisher).toBeDefined();
+    });
+
+    it('dataset without a linked user group omits the `publisher` block', async () => {
+      const res = await request(app).get(`/v2/${LOOSE_DATASET_ID}`);
+      expect(res.status).toBe(200);
+      expect(res.body.publisher).toBeUndefined();
+    });
+
+    it('optional fields on the DTO are omitted (undefined) rather than null', async () => {
+      const res = await request(app).get(`/v2/${LOOSE_DATASET_ID}`);
+      expect(res.body).not.toHaveProperty('archived_at');
+      expect(res.body).not.toHaveProperty('replaced_by');
+      expect(res.body).not.toHaveProperty('start_date');
+      expect(res.body).not.toHaveProperty('end_date');
+      expect(res.body.published_revision).not.toHaveProperty('unpublished_at');
+    });
+
+    it('returns 404 for a malformed UUID', async () => {
+      const res = await request(app).get('/v2/not-a-uuid');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a well-formed UUID that does not exist', async () => {
+      const res = await request(app).get('/v2/99999999-9999-4999-8999-999999999999');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /v2/:dataset_id/revision/:revision_id — single-revision metadata (undocumented)', () => {
+    // NOTE: swagger-ignored at src/routes/consumer/v2/api.ts:206. Behaviour recorded here
+    // so we can decide later whether to document, keep hidden, or remove.
+    it('returns 200 with SingleLanguageRevisionDTO shape for a valid dataset/revision pair', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body.id).toBe(REV_2_ID);
+      expect(res.body.revision_index).toBe(2);
+      expect(typeof res.body.updated_at).toBe('string');
+      expect(typeof res.body.publish_at).toBe('string');
+      // metadata is language-filtered (single entry, not an array like /:dataset_id)
+      expect(res.body.metadata).toBeDefined();
+      expect(Array.isArray(res.body.metadata)).toBe(false);
+    });
+
+    it('metadata is English by default', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`);
+      expect(res.body.metadata.title).toBe('Population estimates (updated)');
+    });
+
+    it('metadata is Welsh when lang=cy', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`).query({ lang: 'cy' });
+      expect(res.body.metadata.title).toBe('Amcangyfrifon poblogaeth (wedi diweddaru)');
+    });
+
+    it('returns 404 for a revision that does not belong to the URL dataset', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${OTHER_REV_ID}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a malformed revision UUID', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/not-a-uuid`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a well-formed revision UUID that does not exist', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/revision/99999999-9999-4999-8999-999999999999`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a malformed dataset UUID (ensurePublishedDataset guard)', async () => {
+      const res = await request(app).get(`/v2/not-a-uuid/revision/${REV_2_ID}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('optional revision fields are omitted rather than null', async () => {
+      const res = await request(app).get(`/v2/${LOOSE_DATASET_ID}/revision/${LOOSE_REV_ID}`);
+      expect(res.status).toBe(200);
+      // Per project convention unset optional fields should be absent, not null.
+      expect(res.body).not.toHaveProperty('unpublished_at');
+      expect(res.body).not.toHaveProperty('rounding_description');
+      expect(res.body).not.toHaveProperty('designation');
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/dataset-metadata.test.ts
+++ b/test/integration/routes/consumer-v2/dataset-metadata.test.ts
@@ -86,7 +86,7 @@ describe('Consumer V2 — dataset metadata (/:dataset_id)', () => {
       expect(res.body).toHaveProperty('published_revision');
       // v2's Dataset DTO intentionally omits the full revisions[] array that v1 includes —
       // the OpenAPI schema (src/routes/consumer/v2/openapi-en.json) only defines
-      // published_revision. History is available via the (hidden) /revision/:revision_id.
+      // published_revision.
       expect(res.body).not.toHaveProperty('revisions');
     });
 

--- a/test/integration/routes/consumer-v2/dataset-metadata.test.ts
+++ b/test/integration/routes/consumer-v2/dataset-metadata.test.ts
@@ -30,15 +30,9 @@ const LOOSE_DATASET_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-bbbbbbbbbbbb';
 const LOOSE_REV_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-aaaaaaaaaaaa';
 const LOOSE_DT_ID = 'bbbbbbbb-bbbb-4bbb-8bb2-bbbbbbbbbbbb';
 
-// A third dataset, used to prove that a revision that doesn't belong to the URL's dataset
-// is rejected by ensurePublishedRevision.
-const OTHER_DATASET_ID = 'cccccccc-cccc-4ccc-8cc2-cccccccccccc';
-const OTHER_REV_ID = 'cccccccc-cccc-4ccc-8cc2-aaaaaaaaaaaa';
-const OTHER_DT_ID = 'cccccccc-cccc-4ccc-8cc2-bbbbbbbbbbbb';
-
 const DAYS = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
 
-describe('Consumer V2 — dataset metadata (/:dataset_id, /:dataset_id/revision/:revision_id)', () => {
+describe('Consumer V2 — dataset metadata (/:dataset_id)', () => {
   beforeAll(async () => {
     await ensureWorkerDataSources();
     await resetDatabase();
@@ -79,15 +73,6 @@ describe('Consumer V2 — dataset metadata (/:dataset_id, /:dataset_id/revision/
       skipUserGroup: true,
       publishAt: DAYS(1),
       firstPublishedAt: DAYS(1)
-    });
-
-    await seedPublishedDataset({
-      user,
-      datasetId: OTHER_DATASET_ID,
-      revisionId: OTHER_REV_ID,
-      dataTableId: OTHER_DT_ID,
-      publishAt: DAYS(5),
-      firstPublishedAt: DAYS(5)
     });
   }, 120_000);
 
@@ -148,62 +133,6 @@ describe('Consumer V2 — dataset metadata (/:dataset_id, /:dataset_id/revision/
     it('returns 404 for a well-formed UUID that does not exist', async () => {
       const res = await request(app).get('/v2/99999999-9999-4999-8999-999999999999');
       expect(res.status).toBe(404);
-    });
-  });
-
-  describe('GET /v2/:dataset_id/revision/:revision_id — single-revision metadata (undocumented)', () => {
-    // NOTE: swagger-ignored at src/routes/consumer/v2/api.ts:206. Behaviour recorded here
-    // so we can decide later whether to document, keep hidden, or remove.
-    it('returns 200 with SingleLanguageRevisionDTO shape for a valid dataset/revision pair', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`);
-      expect(res.status).toBe(200);
-      expect(res.headers['content-type']).toMatch(/application\/json/);
-      expect(res.body.id).toBe(REV_2_ID);
-      expect(res.body.revision_index).toBe(2);
-      expect(typeof res.body.updated_at).toBe('string');
-      expect(typeof res.body.publish_at).toBe('string');
-      // metadata is language-filtered (single entry, not an array like /:dataset_id)
-      expect(res.body.metadata).toBeDefined();
-      expect(Array.isArray(res.body.metadata)).toBe(false);
-    });
-
-    it('metadata is English by default', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`);
-      expect(res.body.metadata.title).toBe('Population estimates (updated)');
-    });
-
-    it('metadata is Welsh when lang=cy', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${REV_2_ID}`).query({ lang: 'cy' });
-      expect(res.body.metadata.title).toBe('Amcangyfrifon poblogaeth (wedi diweddaru)');
-    });
-
-    it('returns 404 for a revision that does not belong to the URL dataset', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/${OTHER_REV_ID}`);
-      expect(res.status).toBe(404);
-    });
-
-    it('returns 404 for a malformed revision UUID', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/not-a-uuid`);
-      expect(res.status).toBe(404);
-    });
-
-    it('returns 404 for a well-formed revision UUID that does not exist', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/revision/99999999-9999-4999-8999-999999999999`);
-      expect(res.status).toBe(404);
-    });
-
-    it('returns 404 for a malformed dataset UUID (ensurePublishedDataset guard)', async () => {
-      const res = await request(app).get(`/v2/not-a-uuid/revision/${REV_2_ID}`);
-      expect(res.status).toBe(404);
-    });
-
-    it('optional revision fields are omitted rather than null', async () => {
-      const res = await request(app).get(`/v2/${LOOSE_DATASET_ID}/revision/${LOOSE_REV_ID}`);
-      expect(res.status).toBe(200);
-      // Per project convention unset optional fields should be absent, not null.
-      expect(res.body).not.toHaveProperty('unpublished_at');
-      expect(res.body).not.toHaveProperty('rounding_description');
-      expect(res.body).not.toHaveProperty('designation');
     });
   });
 });

--- a/test/integration/routes/consumer-v2/filters-and-queries.test.ts
+++ b/test/integration/routes/consumer-v2/filters-and-queries.test.ts
@@ -1,0 +1,287 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import { FactTableColumnType } from '../../../../src/enums/fact-table-column-type';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 filters/queries test user');
+let userGroup = getTestUserGroup('V2 Filters Test Group');
+
+const DATASET_ID = 'eeeeeeee-eeee-4eee-8ee2-eeeeeeeeeeee';
+const REVISION_ID = 'eeeeeeee-eeee-4eee-8ee2-aaaaaaaaaaaa';
+const DATA_TABLE_ID = 'eeeeeeee-eeee-4eee-8ee2-bbbbbbbbbbbb';
+
+const AREAS = ['W06000001', 'W06000002', 'W06000003'];
+const YEARS = [2020, 2021, 2022, 2023];
+// One row per (Area, Year) combination — fact table has a composite PK on the
+// Dimension/Measure columns, so rows must be unique across them.
+const ROW_COUNT = AREAS.length * YEARS.length;
+
+const AREA_LOOKUP_ID = 'abcdef00-0000-4000-8000-000000000001';
+const YEAR_LOOKUP_ID = 'abcdef00-0000-4000-8000-000000000002';
+
+const AREA_LABELS: Record<string, { en: string; cy: string }> = {
+  W06000001: { en: 'Isle of Anglesey', cy: 'Ynys Môn' },
+  W06000002: { en: 'Gwynedd', cy: 'Gwynedd' },
+  W06000003: { en: 'Conwy', cy: 'Conwy' }
+};
+
+const areaLookupRows = AREAS.flatMap((ref, idx) => [
+  { reference: ref, language: 'en' as const, description: AREA_LABELS[ref].en, sortOrder: idx },
+  { reference: ref, language: 'cy' as const, description: AREA_LABELS[ref].cy, sortOrder: idx }
+]);
+
+const yearLookupRows = YEARS.flatMap((year, idx) => [
+  { reference: year, language: 'en' as const, description: String(year), sortOrder: idx },
+  { reference: year, language: 'cy' as const, description: String(year), sortOrder: idx }
+]);
+
+const rowBuilder = (i: number): unknown[] => {
+  const area = AREAS[Math.floor(i / YEARS.length) % AREAS.length];
+  const year = YEARS[i % YEARS.length];
+  return [area, year, 'count', Math.round((i + 1) * 10.5 * 100) / 100, null];
+};
+
+describe('Consumer V2 — filters + query-store endpoints', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REVISION_ID,
+      dataTableId: DATA_TABLE_ID,
+      title: { en: 'Filters fixture', cy: 'Ffynhonnell hidlwyr' },
+      factColumns: [
+        { name: 'AreaCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'YearCode', datatype: 'BIGINT', columnType: FactTableColumnType.Dimension },
+        { name: 'MeasureCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Measure },
+        { name: 'Data', datatype: 'DOUBLE PRECISION', columnType: FactTableColumnType.DataValues },
+        { name: 'NoteCode', datatype: 'VARCHAR', columnType: FactTableColumnType.NoteCodes }
+      ],
+      rowBuilder,
+      rowCount: ROW_COUNT,
+      dimensions: [
+        {
+          factTableColumn: 'AreaCode',
+          lookupTableId: AREA_LOOKUP_ID,
+          name: { en: 'Area', cy: 'Ardal' },
+          lookupRows: areaLookupRows
+        },
+        {
+          factTableColumn: 'YearCode',
+          lookupTableId: YEAR_LOOKUP_ID,
+          referenceDatatype: 'BIGINT',
+          name: { en: 'Year', cy: 'Blwyddyn' },
+          lookupRows: yearLookupRows
+        }
+      ]
+    });
+  }, 120_000);
+
+  describe('GET /v2/:dataset_id/filters — available filters', () => {
+    it('returns 200 and the documented Filters shape', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      // Response is an array of Filter objects; each has columnName + values.
+      // (Lookup-backed dimensions would also carry reference/description per value.)
+      expect(Array.isArray(res.body) || Array.isArray(res.body.data) || typeof res.body === 'object').toBe(true);
+    });
+
+    it('returns 404 for a non-existent dataset', async () => {
+      const res = await request(app).get('/v2/99999999-9999-4999-8999-999999999999/filters');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a malformed UUID', async () => {
+      const res = await request(app).get('/v2/not-a-uuid/filters');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /v2/:dataset_id/data — generate filter ID', () => {
+    it('empty body returns a FilterId for the default query', async () => {
+      const res = await request(app).post(`/v2/${DATASET_ID}/data`).send({});
+      expect(res.status).toBe(200);
+      expect(typeof res.body.filterId).toBe('string');
+    });
+
+    it('valid DataOptions body returns a FilterId', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/data`)
+        .send({
+          filters: [{ AreaCode: ['W06000001'] }],
+          options: { use_raw_column_names: true, use_reference_values: true, data_value_type: 'raw' }
+        });
+      expect(res.status).toBe(200);
+      expect(typeof res.body.filterId).toBe('string');
+    });
+
+    it('identical bodies return the same FilterId (deterministic)', async () => {
+      const body = {
+        filters: [{ YearCode: ['2020', '2021'] }],
+        options: { use_raw_column_names: true, use_reference_values: true, data_value_type: 'raw' }
+      };
+      const a = await request(app).post(`/v2/${DATASET_ID}/data`).send(body);
+      const b = await request(app).post(`/v2/${DATASET_ID}/data`).send(body);
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200);
+      expect(a.body.filterId).toBe(b.body.filterId);
+    });
+
+    it('different bodies return different FilterIds', async () => {
+      const a = await request(app)
+        .post(`/v2/${DATASET_ID}/data`)
+        .send({ filters: [{ YearCode: ['2020'] }] });
+      const b = await request(app)
+        .post(`/v2/${DATASET_ID}/data`)
+        .send({ filters: [{ YearCode: ['2021'] }] });
+      expect(a.body.filterId).not.toBe(b.body.filterId);
+    });
+
+    it('invalid body (wrong type on options) → 400', async () => {
+      const res = await request(app).post(`/v2/${DATASET_ID}/data`).send({ options: 'not-an-object' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a non-existent dataset', async () => {
+      const res = await request(app).post('/v2/99999999-9999-4999-8999-999999999999/data').send({});
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /v2/:dataset_id/pivot — generate pivot filter ID', () => {
+    it('valid pivot body with x/y on real columns returns a FilterId', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/pivot`)
+        .send({ pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } });
+      expect(res.status).toBe(200);
+      expect(typeof res.body.filterId).toBe('string');
+    });
+
+    it('identical pivot bodies return the same FilterId', async () => {
+      const body = { pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } };
+      const a = await request(app).post(`/v2/${DATASET_ID}/pivot`).set('Accept-Language', 'en-GB').send(body);
+      const b = await request(app).post(`/v2/${DATASET_ID}/pivot`).set('Accept-Language', 'en-GB').send(body);
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200);
+      expect(typeof a.body.filterId).toBe('string');
+      expect(a.body.filterId).toBe(b.body.filterId);
+    });
+
+    it('missing pivot.x or pivot.y → 400', async () => {
+      const res = await request(app).post(`/v2/${DATASET_ID}/pivot`).send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('multi-column x ("a,b") → 400 errors.pivot_only_one_column', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/pivot`)
+        .send({ pivot: { x: 'AreaCode,YearCode', y: 'YearCode' }, options: { use_raw_column_names: true } });
+      expect(res.status).toBe(400);
+    });
+
+    it('unknown x column → 400', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/pivot`)
+        .send({ pivot: { x: 'NotAColumn', y: 'YearCode' }, options: { use_raw_column_names: true } });
+      expect(res.status).toBe(400);
+    });
+
+    it('unknown y column → 400', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/pivot`)
+        .send({ pivot: { x: 'AreaCode', y: 'NotAColumn' }, options: { use_raw_column_names: true } });
+      expect(res.status).toBe(400);
+    });
+
+    it('non-axis filter with multiple values → 400', async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/pivot`)
+        .send({
+          pivot: { x: 'AreaCode', y: 'YearCode' },
+          filters: [{ Data: ['1.0', '2.0'] }],
+          options: { use_raw_column_names: true }
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a non-existent dataset', async () => {
+      const res = await request(app)
+        .post('/v2/99999999-9999-4999-8999-999999999999/pivot')
+        .send({ pivot: { x: 'AreaCode', y: 'YearCode' } });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /v2/:dataset_id/query/:filter_id — filter details', () => {
+    let filterId: string;
+
+    beforeAll(async () => {
+      const res = await request(app)
+        .post(`/v2/${DATASET_ID}/data`)
+        .send({ filters: [{ AreaCode: ['W06000001'] }] });
+      filterId = res.body.filterId;
+    });
+
+    it('returns the QueryStore shape for a valid filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/query/${filterId}`);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(filterId);
+      expect(res.body).toHaveProperty('hash');
+      expect(res.body).toHaveProperty('datasetId');
+      expect(res.body).toHaveProperty('revisionId');
+      expect(res.body).toHaveProperty('requestObject');
+      expect(res.body.datasetId).toBe(DATASET_ID);
+    });
+
+    it('requestObject round-trips the filters that were posted', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/query/${filterId}`);
+      expect(res.body.requestObject.filters).toEqual([{ AreaCode: ['W06000001'] }]);
+    });
+
+    it('returns 404 for a non-existent filter_id', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/query/88888888-8888-4888-8888-888888888888`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when the dataset does not exist (middleware guard runs first)', async () => {
+      const res = await request(app).get(`/v2/99999999-9999-4999-8999-999999999999/query/${filterId}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /v2/:dataset_id/query/ — no filter ID (undocumented)', () => {
+    // NOTE: swagger-ignored at src/routes/consumer/v2/api.ts:467. The controller computes a
+    // default-options QueryStore when filter_id is absent. Record behaviour so we can decide
+    // later whether to document or remove it.
+    it('returns a QueryStore shape for the default query (or 404)', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/query/`);
+      expect([200, 404]).toContain(res.status);
+      if (res.status === 200) {
+        expect(res.body).toHaveProperty('id');
+        expect(res.body.datasetId).toBe(DATASET_ID);
+      }
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/filters-and-queries.test.ts
+++ b/test/integration/routes/consumer-v2/filters-and-queries.test.ts
@@ -103,9 +103,12 @@ describe('Consumer V2 — filters + query-store endpoints', () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/application\/json/);
-      // Response is an array of Filter objects; each has columnName + values.
-      // (Lookup-backed dimensions would also carry reference/description per value.)
-      expect(Array.isArray(res.body) || Array.isArray(res.body.data) || typeof res.body === 'object').toBe(true);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+      const filter = res.body[0];
+      expect(typeof filter.factTableColumn).toBe('string');
+      expect(typeof filter.columnName).toBe('string');
+      expect(Array.isArray(filter.values)).toBe(true);
     });
 
     it('returns 404 for a non-existent dataset', async () => {
@@ -275,13 +278,11 @@ describe('Consumer V2 — filters + query-store endpoints', () => {
     // NOTE: swagger-ignored at src/routes/consumer/v2/api.ts:467. The controller computes a
     // default-options QueryStore when filter_id is absent. Record behaviour so we can decide
     // later whether to document or remove it.
-    it('returns a QueryStore shape for the default query (or 404)', async () => {
+    it('returns a QueryStore shape for the default query', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/query/`);
-      expect([200, 404]).toContain(res.status);
-      if (res.status === 200) {
-        expect(res.body).toHaveProperty('id');
-        expect(res.body.datasetId).toBe(DATASET_ID);
-      }
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.datasetId).toBe(DATASET_ID);
     });
   });
 });

--- a/test/integration/routes/consumer-v2/filters-and-queries.test.ts
+++ b/test/integration/routes/consumer-v2/filters-and-queries.test.ts
@@ -181,8 +181,8 @@ describe('Consumer V2 — filters + query-store endpoints', () => {
 
     it('identical pivot bodies return the same FilterId', async () => {
       const body = { pivot: { x: 'AreaCode', y: 'YearCode' }, options: { use_raw_column_names: true } };
-      const a = await request(app).post(`/v2/${DATASET_ID}/pivot`).set('Accept-Language', 'en-GB').send(body);
-      const b = await request(app).post(`/v2/${DATASET_ID}/pivot`).set('Accept-Language', 'en-GB').send(body);
+      const a = await request(app).post(`/v2/${DATASET_ID}/pivot`).send(body);
+      const b = await request(app).post(`/v2/${DATASET_ID}/pivot`).send(body);
       expect(a.status).toBe(200);
       expect(b.status).toBe(200);
       expect(typeof a.body.filterId).toBe('string');

--- a/test/integration/routes/consumer-v2/listings.test.ts
+++ b/test/integration/routes/consumer-v2/listings.test.ts
@@ -1,0 +1,314 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { MAX_PAGE_SIZE } from '../../../../src/utils/page-defaults';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset, seedTopic } from '../../../helpers/seed-published-dataset';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 listings test user');
+let userGroup = getTestUserGroup('V2 Listings Test Group');
+
+const DS_HEALTH_1 = '11111111-1111-4111-8211-111111111111';
+const REV_HEALTH_1 = '11111111-1111-4111-8211-aaaaaaaaaaaa';
+const DT_HEALTH_1 = '11111111-1111-4111-8211-bbbbbbbbbbbb';
+
+const DS_HEALTH_2 = '22222222-2222-4222-8222-222222222202';
+const REV_HEALTH_2 = '22222222-2222-4222-8222-aaaaaaaaaaa2';
+const DT_HEALTH_2 = '22222222-2222-4222-8222-bbbbbbbbbbb2';
+
+const DS_TRANSPORT = '33333333-3333-4333-8333-333333333303';
+const REV_TRANSPORT = '33333333-3333-4333-8333-aaaaaaaaaaa3';
+const DT_TRANSPORT = '33333333-3333-4333-8333-bbbbbbbbbbb3';
+
+const DS_UNPUBLISHED = '44444444-4444-4444-8444-444444444404';
+const REV_UNPUBLISHED = '44444444-4444-4444-8444-aaaaaaaaaaa4';
+const DT_UNPUBLISHED = '44444444-4444-4444-8444-bbbbbbbbbbb4';
+
+// Topic hierarchy (same shape as v1 listings fixture):
+//   Health (100)
+//     └─ Dental (101)     ← leaf, 2 datasets tagged here
+//   Transport (200)         ← 1 dataset tagged directly
+//   Fisheries (300)         ← only an unpublished (future) dataset → must not appear
+const TOPIC_HEALTH = 100;
+const TOPIC_DENTAL = 101;
+const TOPIC_TRANSPORT = 200;
+const TOPIC_FISHERIES = 300;
+
+const DAYS = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+describe('Consumer V2 — listings (/, /topic, /topic/:topic_id)', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedTopic({ id: TOPIC_HEALTH, path: `${TOPIC_HEALTH}`, nameEN: 'Health', nameCY: 'Iechyd' });
+    await seedTopic({
+      id: TOPIC_DENTAL,
+      path: `${TOPIC_HEALTH}.${TOPIC_DENTAL}`,
+      nameEN: 'Dental services',
+      nameCY: 'Gwasanaethau deintyddol'
+    });
+    await seedTopic({ id: TOPIC_TRANSPORT, path: `${TOPIC_TRANSPORT}`, nameEN: 'Transport', nameCY: 'Trafnidiaeth' });
+    await seedTopic({ id: TOPIC_FISHERIES, path: `${TOPIC_FISHERIES}`, nameEN: 'Fisheries', nameCY: 'Pysgodfeydd' });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_HEALTH_1,
+      revisionId: REV_HEALTH_1,
+      dataTableId: DT_HEALTH_1,
+      title: { en: 'Dental appointments 2023', cy: 'Apwyntiadau deintyddol 2023' },
+      topicIds: [TOPIC_DENTAL],
+      publishAt: DAYS(3),
+      firstPublishedAt: DAYS(30)
+    });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_HEALTH_2,
+      revisionId: REV_HEALTH_2,
+      dataTableId: DT_HEALTH_2,
+      title: { en: 'Dental appointments 2024', cy: 'Apwyntiadau deintyddol 2024' },
+      topicIds: [TOPIC_DENTAL],
+      publishAt: DAYS(2),
+      firstPublishedAt: DAYS(10)
+    });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_TRANSPORT,
+      revisionId: REV_TRANSPORT,
+      dataTableId: DT_TRANSPORT,
+      title: { en: 'Bus journeys', cy: 'Teithiau bws' },
+      topicIds: [TOPIC_TRANSPORT],
+      publishAt: DAYS(1),
+      firstPublishedAt: DAYS(1)
+    });
+
+    // Future-dated publish => not yet visible; topic should not appear in /topic.
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_UNPUBLISHED,
+      revisionId: REV_UNPUBLISHED,
+      dataTableId: DT_UNPUBLISHED,
+      title: { en: 'Future fisheries dataset', cy: 'Set ddata pysgodfeydd yn y dyfodol' },
+      topicIds: [TOPIC_FISHERIES],
+      publishAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      firstPublishedAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+  }, 120_000);
+
+  describe('GET /v2 — list all published datasets', () => {
+    it('returns DatasetsWithCount shape with published datasets only', async () => {
+      const res = await request(app).get('/v2');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body).toHaveProperty('count');
+      expect(Array.isArray(res.body.data)).toBe(true);
+
+      const ids = res.body.data.map((d: { id: string }) => d.id);
+      expect(ids).toContain(DS_HEALTH_1);
+      expect(ids).toContain(DS_HEALTH_2);
+      expect(ids).toContain(DS_TRANSPORT);
+      expect(ids).not.toContain(DS_UNPUBLISHED);
+      expect(res.body.count).toBe(3);
+    });
+
+    it('items match the DatasetListItem shape', async () => {
+      const res = await request(app).get('/v2');
+      const item = res.body.data.find((d: { id: string }) => d.id === DS_HEALTH_1);
+      expect(item).toBeDefined();
+      expect(typeof item.id).toBe('string');
+      expect(typeof item.title).toBe('string');
+      expect(typeof item.first_published_at).toBe('string');
+      expect(typeof item.last_updated_at).toBe('string');
+    });
+
+    it('returns English titles by default', async () => {
+      const res = await request(app).get('/v2');
+      const h1 = res.body.data.find((d: { id: string }) => d.id === DS_HEALTH_1);
+      expect(h1.title).toBe('Dental appointments 2023');
+    });
+
+    it('returns Welsh titles when lang=cy', async () => {
+      const res = await request(app).get('/v2').query({ lang: 'cy' });
+      const h1 = res.body.data.find((d: { id: string }) => d.id === DS_HEALTH_1);
+      expect(h1.title).toBe('Apwyntiadau deintyddol 2023');
+    });
+
+    it('orders datasets by first_published_at DESC', async () => {
+      const res = await request(app).get('/v2');
+      const ids = res.body.data.map((d: { id: string }) => d.id);
+      expect(ids).toEqual([DS_TRANSPORT, DS_HEALTH_2, DS_HEALTH_1]);
+    });
+
+    it('honours page_size', async () => {
+      const res = await request(app).get('/v2').query({ page_size: 1 });
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.count).toBe(3);
+    });
+
+    it('honours page_number', async () => {
+      const p1 = await request(app).get('/v2').query({ page_size: 1, page_number: 1 });
+      const p2 = await request(app).get('/v2').query({ page_size: 1, page_number: 2 });
+      expect(p1.body.data[0].id).not.toBe(p2.body.data[0].id);
+    });
+
+    it('clamps page_size above MAX_PAGE_SIZE silently', async () => {
+      const res = await request(app)
+        .get('/v2')
+        .query({ page_size: MAX_PAGE_SIZE + 10 });
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(3);
+    });
+
+    it('treats page_number < 1 as 1 (controller uses Math.max(1, ...))', async () => {
+      const res = await request(app).get('/v2').query({ page_number: 0 });
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(3);
+    });
+  });
+
+  describe('GET /v2/topic — root topics', () => {
+    it('returns the RootTopics payload shape', async () => {
+      const res = await request(app).get('/v2/topic');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body).toHaveProperty('children');
+      expect(Array.isArray(res.body.children)).toBe(true);
+    });
+
+    it('includes only root topics with a published dataset directly or via descendants', async () => {
+      const res = await request(app).get('/v2/topic');
+      const rootIds = res.body.children.map((t: { id: number }) => t.id);
+      expect(rootIds).toContain(TOPIC_HEALTH);
+      expect(rootIds).toContain(TOPIC_TRANSPORT);
+      expect(rootIds).not.toContain(TOPIC_FISHERIES);
+      expect(rootIds).not.toContain(TOPIC_DENTAL);
+    });
+
+    it('each topic has id, path, name, name_en, name_cy', async () => {
+      const res = await request(app).get('/v2/topic');
+      const health = res.body.children.find((t: { id: number }) => t.id === TOPIC_HEALTH);
+      expect(health).toBeDefined();
+      expect(health.id).toBe(TOPIC_HEALTH);
+      expect(health.path).toBe(`${TOPIC_HEALTH}`);
+      expect(health.name_en).toBe('Health');
+      expect(health.name_cy).toBe('Iechyd');
+      expect(health.name).toBe('Health');
+    });
+
+    it('selects Welsh name for the `name` field when lang=cy', async () => {
+      const res = await request(app).get('/v2/topic').query({ lang: 'cy' });
+      const health = res.body.children.find((t: { id: number }) => t.id === TOPIC_HEALTH);
+      expect(health.name).toBe('Iechyd');
+    });
+
+    it('selectedTopic/parents/datasets absent for root-topic listing', async () => {
+      const res = await request(app).get('/v2/topic');
+      expect(res.body.selectedTopic).toBeUndefined();
+      expect(res.body.parents).toBeUndefined();
+      expect(res.body.datasets).toBeUndefined();
+    });
+  });
+
+  describe('GET /v2/topic/:topic_id — sub-topics / leaf datasets', () => {
+    it('for a non-leaf topic returns children + parents, no datasets', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_HEALTH}`);
+      expect(res.status).toBe(200);
+      expect(res.body.selectedTopic?.id).toBe(TOPIC_HEALTH);
+      expect(Array.isArray(res.body.children)).toBe(true);
+      const childIds = res.body.children.map((c: { id: number }) => c.id);
+      expect(childIds).toContain(TOPIC_DENTAL);
+      expect(res.body.datasets).toBeUndefined();
+      expect(res.body.parents === undefined || res.body.parents.length === 0).toBe(true);
+    });
+
+    it('for a leaf topic returns paginated datasets tagged directly to it', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_DENTAL}`);
+      expect(res.status).toBe(200);
+      expect(res.body.selectedTopic?.id).toBe(TOPIC_DENTAL);
+      expect(Array.isArray(res.body.children)).toBe(true);
+      expect(res.body.children.length).toBe(0);
+      expect(res.body.datasets).toBeDefined();
+      const datasetIds = res.body.datasets.data.map((d: { id: string }) => d.id);
+      expect(datasetIds.sort()).toEqual([DS_HEALTH_1, DS_HEALTH_2].sort());
+      expect(res.body.datasets.count).toBe(2);
+    });
+
+    it('includes parents array for a sub-topic', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_DENTAL}`);
+      expect(Array.isArray(res.body.parents)).toBe(true);
+      const parentIds = res.body.parents.map((p: { id: number }) => p.id);
+      expect(parentIds).toContain(TOPIC_HEALTH);
+    });
+
+    it('sort_by=title ASC is respected', async () => {
+      const res = await request(app)
+        .get(`/v2/topic/${TOPIC_DENTAL}`)
+        .query({ sort_by: JSON.stringify([{ columnName: 'title', direction: 'ASC' }]) });
+      expect(res.status).toBe(200);
+      const titles = res.body.datasets.data.map((d: { title: string }) => d.title);
+      expect(titles).toEqual([...titles].sort((a: string, b: string) => a.localeCompare(b)));
+    });
+
+    it('sort_by on a disallowed column → 400', async () => {
+      const res = await request(app)
+        .get(`/v2/topic/${TOPIC_DENTAL}`)
+        .query({ sort_by: JSON.stringify([{ columnName: 'id', direction: 'ASC' }]) });
+      expect(res.status).toBe(400);
+    });
+
+    it('non-existent numeric topic_id → 404', async () => {
+      const res = await request(app).get('/v2/topic/999999');
+      expect(res.status).toBe(404);
+    });
+
+    it('non-numeric topic_id → 404', async () => {
+      const res = await request(app).get('/v2/topic/abc');
+      expect(res.status).toBe(404);
+    });
+
+    // Same bug as v1 defect 3 — controller uses unanchored /\d+/ on topic_id, so "100abc"
+    // matches and parseInt yields 100. Intended: treat non-integer as invalid → 404.
+    it('topic_id with trailing garbage (e.g. "100abc") should be rejected', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_HEALTH}abc`);
+      expect(res.status).toBe(404);
+    });
+
+    it('page_size query param is respected for leaf-topic datasets', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_DENTAL}`).query({ page_size: 1 });
+      expect(res.status).toBe(200);
+      expect(res.body.datasets.data.length).toBe(1);
+      expect(res.body.datasets.count).toBe(2);
+    });
+
+    it('future-dated-only topic (Fisheries) is treated as having no published datasets', async () => {
+      const res = await request(app).get(`/v2/topic/${TOPIC_FISHERIES}`);
+      if (res.status === 200) {
+        const hasData = res.body.datasets && res.body.datasets.data && res.body.datasets.data.length > 0;
+        expect(hasData).toBe(false);
+      } else {
+        expect(res.status).toBe(404);
+      }
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/listings.test.ts
+++ b/test/integration/routes/consumer-v2/listings.test.ts
@@ -287,9 +287,9 @@ describe('Consumer V2 — listings (/, /topic, /topic/:topic_id)', () => {
       expect(res.status).toBe(404);
     });
 
-    // Same bug as v1 defect 3 — controller uses unanchored /\d+/ on topic_id, so "100abc"
-    // matches and parseInt yields 100. Intended: treat non-integer as invalid → 404.
-    it('topic_id with trailing garbage (e.g. "100abc") should be rejected', async () => {
+    // Regression test: controller previously used an unanchored /\d+/ on topic_id so
+    // "100abc" matched and parseInt yielded 100. Anchored to /^\d+$/ — non-integer → 404.
+    it('topic_id with trailing garbage (e.g. "100abc") is rejected', async () => {
       const res = await request(app).get(`/v2/topic/${TOPIC_HEALTH}abc`);
       expect(res.status).toBe(404);
     });

--- a/test/integration/routes/consumer-v2/search.test.ts
+++ b/test/integration/routes/consumer-v2/search.test.ts
@@ -1,0 +1,160 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { SearchLog } from '../../../../src/entities/search-log';
+import { SearchMode } from '../../../../src/enums/search-mode';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('v2 search test user');
+let userGroup = getTestUserGroup('V2 Search Test Group');
+
+const DS_DENTAL = '11111111-1111-4111-8311-111111111111';
+const REV_DENTAL = '11111111-1111-4111-8311-aaaaaaaaaaaa';
+const DT_DENTAL = '11111111-1111-4111-8311-bbbbbbbbbbbb';
+
+const DS_BUSES = '22222222-2222-4222-8322-222222222222';
+const REV_BUSES = '22222222-2222-4222-8322-aaaaaaaaaaaa';
+const DT_BUSES = '22222222-2222-4222-8322-bbbbbbbbbbbb';
+
+const DS_WELSH_ONLY = '33333333-3333-4333-8333-333333331113';
+const REV_WELSH_ONLY = '33333333-3333-4333-8333-aaaaaaaaaa13';
+const DT_WELSH_ONLY = '33333333-3333-4333-8333-bbbbbbbbbb13';
+
+describe('Consumer V2 — GET /v2/search', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_DENTAL,
+      revisionId: REV_DENTAL,
+      dataTableId: DT_DENTAL,
+      title: { en: 'Dental appointments in Cardiff', cy: 'Apwyntiadau deintyddol yng Nghaerdydd' },
+      summary: { en: 'Monthly dental activity across Wales', cy: 'Gweithgarwch deintyddol misol ledled Cymru' }
+    });
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_BUSES,
+      revisionId: REV_BUSES,
+      dataTableId: DT_BUSES,
+      title: { en: 'Bus journeys by local authority', cy: 'Teithiau bws fesul awdurdod lleol' },
+      summary: { en: 'Quarterly bus passenger numbers', cy: 'Nifer y teithwyr bws chwarterol' }
+    });
+
+    // A dataset whose English title has no distinguishing word but whose Welsh title does —
+    // lets us verify the search hits the correct language columns.
+    await seedPublishedDataset({
+      user,
+      datasetId: DS_WELSH_ONLY,
+      revisionId: REV_WELSH_ONLY,
+      dataTableId: DT_WELSH_ONLY,
+      title: { en: 'Generic population data', cy: 'Ffwlbriwlsyn poblogaeth' },
+      summary: { en: 'Population counts by year', cy: 'Cyfrifon poblogaeth yn ôl blwyddyn' }
+    });
+  }, 120_000);
+
+  describe('validation', () => {
+    it('missing keywords → 400', async () => {
+      const res = await request(app).get('/v2/search');
+      expect(res.status).toBe(400);
+    });
+
+    it('empty keywords → 400', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('invalid mode → 400', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: 'dental', mode: 'not-a-mode' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('happy path across SearchMode variants', () => {
+    const modes = [SearchMode.Basic, SearchMode.BasicSplit, SearchMode.FTS, SearchMode.FTSSimple, SearchMode.Fuzzy];
+
+    for (const mode of modes) {
+      it(`mode=${mode} returns SearchResultsWithCount shape and matches "dental"`, async () => {
+        const res = await request(app).get('/v2/search').query({ keywords: 'dental', mode });
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).toHaveProperty('count');
+        expect(Array.isArray(res.body.data)).toBe(true);
+        const ids = res.body.data.map((d: { id: string }) => d.id);
+        expect(ids).toContain(DS_DENTAL);
+      });
+    }
+
+    it('defaults to basic mode when mode omitted', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: 'dental' });
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((d: { id: string }) => d.id);
+      expect(ids).toContain(DS_DENTAL);
+    });
+
+    it('items carry the documented SearchResultDTO fields', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: 'dental' });
+      const item = res.body.data.find((d: { id: string }) => d.id === DS_DENTAL);
+      expect(item).toBeDefined();
+      expect(typeof item.id).toBe('string');
+      expect(typeof item.title).toBe('string');
+    });
+  });
+
+  describe('bilingual search', () => {
+    it('a Welsh-only distinctive word is found with lang=cy', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: 'Ffwlbriwlsyn', lang: 'cy' });
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((d: { id: string }) => d.id);
+      expect(ids).toContain(DS_WELSH_ONLY);
+    });
+
+    it('the same Welsh word is NOT found with lang=en (English title has no match)', async () => {
+      const res = await request(app).get('/v2/search').query({ keywords: 'Ffwlbriwlsyn', lang: 'en' });
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((d: { id: string }) => d.id);
+      expect(ids).not.toContain(DS_WELSH_ONLY);
+    });
+  });
+
+  describe('SearchLog telemetry', () => {
+    it('every successful search writes a SearchLog row with mode, keywords and result count', async () => {
+      const before = await SearchLog.count();
+      const res = await request(app).get('/v2/search').query({ keywords: 'bus-unique-keyword-xyz' });
+      expect(res.status).toBe(200);
+      const after = await SearchLog.count();
+      expect(after).toBe(before + 1);
+
+      const [log] = await SearchLog.find({ where: { keywords: 'bus-unique-keyword-xyz' } });
+      expect(log).toBeDefined();
+      expect(log.mode).toBe(SearchMode.Basic);
+      expect(log.resultCount).toBe(res.body.count);
+    });
+
+    it('mode is recorded on the log when provided', async () => {
+      await request(app).get('/v2/search').query({ keywords: 'fts-log-keyword', mode: SearchMode.FTS });
+      const [log] = await SearchLog.find({ where: { keywords: 'fts-log-keyword' } });
+      expect(log?.mode).toBe(SearchMode.FTS);
+    });
+  });
+});

--- a/test/unit/dtos/data-options-dto.test.ts
+++ b/test/unit/dtos/data-options-dto.test.ts
@@ -18,7 +18,7 @@ describe('DataOptionsDTO validation', () => {
       pivot: {
         backend: 'duckdb',
         include_performance: false,
-        x: ['dim1'],
+        x: 'dim1',
         y: 'measure1'
       },
       filters: [{ region: ['wales'] }],


### PR DESCRIPTION
## Summary

Follow-up to #660. Adds integration tests for the consumer v2 API mirroring the v1 work, then fixes the defects and smells surfaced by those tests.

## Test suite

Six grouped files under `test/integration/routes/consumer-v2/` (~109 tests):

- `listings.test.ts` — `GET /`, `GET /topic`, `GET /topic/:topic_id`
- `search.test.ts` — `GET /search` across every `SearchMode`, bilingual, `SearchLog` side-effect
- `dataset-metadata.test.ts` — `GET /:dataset_id`
- `filters-and-queries.test.ts` — `GET /:id/filters`, `POST /:id/data`, `POST /:id/pivot`, `GET /:id/query/[…]`
- `data-and-pivot.test.ts` — `GET /:id/data`, `GET /:id/data/:filter_id`, `GET /:id/pivot/:filter_id`, experimental `GET /:id/data/:filter_id/pivot`
- `cross-cutting.test.ts` — CORS preflight, `Vary: Accept-Language`, malformed / non-existent UUID sweeps

`test/helpers/seed-published-dataset.ts` was extended with support for lookup-backed `Dimension` entities (+ rows in `lookup_tables.<id>` in the cube schema) and an auto-wired `Measure` entity so the full-cube build path runs for v2 filter/pivot tests.

## Defects fixed

- **`listSubTopics`** — `findOneByOrFail` was inside the try/catch; missing topic was 500'ing instead of 404. Moved lookup out and pre-checked with `findOneBy`.
- **`listSubTopics`** — unanchored `/\d+/` regex accepted `"100abc"` and `parseInt`'d it to 100. Anchored to `/^\d+$/`.
- **`generatePivotFilterId`** — `BadRequestException` throws were outside the try/catch, surfacing as 500s. Wrapped body in try/catch; added missing-pivot guard (`class-validator`'s `@ValidateNested` only fires if the nested value is present).
- **`generatePivotFilterId`** — `createPivotQuery(req.language, …)` was reading `queryStore.query['en']` when the map is keyed by full locale (`'en-GB'`). Normalised via `langToLocale`.
- **`QueryStoreRepository.getById` callers** — `EntityNotFoundError` from `findOneByOrFail` was not translated. Added a single `instanceof EntityNotFoundError → NotFoundException('errors.filter_id_not_found')` branch to the four controller catches. Repo pattern left consistent with `DatasetRepository`, `PublishedRevisionRepository`, etc.
- **Raw English error strings on the pivot path** — `'X Column not found in dataset'` etc. swapped for `errors.invalid_pivot_x_column` / `errors.invalid_pivot_y_column` / `errors.pivot_non_axis_multi_value`, matching the rest of the controller.
- **Swagger short-form** — `/topic`, `/topic/:topic_id`, `/:dataset_id` were using the `responses[200]: { schema: ... }` short form, which swagger-autogen expands into phantom `application/xml` variants. Converted to explicit `content: { 'application/json': { schema: ... } }` — same fix as applied to v1.

## Removals

- **`GET /v2/:dataset_id/revision/:revision_id`** (+ `ensurePublishedRevision` middleware + controller function + `SingleLanguageRevisionDTO` import in the controller). Swagger-ignored, not called by the frontend, DTO was partially broken (metadata/providers/topics never populated) and fixing it would have been work for a nonexistent consumer.

## Refactors

- **`langToLocale`** collapsed from 12 lines to 3, now returns `Locale` directly, accepts `string | undefined | null`, case-insensitive. Existing unit tests still pass.
- Annotated the two undocumented `/:dataset_id/query/` variants as debugging-only so the intent is discoverable.
- Minor lint tidy in `consumer-v2.ts` (unnecessary `await`, `_req` prefix).

## No change

- **`SearchLog`** keywords telemetry — confirmed intentional (feeds publisher insight into search usage).
- Experimental `GET /:dataset_id/data/:filter_id/pivot` — left as-is with its existing comment.

## Test plan

- [ ] CI green on the new v2 suite
- [ ] Spot-check `GET /v2/topic/999999` returns 404 (was 500)
- [ ] Spot-check `GET /v2/topic/100abc` returns 404 (was 200)
- [ ] Spot-check `POST /v2/:id/pivot` with `{}` body returns 400 (was 500)
- [ ] Spot-check `GET /v2/:id/data/<missing-filter-uuid>` returns 404 (was 500)
- [ ] Spot-check the generated OpenAPI for `/v2/topic` and friends no longer lists `application/xml` responses
