### PR TITLE
SW-1263 Add retry and rebuild to frontend queries

### DIFF
--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -19,6 +19,8 @@ import { PageOptions } from '../interfaces/page-options';
 import { logger } from '../utils/logger';
 import { ConsumerDatasetDTO } from '../dtos/consumer-dataset-dto';
 import { getColumnHeaders } from '../utils/column-headers';
+import { QueryStoreRepository } from '../repositories/query-store';
+import { DataSource } from 'typeorm';
 
 const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76 rows because ?
 const HIGH_WATER_MARK = 500; // max rows to buffer in memory at once when streaming from the database
@@ -279,6 +281,32 @@ export async function sendFilters(query: string, res: Response): Promise<void> {
   }
 }
 
+async function runAndRetryQuery(query: string, queryStore: QueryStore, cubeDataSource: DataSource): Promise<never[]> {
+  logger.debug(`Fetching view data for query id ${queryStore.id}...`);
+  let rows: never[];
+  try {
+    rows = await cubeDataSource.query(query);
+  } catch (error) {
+    logger.warn(error, 'Query failed trying alternative view name');
+    let retryQuery = query;
+    if (query.includes('core_view_mat')) {
+      retryQuery = query.replace('core_view_mat', 'core_view');
+    } else {
+      retryQuery = query.replace('core_view', 'core_view_mat');
+    }
+    try {
+      rows = await cubeDataSource.query(retryQuery);
+    } catch (retryError) {
+      logger.warn(retryError, 'Query still failed after retrying');
+      throw retryError;
+    }
+    void QueryStoreRepository.rebuildQueriesForRevision(queryStore.revisionId).catch((err) => {
+      logger.warn(err, `Rebuild query store entries for revision ${queryStore.revisionId} failed.`);
+    });
+  }
+  return rows;
+}
+
 export async function sendFrontendView(
   query: string,
   queryStore: QueryStore,
@@ -317,8 +345,7 @@ export async function sendFrontendView(
     logger.debug(`Fetching dataset ${queryStore.datasetId}...`);
     const dataset = await DatasetRepository.getById(queryStore.datasetId, { factTable: true, dimensions: true });
 
-    logger.debug(`Fetching view data for query id ${queryStore.id}...`);
-    const rows = await cubeDataSource.query(query);
+    const rows = await runAndRetryQuery(query, queryStore, cubeDataSource);
     logger.debug(`Fetched ${rows.length} rows`);
 
     // Build headers from the first row if available

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -300,9 +300,7 @@ async function runAndRetryQuery(query: string, queryStore: QueryStore, cubeDataS
       logger.warn(retryError, 'Query still failed after retrying');
       throw retryError;
     }
-    void QueryStoreRepository.rebuildQueriesForRevision(queryStore.revisionId).catch((err) => {
-      logger.warn(err, `Rebuild query store entries for revision ${queryStore.revisionId} failed.`);
-    });
+    void QueryStoreRepository.rebuildQueryEntry(queryStore.id);
   }
   return rows;
 }

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -288,12 +288,9 @@ async function runAndRetryQuery(query: string, queryStore: QueryStore, cubeDataS
     rows = await cubeDataSource.query(query);
   } catch (error) {
     logger.warn(error, 'Query failed trying alternative view name');
-    let retryQuery = query;
-    if (query.includes('core_view_mat')) {
-      retryQuery = query.replace('core_view_mat', 'core_view');
-    } else {
-      retryQuery = query.replace('core_view', 'core_view_mat');
-    }
+    const retryQuery = query.includes('core_view_mat')
+      ? query.replace('core_view_mat', 'core_view')
+      : query.replace('core_view', 'core_view_mat');
     try {
       rows = await cubeDataSource.query(retryQuery);
     } catch (retryError) {

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -301,7 +301,9 @@ async function runAndRetryQuery(
       logger.warn(retryError, 'Query still failed after retrying');
       throw retryError;
     }
-    void QueryStoreRepository.rebuildQueryEntry(queryStore.id);
+    void QueryStoreRepository.rebuildQueryEntry(queryStore.id).catch((rebuildError) => {
+      logger.warn(rebuildError, `Failed to rebuild query entry for query id ${queryStore.id}`);
+    });
   }
   return rows;
 }

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -281,9 +281,13 @@ export async function sendFilters(query: string, res: Response): Promise<void> {
   }
 }
 
