### PR TITLE
SW-1263 Change how cube rebuilds happen

### DIFF
--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 import { performance } from 'node:perf_hooks';
+import { randomUUID } from 'node:crypto';
 
 import { NextFunction, Request, Response } from 'express';
 import { t } from 'i18next';
@@ -47,7 +48,6 @@ import { buildStatusValidator, buildTypeValidator, hasError } from '../validator
 import { CubeBuildType } from '../enums/cube-build-type';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 import { BuildLogRepository } from '../repositories/build-log';
-import { randomUUID } from 'node:crypto';
 
 export const getDataTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const revision: Revision = res.locals.revision;

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -40,17 +40,14 @@ import { cleanupTmpFile, uploadAvScan } from '../services/virus-scanner';
 import { TempFile } from '../interfaces/temp-file';
 import { DEFAULT_PAGE_SIZE } from '../utils/page-defaults';
 import { attachUpdateDataTableToRevision } from '../services/revision';
-import { performanceReporting } from '../utils/performance-reporting';
 import { resolvePreviewRevisionId } from '../utils/revision';
-import { CubeBuildResult } from '../dtos/cube-build-result';
 import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
 import { BuiltLogEntryDto } from '../dtos/build-log';
 import { buildStatusValidator, buildTypeValidator, hasError } from '../validators';
 import { CubeBuildType } from '../enums/cube-build-type';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 import { BuildLogRepository } from '../repositories/build-log';
-import { QueryStore } from '../entities/query-store';
-import { QueryStoreRepository } from '../repositories/query-store';
+import { randomUUID } from 'node:crypto';
 
 export const getDataTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const revision: Revision = res.locals.revision;
@@ -453,44 +450,22 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
   const datasetId: string = res.locals.datasetId;
   const revision: Revision = res.locals.revision;
   const userId = req.user?.id;
-
-  const startTime = new Date(Date.now());
-  const start = performance.now();
+  const buildId = randomUUID();
   try {
     await bootstrapCubeBuildProcess(datasetId, revision.id);
-    await createAllCubeFiles(datasetId, revision.id, userId);
-    // If this is draft revision we can just purge the query store,
-    // otherwise we can attempt to rebuild all the queries preserving
-    // their IDs so as not to break peoples links.
-    if (!revision.publishAt || revision.publishAt.getTime() > Date.now()) {
-      await QueryStore.delete({ revisionId: revision.id });
-    } else {
-      await QueryStoreRepository.rebuildQueriesForRevision(revision.id);
-    }
   } catch (err) {
-    logger.error(err, `Something went wrong trying to create the cube`);
+    logger.error(err, `Something went wrong trying to boot strap the cube build process`);
     const exception = new UnknownException('errors.cube_builder.cube_build_failed');
-    exception.performance = {
-      message: 'Cube regeneration failed',
-      memory_usage: process.memoryUsage(),
-      start_time: startTime,
-      finish_time: new Date(Date.now()),
-      total_time: performance.now() - start,
-      error: err as Error
-    };
     next(exception);
     return;
   }
