### PR TITLE
SW-1253: distinguish dataset-not-found from DB errors in load middleware

### DIFF
--- a/src/routes/consumer/v1/api.ts
+++ b/src/routes/consumer/v1/api.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Router, Request, Response } from 'express';
-import { FindOptionsRelations } from 'typeorm';
+import { EntityNotFoundError, FindOptionsRelations } from 'typeorm';
 import cors from 'cors';
 
 import { logger } from '../../../utils/logger';
@@ -36,8 +36,12 @@ export const loadPublishedDataset = (relations?: FindOptionsRelations<Dataset>) 
       const dataset = await PublishedDatasetRepository.getById(req.params.dataset_id, relations);
       res.locals.datasetId = dataset.id;
       res.locals.dataset = dataset;
-    } catch (_err) {
-      next(new NotFoundException('errors.no_dataset'));
+    } catch (err) {
+      if (err instanceof EntityNotFoundError) {
+        next(new NotFoundException('errors.no_dataset'));
+        return;
+      }
+      next(err);
       return;
     }
 

--- a/src/routes/consumer/v1/api.ts
+++ b/src/routes/consumer/v1/api.ts
@@ -14,6 +14,7 @@ import {
   getPublicationHistory
 } from '../../../controllers/consumer';
 import { NotFoundException } from '../../../exceptions/not-found.exception';
+import { UnknownException } from '../../../exceptions/unknown.exception';
 import { longTimeout } from '../../../middleware/timeout';
 import { PublishedDatasetRepository } from '../../../repositories/published-dataset';
 import { hasError, datasetIdValidator } from '../../../validators';
@@ -41,7 +42,8 @@ export const loadPublishedDataset = (relations?: FindOptionsRelations<Dataset>) 
         next(new NotFoundException('errors.no_dataset'));
         return;
       }
-      next(err);
+      logger.error(err, `Failed to load published dataset ${req.params.dataset_id}`);
+      next(new UnknownException());
       return;
     }
 

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -1,4 +1,5 @@
 import express, { NextFunction, Router, Request, Response } from 'express';
+import { EntityNotFoundError } from 'typeorm';
 import cors from 'cors';
 
 import { logger } from '../../../utils/logger';
@@ -37,13 +38,17 @@ export const ensurePublishedDataset = async (req: Request, res: Response, next: 
     const dataset = await PublishedDatasetRepository.getById(req.params.dataset_id);
 
     if (!dataset.publishedRevisionId) {
-      throw new Error('dataset has no published revision');
+      throw new NotFoundException('errors.no_dataset');
     }
 
     res.locals.datasetId = dataset.id;
     res.locals.dataset = dataset;
-  } catch (_err) {
-    next(new NotFoundException('errors.no_dataset'));
+  } catch (err) {
+    if (err instanceof EntityNotFoundError || err instanceof NotFoundException) {
+      next(new NotFoundException('errors.no_dataset'));
+      return;
+    }
+    next(err);
     return;
   }
 

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -18,6 +18,7 @@ import {
   getFilterIdDetails
 } from '../../../controllers/consumer-v2';
 import { NotFoundException } from '../../../exceptions/not-found.exception';
+import { UnknownException } from '../../../exceptions/unknown.exception';
 import { longTimeout } from '../../../middleware/timeout';
 import { PublishedDatasetRepository } from '../../../repositories/published-dataset';
 import { hasError, uuidValidator } from '../../../validators';
@@ -44,11 +45,16 @@ export const ensurePublishedDataset = async (req: Request, res: Response, next: 
     res.locals.datasetId = dataset.id;
     res.locals.dataset = dataset;
   } catch (err) {
-    if (err instanceof EntityNotFoundError || err instanceof NotFoundException) {
+    if (err instanceof EntityNotFoundError) {
       next(new NotFoundException('errors.no_dataset'));
       return;
     }
-    next(err);
+    if (err instanceof NotFoundException) {
+      next(err);
+      return;
+    }
+    logger.error(err, `Failed to load published dataset ${req.params.dataset_id}`);
+    next(new UnknownException());
     return;
   }
 

--- a/test/integration/routes/consumer-v1/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v1/cross-cutting.test.ts
@@ -129,11 +129,13 @@ describe('Consumer V1 — cross-cutting behaviour (CORS, method guard, Vary, 404
       jest.restoreAllMocks();
     });
 
-    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as 500', async () => {
+    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as a sanitized JSON 500', async () => {
       jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(new Error('connection terminated'));
 
       const res = await request(app).get(`/v1/${DATASET_ID}`);
       expect(res.status).toBe(500);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.text).not.toContain('connection terminated');
     });
   });
 

--- a/test/integration/routes/consumer-v1/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v1/cross-cutting.test.ts
@@ -11,6 +11,7 @@ import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-d
 import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
 import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
 import BlobStorage from '../../../../src/services/blob-storage';