-async function runAndRetryQuery(query: string, queryStore: QueryStore, cubeDataSource: DataSource): Promise<never[]> {
+async function runAndRetryQuery(
+  query: string,
+  queryStore: QueryStore,
+  cubeDataSource: DataSource
+): Promise<Record<string, unknown>[]> {
   logger.debug(`Fetching view data for query id ${queryStore.id}...`);
-  let rows: never[];
+  let rows: Record<string, unknown>[];
   try {
     rows = await cubeDataSource.query(query);
   } catch (error) {

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -640,12 +640,12 @@ describe('consumer-view-v2 service', () => {
       expect(jsonArg.note_codes).toEqual([]);
     });
 
-    it('should retry with core_view when a query using core_view_mat fails', async () => {
+    it('should retry with core_view_en when a query using core_view_mat_en fails', async () => {
       mockCubeQuery
         .mockResolvedValueOnce([]) // filters query
         .mockResolvedValueOnce([]) // note_codes query
         .mockRejectedValueOnce(new Error('relation does not exist')) // first data query fails
-        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view succeeds
+        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view_en succeeds
 
       mockGetById.mockResolvedValue({ id: 'dataset-id', factTable: [], dimensions: [] });
 
@@ -659,22 +659,22 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM "schema".core_view_mat', queryStore, pageOptions, res);
+      await sendFrontendView('SELECT * FROM "schema".core_view_mat_en', queryStore, pageOptions, res);
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);
       const retryCall = mockCubeQuery.mock.calls[3][0] as string;
-      expect(retryCall).toContain('core_view');
-      expect(retryCall).not.toContain('core_view_mat');
+      expect(retryCall).toContain('core_view_en');
+      expect(retryCall).not.toContain('core_view_mat_en');
       expect(mockRebuildQueryEntry).toHaveBeenCalledWith(queryStore.id);
       expect(res.json).toHaveBeenCalled();
     });
 
-    it('should retry with core_view_mat when a query using core_view fails', async () => {
+    it('should retry with core_view_mat_en when a query using core_view_en fails', async () => {
       mockCubeQuery
         .mockResolvedValueOnce([]) // filters query
         .mockResolvedValueOnce([]) // note_codes query
         .mockRejectedValueOnce(new Error('relation does not exist')) // first data query fails
-        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view_mat succeeds
+        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view_mat_en succeeds
 
       mockGetById.mockResolvedValue({ id: 'dataset-id', factTable: [], dimensions: [] });
 
@@ -688,11 +688,11 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM "schema".core_view', queryStore, pageOptions, res);
+      await sendFrontendView('SELECT * FROM "schema".core_view_en', queryStore, pageOptions, res);
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);
       const retryCall = mockCubeQuery.mock.calls[3][0] as string;
-      expect(retryCall).toContain('core_view_mat');
+      expect(retryCall).toContain('core_view_mat_en');
       expect(mockRebuildQueryEntry).toHaveBeenCalledWith(queryStore.id);
       expect(res.json).toHaveBeenCalled();
     });
@@ -718,7 +718,7 @@ describe('consumer-view-v2 service', () => {
       const res = createMockStreamResponse();
 
       await expect(
-        sendFrontendView('SELECT * FROM "schema".core_view_mat', queryStore, pageOptions, res)
+        sendFrontendView('SELECT * FROM "schema".core_view_mat_en', queryStore, pageOptions, res)
       ).rejects.toThrow('retry also failed');
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -19,6 +19,14 @@ const mockCubeQuery = jest.fn();
 const mockObtainMasterConnection = jest.fn();
 const mockRelease = jest.fn();
 
+// Mock QueryStoreRepository
+const mockRebuildQueryEntry = jest.fn();
+jest.mock('../../../src/repositories/query-store', () => ({
+  QueryStoreRepository: {
+    rebuildQueryEntry: (...args: unknown[]) => mockRebuildQueryEntry(...args)
+  }
+}));
+
 jest.mock('../../../src/db/database-manager', () => ({
   dbManager: {
     getCubeDataSource: () => ({
@@ -190,6 +198,7 @@ describe('consumer-view-v2 service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRelease.mockResolvedValue(undefined);
+    mockRebuildQueryEntry.mockResolvedValue(undefined);
   });
 
   describe('sendCsv', () => {
@@ -629,6 +638,91 @@ describe('consumer-view-v2 service', () => {
 
       const jsonArg = (res.json as jest.Mock).mock.calls[0][0];
       expect(jsonArg.note_codes).toEqual([]);
+    });
+
+    it('should retry with core_view when a query using core_view_mat fails', async () => {
+      mockCubeQuery
+        .mockResolvedValueOnce([]) // filters query
+        .mockResolvedValueOnce([]) // note_codes query
+        .mockRejectedValueOnce(new Error('relation does not exist')) // first data query fails
+        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view succeeds
+
+      mockGetById.mockResolvedValue({ id: 'dataset-id', factTable: [], dimensions: [] });
+
+      const queryStore = createMockQueryStore({ totalLines: 1 });
+      const pageOptions: PageOptions = {
+        format: OutputFormats.Frontend,
+        sort: [],
+        locale: Locale.EnglishGb,
+        pageNumber: 1,
+        pageSize: 10
+      };
+      const res = createMockStreamResponse();
+
+      await sendFrontendView('SELECT * FROM "schema".core_view_mat', queryStore, pageOptions, res);
+
+      expect(mockCubeQuery).toHaveBeenCalledTimes(4);
+      const retryCall = mockCubeQuery.mock.calls[3][0] as string;
+      expect(retryCall).toContain('core_view');
+      expect(retryCall).not.toContain('core_view_mat');
+      expect(mockRebuildQueryEntry).toHaveBeenCalledWith(queryStore.id);
+      expect(res.json).toHaveBeenCalled();
+    });
+
+    it('should retry with core_view_mat when a query using core_view fails', async () => {
+      mockCubeQuery
+        .mockResolvedValueOnce([]) // filters query
+        .mockResolvedValueOnce([]) // note_codes query
+        .mockRejectedValueOnce(new Error('relation does not exist')) // first data query fails
+        .mockResolvedValueOnce([{ col1: 'val1' }]); // retry with core_view_mat succeeds
+
+      mockGetById.mockResolvedValue({ id: 'dataset-id', factTable: [], dimensions: [] });
+
+      const queryStore = createMockQueryStore({ totalLines: 1 });
+      const pageOptions: PageOptions = {
+        format: OutputFormats.Frontend,
+        sort: [],
+        locale: Locale.EnglishGb,
+        pageNumber: 1,
+        pageSize: 10
+      };
+      const res = createMockStreamResponse();
+
+      await sendFrontendView('SELECT * FROM "schema".core_view', queryStore, pageOptions, res);
+
+      expect(mockCubeQuery).toHaveBeenCalledTimes(4);
+      const retryCall = mockCubeQuery.mock.calls[3][0] as string;
+      expect(retryCall).toContain('core_view_mat');
+      expect(mockRebuildQueryEntry).toHaveBeenCalledWith(queryStore.id);
+      expect(res.json).toHaveBeenCalled();
+    });
+
+    it('should surface the retry error when both the original query and the retry fail', async () => {
+      const retryError = new Error('retry also failed');
+      mockCubeQuery
+        .mockResolvedValueOnce([]) // filters query
+        .mockResolvedValueOnce([]) // note_codes query
+        .mockRejectedValueOnce(new Error('first attempt failed')) // first data query fails
+        .mockRejectedValueOnce(retryError); // retry also fails
+
+      mockGetById.mockResolvedValue({ id: 'dataset-id', factTable: [], dimensions: [] });
+
+      const queryStore = createMockQueryStore({ totalLines: 1 });
+      const pageOptions: PageOptions = {
+        format: OutputFormats.Frontend,
+        sort: [],
+        locale: Locale.EnglishGb,
+        pageNumber: 1,
+        pageSize: 10
+      };
+      const res = createMockStreamResponse();
+
+      await expect(
+        sendFrontendView('SELECT * FROM "schema".core_view_mat', queryStore, pageOptions, res)
+      ).rejects.toThrow('retry also failed');
+
+      expect(mockCubeQuery).toHaveBeenCalledTimes(4);
+      expect(mockRebuildQueryEntry).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Sometimes the frontend query could fail for example if the stored query is based on an non-existant 'core_view' at the point the query is run. This can occur if the original view is accessed before the materialised view is created.  So added some code to retry on the alternative view name and the if that succeeds to rebuild the query store entry.