-  performanceReporting(performance.now() - start, 30000, 'Full Cube Rebuild');
-  res.status(201);
-  const reporting: CubeBuildResult = {
-    message: 'Cube regeneration in postgres successful',
-    memory_usage: process.memoryUsage(),
-    start_time: startTime,
-    finish_time: new Date(Date.now()),
-    total_time: performance.now() - start
-  };
-  res.json(reporting);
+  void createAllCubeFiles(datasetId, revision.id, userId, CubeBuildType.FullCube, buildId).catch((err) => {
+    logger.warn(err, `Async cube build with build id ${buildId} failed with an error.`);
+  });
+  res.status(202);
+  res.json({
+    build_id: buildId
+  });
 };
 
 // export const downloadRevisionCubeFile = async (req: Request, res: Response) => {

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -454,7 +454,7 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
   try {
     await bootstrapCubeBuildProcess(datasetId, revision.id);
   } catch (err) {
-    logger.error(err, `Something went wrong trying to boot strap the cube build process`);
+    logger.error(err, `Something went wrong trying to bootstrap the cube build process`);
     const exception = new UnknownException('errors.cube_builder.cube_build_failed');
     next(exception);
     return;

--- a/src/dtos/cube-build-result.ts
+++ b/src/dtos/cube-build-result.ts
@@ -1,8 +1,0 @@
-export interface CubeBuildResult {
-  message: string;
-  memory_usage: NodeJS.MemoryUsage;
-  start_time: Date;
-  finish_time: Date;
-  total_time: number;
-  error?: Error;
-}

--- a/src/exceptions/unknown.exception.ts
+++ b/src/exceptions/unknown.exception.ts
@@ -1,7 +1,4 @@
-import { CubeBuildResult } from '../dtos/cube-build-result';
-
 export class UnknownException extends Error {
-  performance: CubeBuildResult | null = null;
   constructor(
     public message = 'Server Error',
     public status = 500

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -36,6 +36,8 @@ import { UniqueMeasureDetails } from '../interfaces/unique-measure-details';
 import { MeasureFormat } from '../interfaces/measure-format';
 import { RevisionRepository } from '../repositories/revision';
 import { QueryStore } from '../entities/query-store';
+import { isPublished } from '../utils/revision';
+import { QueryStoreRepository } from '../repositories/query-store';
 
 export const FACT_TABLE_NAME = 'fact_table';
 export const METADATA_TABLE_NAME = 'metadata';
@@ -179,18 +181,13 @@ export const createAllCubeFiles = async (
   build.status = CubeBuildStatus.Materializing;
   await build.save();
 
-  // Purge query store on unpublished cube changes
-  if (dataset.draftRevisionId === buildRevisionId) {
-    await QueryStore.delete({ revisionId: buildRevisionId });
-  }
-
   if (awaitMaterialisation) {
     logger.debug('Awaiting materialised view creation...');
-    await createMaterialisedView(buildRevisionId, dataset, build.id, cubeBuild, cubeBuildConfig);
+    await createMaterialisedView(buildRevision, dataset, build.id, cubeBuild, cubeBuildConfig);
   } else {
     // don't wait for this, can happen in the background so we can send the response earlier
     logger.debug(`Fire-and-forget materialised view creation for revision ${buildRevisionId}`);
-    void createMaterialisedView(buildRevisionId, dataset, build.id, cubeBuild, cubeBuildConfig).catch((err) => {
+    void createMaterialisedView(buildRevision, dataset, build.id, cubeBuild, cubeBuildConfig).catch((err) => {
       logger.error(
         err,
         `[build ID: ${build.id}] An error occurred trying to create materialised view for revision ${buildRevisionId}`
@@ -350,7 +347,7 @@ async function createBasePostgresCube(
 }
 
 async function createMaterialisedView(
-  revisionId: string,
+  revision: Revision,
   dataset: Dataset,
   buildId: string,
   cubeBuilder: CubeBuilder,
@@ -367,21 +364,23 @@ async function createMaterialisedView(
     const lang = locale.toLowerCase().split('-')[0];
     const materializedViewName = `${CORE_VIEW_NAME}_mat_${lang}`;
     const originalCoreViewSQL =
-      cubeBuilder.coreViewSQL.get(locale) || pgformat('SELECT * FROM %I.%I;', revisionId, FACT_TABLE_NAME);
+      cubeBuilder.coreViewSQL.get(locale) || pgformat('SELECT * FROM %I.%I;', revision.id, FACT_TABLE_NAME);
     statements.push(
       pgformat(
         'CREATE MATERIALIZED VIEW %I.%I AS %s;',
-        revisionId,
+        revision.id,
         materializedViewName,
-        originalCoreViewSQL.replaceAll(build.id, revisionId)
+        originalCoreViewSQL.replaceAll(build.id, revision.id)
       )
     );
-    statements.push(...createViewsFromConfig(revisionId, materializedViewName, locale, viewConfig, dataset.factTable!));
-    statements.push(pgformat('DROP VIEW %I.%I;', revisionId, `${CORE_VIEW_NAME}_${lang}`));
+    statements.push(
+      ...createViewsFromConfig(revision.id, materializedViewName, locale, viewConfig, dataset.factTable!)
+    );
+    statements.push(pgformat('DROP VIEW %I.%I;', revision.id, `${CORE_VIEW_NAME}_${lang}`));
     statements.push(
       pgformat(
         `UPDATE %I.${METADATA_TABLE_NAME} SET value = %L WHERE key = %L;`,
-        revisionId,
+        revision.id,
         CubeBuildStatus.Completed,
         CubeMetaDataKeys.BuildStatus
       )
@@ -389,7 +388,7 @@ async function createMaterialisedView(
     statements.push(
       pgformat(
         `INSERT INTO %I.${METADATA_TABLE_NAME} VALUES(%L, %L);`,
-        revisionId,
+        revision.id,
         CubeMetaDataKeys.BuildFinished,
         new Date().toISOString()
       )
@@ -401,7 +400,7 @@ async function createMaterialisedView(
       }
     }
     for (const col of indexCols) {
-      statements.push(pgformat('CREATE INDEX ON %I.%I (%I);', revisionId, materializedViewName, col));
+      statements.push(pgformat('CREATE INDEX ON %I.%I (%I);', revision.id, materializedViewName, col));
     }
   }
   statements.push('COMMIT;');
@@ -410,14 +409,12 @@ async function createMaterialisedView(
   for (const blk of cubeBuilder.transactionBlocks) {
     fullBuildScriptArr.push(...blk.statements);
   }
-  const buildStatements = statements.join('\n').replaceAll(build.id, revisionId);
+  const buildStatements = statements.join('\n').replaceAll(build.id, revision.id);
 
   const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
   try {
     logger.trace(`Running query:\n\n${buildStatements}\n\n`);
     await cubeDB.query(buildStatements);
-    build.completeBuild(CubeBuildStatus.Completed, fullBuildScriptArr.join('\n'));
-    await build.save();
     performanceReporting(Math.round(performance.now() - viewCreation), 3000, 'Setting up the materialized views');
   } catch (error) {
     await cubeDB.query('ROLLBACK;');
@@ -426,13 +423,13 @@ async function createMaterialisedView(
         'BEGIN TRANSACTION;',
         pgformat(
           `UPDATE %I.${METADATA_TABLE_NAME} SET value = %L WHERE key = %L;`,
-          revisionId,
+          revision.id,
           CubeBuildStatus.Failed,
           CubeMetaDataKeys.BuildStatus
         ),
         pgformat(
           `UPDATE %I.${METADATA_TABLE_NAME} SET value = %L WHERE key = %L;`,
-          revisionId,
+          revision.id,
           JSON.stringify(error),
           CubeMetaDataKeys.BuildResults
         ),
@@ -452,6 +449,30 @@ async function createMaterialisedView(
   } finally {
     void cubeDB.release();
   }
+
+  const queryStoreCreation = performance.now();
+  try {
+    if (isPublished(revision)) {
+      await QueryStoreRepository.rebuildQueriesForRevision(revision.id);
+    } else {
+      await QueryStore.delete({ revisionId: revision.id });
+    }
+    performanceReporting(Math.round(performance.now() - queryStoreCreation), 3000, 'Processing the query store');
+  } catch (error) {
+    performanceReporting(Math.round(performance.now() - queryStoreCreation), 3000, 'Processing the query store');
+    logger.error(error, `Something went wrong trying to rebuild query store for revision ${revision.id}`);
+    build.completeBuild(CubeBuildStatus.Failed, fullBuildScriptArr.join('\n'), JSON.stringify(error));
+    await build.save();
+    throw error;
+  }
+
+  build.completeBuild(CubeBuildStatus.Completed, fullBuildScriptArr.join('\n'));
+  await build.save();
+  performanceReporting(
+    Math.round(performance.now() - viewCreation),
+    3000,
+    'Setting up the materialized views and dealing with the query store'
+  );
 }
 
 /*

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -106,16 +106,22 @@ describe('POST /dataset/:dataset_id/revision/by-id/:revision_id', () => {
   });
 
   test('creates a BuildLog row in the database for the returned build_id', async () => {
-    jest.mocked(createAllCubeFiles).mockImplementation(async (_datasetId, _revisionId, userId, buildType, buildId) => {
-      const revision = await Revision.findOneBy({ id: _revisionId });
-      await BuildLog.startBuild(revision, buildType!, userId, buildId);
+    let createAllCubeFilesPromise: Promise<void> | undefined;
+
+    jest.mocked(createAllCubeFiles).mockImplementation((_datasetId, _revisionId, userId, buildType, buildId) => {
+      createAllCubeFilesPromise = (async () => {
+        const revision = await Revision.findOneBy({ id: _revisionId });
+        await BuildLog.startBuild(revision, buildType!, userId, buildId);
+      })();
+
+      return createAllCubeFilesPromise;
     });
 
     const res = await request(app).post(endpoint()).set(getAuthHeader(user));
     expect(res.status).toBe(202);
 
-    // Allow the fire-and-forget promise to settle before querying the DB
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    expect(createAllCubeFilesPromise).toBeDefined();
+    await createAllCubeFilesPromise;
 
     const buildLog = await BuildLog.findOneBy({ id: res.body.build_id });
     expect(buildLog).not.toBeNull();

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -1,0 +1,124 @@
+import request from 'supertest';
+
+import app from '../../../src/app';
+import { dbManager } from '../../../src/db/database-manager';
+import { initPassport } from '../../../src/middleware/passport-auth';
+import { BuildLog } from '../../../src/entities/dataset/build-log';
+import { Revision } from '../../../src/entities/dataset/revision';
+import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
+import { CubeBuildType } from '../../../src/enums/cube-build-type';
+import { GroupRole } from '../../../src/enums/group-role';
+import { User } from '../../../src/entities/user/user';
+import { UserGroup } from '../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../src/entities/user/user-group-role';
+import { ensureWorkerDataSources, resetDatabase } from '../../helpers/reset-database';
+import { createSmallDataset } from '../../helpers/test-helper';
+import { getTestUser, getTestUserGroup } from '../../helpers/get-test-user';
+import { getAuthHeader } from '../../helpers/auth-header';
+import BlobStorage from '../../../src/services/blob-storage';
+
+jest.mock('../../../src/services/blob-storage');
+
+jest.mock('../../../src/utils/lookup-table-utils', () => ({
+  bootstrapCubeBuildProcess: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../../../src/services/cube-builder', () => ({
+  createAllCubeFiles: jest.fn().mockResolvedValue(undefined)
+}));
+
+import { bootstrapCubeBuildProcess } from '../../../src/utils/lookup-table-utils';
+import { createAllCubeFiles } from '../../../src/services/cube-builder';
+
+BlobStorage.prototype.listFiles = jest
+  .fn()
+  .mockReturnValue([{ name: 'test-data-1.csv', path: 'test/test-data-1.csv', isDirectory: false }]);
+BlobStorage.prototype.saveBuffer = jest.fn();
+
+const datasetId = '11111111-1111-4111-8111-111111111111';
+const revisionId = '22222222-2222-4222-8222-222222222222';
+const dataTableId = '33333333-3333-4333-8333-333333333333';
+const user: User = getTestUser('cube test user');
+let userGroup = getTestUserGroup('Cube Test Group');
+
+const endpoint = (dsId = datasetId, rvId = revisionId) => `/dataset/${dsId}/revision/by-id/${rvId}`;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe('POST /dataset/:dataset_id/revision/by-id/:revision_id', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+    await createSmallDataset(datasetId, revisionId, dataTableId, user);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(bootstrapCubeBuildProcess).mockResolvedValue(undefined);
+    jest.mocked(createAllCubeFiles).mockResolvedValue(undefined);
+  });
+
+  test('returns 401 when no auth header is sent', async () => {
+    const res = await request(app).post(endpoint());
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 404 for an unknown dataset_id', async () => {
+    const res = await request(app).post(endpoint('aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa')).set(getAuthHeader(user));
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 404 for an unknown revision_id', async () => {
+    const res = await request(app)
+      .post(endpoint(datasetId, 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'))
+      .set(getAuthHeader(user));
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 500 when bootstrapCubeBuildProcess throws', async () => {
+    jest.mocked(bootstrapCubeBuildProcess).mockRejectedValue(new Error('Schema not found'));
+    const res = await request(app).post(endpoint()).set(getAuthHeader(user));
+    expect(res.status).toBe(500);
+  });
+
+  test('returns 202 with a build_id UUID', async () => {
+    const res = await request(app).post(endpoint()).set(getAuthHeader(user));
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ build_id: expect.stringMatching(UUID_PATTERN) });
+  });
+
+  test('fires createAllCubeFiles with the returned build_id', async () => {
+    const res = await request(app).post(endpoint()).set(getAuthHeader(user));
+    expect(res.status).toBe(202);
+    expect(createAllCubeFiles).toHaveBeenCalledWith(
+      datasetId,
+      revisionId,
+      expect.anything(),
+      CubeBuildType.FullCube,
+      res.body.build_id
+    );
+  });
+
+  test('creates a BuildLog row in the database for the returned build_id', async () => {
+    jest.mocked(createAllCubeFiles).mockImplementation(async (_datasetId, _revisionId, userId, buildType, buildId) => {
+      const revision = await Revision.findOneBy({ id: _revisionId });
+      await BuildLog.startBuild(revision, buildType!, userId, buildId);
+    });
+
+    const res = await request(app).post(endpoint()).set(getAuthHeader(user));
+    expect(res.status).toBe(202);
+
+    // Allow the fire-and-forget promise to settle before querying the DB
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+    const buildLog = await BuildLog.findOneBy({ id: res.body.build_id });
+    expect(buildLog).not.toBeNull();
+    expect(buildLog!.status).toBe(CubeBuildStatus.Queued);
+    expect(buildLog!.type).toBe(CubeBuildType.FullCube);
+    expect(buildLog!.revisionId).toBe(revisionId);
+  });
+});

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -20,6 +20,7 @@ import BlobStorage from '../../../src/services/blob-storage';
 jest.mock('../../../src/services/blob-storage');
 
 jest.mock('../../../src/utils/lookup-table-utils', () => ({
+  ...jest.requireActual('../../../src/utils/lookup-table-utils'),
   bootstrapCubeBuildProcess: jest.fn().mockResolvedValue(undefined)
 }));
 

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../../src/utils/lookup-table-utils', () => ({
 }));
 
 jest.mock('../../../src/services/cube-builder', () => ({
+  ...jest.requireActual('../../../src/services/cube-builder'),
   createAllCubeFiles: jest.fn().mockResolvedValue(undefined)
 }));
 


### PR DESCRIPTION
Dumps the performance metrics returned by the cube rebuild as we no longer use them.  Move clearing or rebuilding the query store to something done as part of the cube build process.  This needs to happens generally after the view has been materialised inside of the cube.