+import { PublishedDatasetRepository } from '../../../../src/repositories/published-dataset';
 
 jest.mock('../../../../src/services/blob-storage');
 BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
@@ -121,6 +122,19 @@ describe('Consumer V1 — cross-cutting behaviour (CORS, method guard, Vary, 404
         expect(res.status).toBe(404);
       });
     }
+  });
+
+  describe('DB error during dataset load returns 500 (SW-1253)', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as 500', async () => {
+      jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(new Error('connection terminated'));
+
+      const res = await request(app).get(`/v1/${DATASET_ID}`);
+      expect(res.status).toBe(500);
+    });
   });
 
   describe('Error response shape', () => {

--- a/test/integration/routes/consumer-v2/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v2/cross-cutting.test.ts
@@ -126,11 +126,13 @@ describe('Consumer V2 — cross-cutting behaviour (CORS, Vary, 404 sweeps)', () 
       jest.restoreAllMocks();
     });
 
-    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as 500', async () => {
+    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as a sanitized JSON 500', async () => {
       jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(new Error('connection terminated'));
 
       const res = await request(app).get(`/v2/${DATASET_ID}`);
       expect(res.status).toBe(500);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.text).not.toContain('connection terminated');
     });
   });
 

--- a/test/integration/routes/consumer-v2/cross-cutting.test.ts
+++ b/test/integration/routes/consumer-v2/cross-cutting.test.ts
@@ -11,6 +11,7 @@ import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-d
 import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
 import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
 import BlobStorage from '../../../../src/services/blob-storage';
+import { PublishedDatasetRepository } from '../../../../src/repositories/published-dataset';
 
 jest.mock('../../../../src/services/blob-storage');
 BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
@@ -118,6 +119,19 @@ describe('Consumer V2 — cross-cutting behaviour (CORS, Vary, 404 sweeps)', () 
         expect(res.status).toBe(404);
       });
     }
+  });
+
+  describe('DB error during dataset load returns 500 (SW-1253)', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('non-EntityNotFoundError from PublishedDatasetRepository.getById surfaces as 500', async () => {
+      jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(new Error('connection terminated'));
+
+      const res = await request(app).get(`/v2/${DATASET_ID}`);
+      expect(res.status).toBe(500);
+    });
   });
 
   describe('Error response shape', () => {


### PR DESCRIPTION
## Summary

The v1 `loadPublishedDataset` and v2 `ensurePublishedDataset` middleware previously caught **every** exception from `PublishedDatasetRepository.getById()` and returned 404, conflating four different conditions (genuine misses, pool-acquisition timeouts, query timeouts, transient connection errors) into one response code.

During the 2026-04-23 incident this conflation actively misled live decision-making — the pgbouncer pool-mode flip was working, but persistent 404s caused by the still-saturated TypeORM pool looked like the change had broken the app, so the mitigation was rolled back.

This change discriminates TypeORM's `EntityNotFoundError` (the specific error `findOneOrFail` throws when the row genuinely isn't there) and maps only that → 404. Any other error propagates to the global error handler, which logs it with stack trace and returns 500 — matching the pattern already used in `src/controllers/consumer-v2.ts` for filter-id lookups.

## Changes

- `src/routes/consumer/v1/api.ts` — discriminate `EntityNotFoundError` in `loadPublishedDataset`'s catch block.
- `src/routes/consumer/v2/api.ts` — same discrimination in `ensurePublishedDataset`; replaced the plain `Error('dataset has no published revision')` with `NotFoundException` so the "no published revision" path keeps its existing 404 behaviour.
- `test/integration/routes/consumer-v1/cross-cutting.test.ts` and `consumer-v2/cross-cutting.test.ts` — added a "DB error during dataset load returns 500" describe block that spies on `PublishedDatasetRepository.getById` to reject with a non-`EntityNotFoundError`.

Existing 404 sweeps (malformed UUID, non-existent dataset) still pass — the genuine-miss path is unchanged.

## Consumer audit

- **statswales-frontend** `consumer/middleware/fetch-dataset.ts:24` already discriminates: it only treats 4xx as "dataset missing" and propagates 5xx via `next(err)`. The new backend behaviour aligns correctly with this — no frontend changes needed.
- The frontend's only other `error.status === 404` check (`publisher/controllers/publish.ts:697`) is on a publisher-API call (`getDatasetPreview`), not the consumer endpoints touched here.

## Test plan

- [x] `npm run check` — all 1260 tests pass, build green.
- [ ] Existing 404 sweeps in both `cross-cutting.test.ts` files still pass (proves genuine misses still return 404).
- [ ] New "DB error → 500" tests in both files pass (proves DB failures now surface correctly).
- [ ] Manual smoke: hit `/v1/<known-good-id>` and `/v2/<known-good-id>` → 200; hit with a random UUID → 404.


[SW-1253]: https://marvellconsulting.atlassian.net/browse/SW-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