### PR TITLE
SW-1234 Fix 0 zero cells in excel

### DIFF
--- a/src/routes/consumer/v2/openapi-cy.json
+++ b/src/routes/consumer/v2/openapi-cy.json
@@ -207,7 +207,7 @@
           "Data"
         ],
         "summary": "Cael hidlwyr sydd ar gael ar gyfer set ddata",
-        "description": "<p>Mae'n dychwelyd rhestr o newidynnau mewn set ddata, y mae modd eu hidlo, a phob gwerth hidladwy ar gyfer pob newidyn.</p>  <p>Mae gan newidynnau:</p>  <ul>  <li>enw 'factTableColumn' a ddefnyddir pan gaiff y set ddata ei chreu yn y lle cyntaf</li>  <li>'columnName' y gall rhywun ei ddarllen</li>  </ul>  <p>Mae gan werthoedd:</p>  <ul>  <li>cod 'reference'</li>  <li>'description' y gall rhywun ei ddarllen</li>  </ul>",
+        "description": "<p>Mae'n dychwelyd rhestr o newidynnau mewn set ddata, y mae modd eu hidlo, a phob gwerth hidladwy ar gyfer pob newidyn.</p>  <p>Mae gan newidynnau:</p>  <ul>  <li>enw 'factTableColumn' a ddefnyddir pan gaiff y set ddata ei chreu yn y lle cyntaf</li>  <li>'columnName' y gall rhywun ei ddarllen</li>  </ul>  <p>Mae gan werthoedd:</p>  <ul>  <li>cod 'reference'</li>  <li>'description' y gall rhywun ei ddarllen</li> </ul> <p>Mae gan werthoedd:</p> <ul> <li>'count'</li> <li>Cyfanswm nifer y ffeithiau sy'n gysylltiedig â chyfeiriad os yw'n hysbys (rhagosodiad i 1 os nad yw'n hysbys)</li> </ul>",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"

--- a/src/routes/consumer/v2/openapi-en.json
+++ b/src/routes/consumer/v2/openapi-en.json
@@ -207,7 +207,7 @@
           "Data"
         ],
         "summary": "Get available filters for a dataset",
-        "description": "<p>Returns a list of variables in a dataset that can be  filtered, and all filterable values for each variable.</p>  <p>Variables have a:</p>  <ul>  <li>'factTableColumn' name which is used when the dataset is originally created</li>  <li>human-readable 'columnName'</li>  </ul>  <p>Values have a:</p>  <ul>  <li>'reference' code</li>  <li>human-readable 'description'</li>  </ul>  ",
+        "description": "<p>Returns a list of variables in a dataset that can be  filtered, and all filterable values for each variable.</p>  <p>Variables have a:</p>  <ul>  <li>'factTableColumn' name which is used when the dataset is originally created</li>  <li>human-readable 'columnName'</li>  </ul>  <p>Values have a:</p>  <ul>  <li>'reference' code</li>  <li>human-readable 'description'</li>  </ul>  <p>Values have a:</p>  <ul>  <li>'count'</li>  <li>Total number of facts associated with a reference if known (defaults to 1 if not known)</li>  </ul>  ",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -278,7 +278,7 @@ async function pivotToExcel(
       if (row === null) break;
       const data = columnMapping.map((srcIdx) => {
         const val = row[srcIdx];
-        if (val === null || val === undefined) return null;
+        if (val === null || val === undefined || val === '') return null;
         return isNaN(Number(val)) ? val : Number(val);
       });
       worksheet.addRow(data).commit();

--- a/test/unit/services/pivots.test.ts
+++ b/test/unit/services/pivots.test.ts
@@ -647,6 +647,38 @@ describe('pivots service', () => {
       });
     });
 
+    describe('Excel output', () => {
+      it('writes a blank cell (not 0) when the DuckDB value is an empty string', async () => {
+        // Number('') === 0, so without the explicit '' check the cell would be written as 0.
+        const columns = ['Area', '2020', '2021'];
+        const rows: DuckDBValue[][] = [['Cardiff', '' as unknown as DuckDBValue, 200]];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockBinaryResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Excel });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const buffer = await res.getBuffer();
+        const workbook = new ExcelJS.Workbook();
+        // @ts-expect-error ExcelJS types expect old Buffer, Node 24 returns Buffer<ArrayBuffer>
+        await workbook.xlsx.load(buffer);
+
+        const worksheet = workbook.getWorksheet(1)!;
+        const dataRow = worksheet.getRow(2).values as (string | number | null)[];
+
+        // ExcelJS row values are 1-indexed (index 0 is empty)
+        expect(dataRow[1]).toBe('Cardiff');
+        expect(dataRow[2]).toBeUndefined(); // blank cell — ExcelJS omits it from the values array
+        expect(dataRow[3]).toBe(200);
+      });
+    });
+
     describe('column reordering aligns cell data with headers', () => {
       // DuckDB returns columns in its own order (e.g. ['Area', '2020', '2022', '2021']),
       // but getSortedPivotColumns reorders them (e.g. ['Area', '2022', '2021', '2020']).

--- a/test/unit/services/pivots.test.ts
+++ b/test/unit/services/pivots.test.ts
@@ -651,7 +651,7 @@ describe('pivots service', () => {
       it('writes a blank cell (not 0) when the DuckDB value is an empty string', async () => {
         // Number('') === 0, so without the explicit '' check the cell would be written as 0.
         const columns = ['Area', '2020', '2021'];
-        const rows: DuckDBValue[][] = [['Cardiff', '' as unknown as DuckDBValue, 200]];
+        const rows: DuckDBValue[][] = [['Cardiff', '', 200]];
         setupMockDuckDB(columns, rows);
 
         const res = createMockBinaryResponse();

--- a/test/unit/services/pivots.test.ts
+++ b/test/unit/services/pivots.test.ts
@@ -670,12 +670,12 @@ describe('pivots service', () => {
         await workbook.xlsx.load(buffer);
 
         const worksheet = workbook.getWorksheet(1)!;
-        const dataRow = worksheet.getRow(2).values as (string | number | null)[];
+        const dataRow = worksheet.getRow(2);
 
-        // ExcelJS row values are 1-indexed (index 0 is empty)
-        expect(dataRow[1]).toBe('Cardiff');
-        expect(dataRow[2]).toBeUndefined(); // blank cell — ExcelJS omits it from the values array
-        expect(dataRow[3]).toBe(200);
+        // ExcelJS cells are 1-indexed
+        expect(dataRow.getCell(1).value).toBe('Cardiff');
+        expect(dataRow.getCell(2).value).toBeNull(); // blank cell
+        expect(dataRow.getCell(3).value).toBe(200);
       });
     });
 


### PR DESCRIPTION
When a cell is empty in the pivot it comes through as an empty string rather than a null.  So added code to treat empty strings as nulls for the purposes of excel downloads.