### PR TITLE
SW-1264 Fix possible race condition around cube builder

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -538,8 +538,6 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     }
   }
 
-
-
   const updatedDataset = await DatasetRepository.getById(dataset.id);
   const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
 

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -716,8 +716,8 @@ export const rebuildDrafts = async (req: Request, res: Response): Promise<void> 
     return;
   }
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.DraftCubes, user.id);
-  res.status(202).json({ build_id: buildLogEntry.id }).end();
   void rebuildDatasetList(buildLogEntry, await RevisionRepository.getAllDraftRevisionIds(), user);
+  res.status(202).json({ build_id: buildLogEntry.id }).end();
 };
 
 export const rebuildAllFilterTables = async (req: Request, res: Response): Promise<void> => {
@@ -736,6 +736,6 @@ export const rebuildAllFilterTables = async (req: Request, res: Response): Promi
     return;
   }
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.AllFilterTables, user.id);
-  res.status(202).json({ build_id: buildLogEntry.id }).end();
   void rebuildAllFilterTablesForRevisions(buildLogEntry, await RevisionRepository.getAllRevisionIds());
+  res.status(202).json({ build_id: buildLogEntry.id }).end();
 };

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { NextFunction, Request, Response } from 'express';
 import { t } from 'i18next';
 import JSZip from 'jszip';
@@ -749,9 +747,9 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
   };
 
   for (const rev of revisionList) {
-    const buildId = randomUUID();
-    buildScript.all_builds.push(buildId);
-    buildScript.current_build = buildId;
+    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
+    buildScript.all_builds.push(build.id);
+    buildScript.current_build = build.id;
     buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
     buildLogEntry.status = CubeBuildStatus.Building;
     await buildLogEntry.save();
@@ -760,14 +758,12 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
     } catch (err) {
       logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
       failedBuilds.push({
-        buildId: buildId.toString(),
+        buildId: build.id.toString(),
         revisionId: rev.id,
         error: JSON.stringify(err)
       });
       continue;
     }
-
-    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
 
     void createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build).catch((err: Error) => {
       logger.warn(err, 'Cube builder threw an error while trying to rebuild the cube');
@@ -781,15 +777,15 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
     }
     if (build.status === CubeBuildStatus.Failed) {
       logger.warn(`[${buildLogEntry}]: Cube for revision ${rev.id} has been failed to rebuild.`);
-      buildScript.failed_to_build.push(buildId);
+      buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;
       failedBuilds.push({
-        buildId,
+        buildId: build.id,
         revisionId: rev.id,
         error: JSON.stringify(build.errors)
       });
     } else {
-      buildScript.successfully_built.push(buildId);
+      buildScript.successfully_built.push(build.id);
       buildScript.successful_builds++;
       logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
     }

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -540,17 +540,11 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
 
   const updatedDataset = await DatasetRepository.getById(dataset.id);
   const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
-
-  try {
-    res.status(202);
-    res.json({
-      dataset: DatasetDTO.fromDataset(updatedDataset),
-      build_id: build.id
-    });
-  } catch (_) {
-    await build.remove();
-  }
-
+  res.status(202);
+  res.json({
+    dataset: DatasetDTO.fromDataset(updatedDataset),
+    build_id: build.id
+  });
   void createAllCubeFiles(updatedDataset.id, revision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(err, `Failed to create cube files for build ${build.id}`);
   });

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -542,15 +542,16 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     }
   }
 
-  const buildId = randomUUID();
+  const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
+
   const updatedDataset = await DatasetRepository.getById(dataset.id);
   res.json({
     dataset: DatasetDTO.fromDataset(updatedDataset),
-    build_id: buildId
+    build_id: build.id
   });
 
-  void createAllCubeFiles(updatedDataset.id, revision.id, userId, CubeBuildType.FullCube, buildId).catch((err) => {
-    logger.error(err, `Failed to create cube files for build ${buildId}`);
+  void createAllCubeFiles(updatedDataset.id, revision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(err, `Failed to create cube files for build ${build.id}`);
   });
 };
 
@@ -766,18 +767,14 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
       continue;
     }
 
-    void createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, buildId).catch((err: Error) => {
+    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
+
+    void createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build).catch((err: Error) => {
       logger.warn(err, 'Cube builder threw an error while trying to rebuild the cube');
     });
 
     await sleep(5000);
-    let build: BuildLog;
-    try {
-      build = await BuildLog.findOneOrFail({ where: { id: buildId.toString() } });
-    } catch (err) {
-      logger.error(err, 'Failed to find build log entry');
-      continue;
-    }
+
     while (!CompleteStatus.includes(build.status)) {
       await sleep(10000);
       await build.reload();
@@ -795,11 +792,6 @@ async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: Revisio
       buildScript.successfully_built.push(buildId);
       buildScript.successful_builds++;
       logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
-      if (buildLogEntry.type === CubeBuildType.DraftCubes) {
-        await QueryStore.delete({ revisionId: rev.id });
-      } else {
-        await QueryStoreRepository.rebuildQueriesForRevision(rev.id);
-      }
     }
     buildScript.current_build = null;
     buildScript.total_builds++;

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -57,6 +57,7 @@ import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
 import { TaskAction } from '../enums/task-action';
 import { TaskService } from '../services/task';
 import { UserGroup } from '../entities/user/user-group';
+import { CubeBuildStatus } from '../enums/cube-build-status';
 import { CubeBuildType } from '../enums/cube-build-type';
 import { BuildLog } from '../entities/dataset/build-log';
 import { RevisionRepository } from '../repositories/revision';
@@ -695,9 +696,18 @@ export const rebuildAll = async (req: Request, res: Response): Promise<void> => 
       .end();
     return;
   }
+  const revisionIds = await RevisionRepository.getAllRevisionIds();
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.AllCubes, user.id);
   res.status(202).json({ build_id: buildLogEntry.id }).end();
-  void rebuildDatasetList(buildLogEntry, await RevisionRepository.getAllRevisionIds(), user);
+  rebuildDatasetList(buildLogEntry, revisionIds, user).catch(async (err) => {
+    logger.error(err, `[${buildLogEntry.id}]: Unhandled error in rebuildAll background task`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
+    await buildLogEntry.save();
+  });
 };
 
 export const rebuildDrafts = async (req: Request, res: Response): Promise<void> => {
@@ -715,9 +725,18 @@ export const rebuildDrafts = async (req: Request, res: Response): Promise<void> 
       .end();
     return;
   }
+  const revisionIds = await RevisionRepository.getAllDraftRevisionIds();
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.DraftCubes, user.id);
-  void rebuildDatasetList(buildLogEntry, await RevisionRepository.getAllDraftRevisionIds(), user);
   res.status(202).json({ build_id: buildLogEntry.id }).end();
+  rebuildDatasetList(buildLogEntry, revisionIds, user).catch(async (err) => {
+    logger.error(err, `[${buildLogEntry.id}]: Unhandled error in rebuildDrafts background task`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
+    await buildLogEntry.save();
+  });
 };
 
 export const rebuildAllFilterTables = async (req: Request, res: Response): Promise<void> => {
@@ -735,7 +754,16 @@ export const rebuildAllFilterTables = async (req: Request, res: Response): Promi
       .end();
     return;
   }
+  const revisionIds = await RevisionRepository.getAllRevisionIds();
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.AllFilterTables, user.id);
-  void rebuildAllFilterTablesForRevisions(buildLogEntry, await RevisionRepository.getAllRevisionIds());
   res.status(202).json({ build_id: buildLogEntry.id }).end();
+  rebuildAllFilterTablesForRevisions(buildLogEntry, revisionIds).catch(async (err) => {
+    logger.error(err, `[${buildLogEntry.id}]: Unhandled error in rebuildAllFilterTables background task`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
+    await buildLogEntry.save();
+  });
 };

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -25,7 +25,7 @@ import { BadRequestException } from '../exceptions/bad-request.exception';
 import { ViewErrDTO } from '../dtos/view-dto';
 import { arrayValidator, dtoValidator } from '../validators/dto-validator';
 import { RevisionMetadataDTO } from '../dtos/revision-metadata-dto';
-import { createAllCubeFiles, updateFilterTableToLatest } from '../services/cube-builder';
+import { createAllCubeFiles } from '../services/cube-builder';
 import {
   createDimensionsFromSourceAssignment,
   ValidatedSourceAssignment,
@@ -57,12 +57,9 @@ import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
 import { TaskAction } from '../enums/task-action';
 import { TaskService } from '../services/task';
 import { UserGroup } from '../entities/user/user-group';
-import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
-import { CubeBuildStatus } from '../enums/cube-build-status';
 import { CubeBuildType } from '../enums/cube-build-type';
-import { BuildLog, CompleteStatus } from '../entities/dataset/build-log';
-import { sleep } from '../utils/sleep';
-import { RevisionList, RevisionRepository } from '../repositories/revision';
+import { BuildLog } from '../entities/dataset/build-log';
+import { RevisionRepository } from '../repositories/revision';
 import { BuildLogRepository } from '../repositories/build-log';
 import { DataOptionsDTO, DEFAULT_DATA_OPTIONS, FRONTEND_DATA_OPTIONS } from '../dtos/data-options-dto';
 import { NotFoundException } from '../exceptions/not-found.exception';
@@ -73,6 +70,7 @@ import { OutputFormats } from '../enums/output-formats';
 import { buildDataQuery, sendCsv, sendExcel, sendFrontendView, sendJson } from '../services/consumer-view-v2';
 import { QueryStore } from '../entities/query-store';
 import { PageOptions } from '../interfaces/page-options';
+import { rebuildAllFilterTablesForRevisions, rebuildDatasetList } from '../services/dataset';
 
 export const listUserDatasets = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -723,83 +721,6 @@ export const rebuildDrafts = async (req: Request, res: Response): Promise<void> 
   void rebuildDatasetList(buildLogEntry, await RevisionRepository.getAllDraftRevisionIds(), user);
 };
 
-async function rebuildDatasetList(buildLogEntry: BuildLog, revisionList: RevisionList[], user: User): Promise<void> {
-  let buildTypeStr = 'all';
-  if (buildLogEntry.type === CubeBuildType.DraftCubes) {
-    buildTypeStr = 'all draft';
-  }
-
-  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr} cubes`);
-  const failedBuilds: {
-    buildId: string;
-    revisionId: string;
-    error: string;
-  }[] = [];
-
-  const buildScript = {
-    current_build: null as string | null,
-    total_builds: 0,
-    successful_builds: 0,
-    failed_builds: 0,
-    all_builds: [] as string[],
-    successfully_built: [] as string[],
-    failed_to_build: [] as string[]
-  };
-
-  for (const rev of revisionList) {
-    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
-    buildScript.all_builds.push(build.id);
-    buildScript.current_build = build.id;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-    buildLogEntry.status = CubeBuildStatus.Building;
-    await buildLogEntry.save();
-    try {
-      await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
-    } catch (err) {
-      logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-      failedBuilds.push({
-        buildId: build.id.toString(),
-        revisionId: rev.id,
-        error: JSON.stringify(err)
-      });
-      continue;
-    }
-
-    void createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build).catch((err: Error) => {
-      logger.warn(err, 'Cube builder threw an error while trying to rebuild the cube');
-    });
-
-    await sleep(5000);
-
-    while (!CompleteStatus.includes(build.status)) {
-      await sleep(10000);
-      await build.reload();
-    }
-    if (build.status === CubeBuildStatus.Failed) {
-      logger.warn(`[${buildLogEntry}]: Cube for revision ${rev.id} has been failed to rebuild.`);
-      buildScript.failed_to_build.push(build.id);
-      buildScript.failed_builds++;
-      failedBuilds.push({
-        buildId: build.id,
-        revisionId: rev.id,
-        error: JSON.stringify(build.errors)
-      });
-    } else {
-      buildScript.successfully_built.push(build.id);
-      buildScript.successful_builds++;
-      logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
-    }
-    buildScript.current_build = null;
-    buildScript.total_builds++;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-    await buildLogEntry.save();
-  }
-  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-  await buildLogEntry.save();
-  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
-}
-
 export const rebuildAllFilterTables = async (req: Request, res: Response): Promise<void> => {
   const user = req.user as User;
 
@@ -819,57 +740,3 @@ export const rebuildAllFilterTables = async (req: Request, res: Response): Promi
   res.status(202).json({ build_id: buildLogEntry.id }).end();
   void rebuildAllFilterTablesForRevisions(buildLogEntry, await RevisionRepository.getAllRevisionIds());
 };
-
-async function rebuildAllFilterTablesForRevisions(
-  buildLogEntry: BuildLog,
-  revisionList: RevisionList[]
-): Promise<void> {
-  const buildTypeStr = 'all filter tables';
-
-  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr}`);
-  const failedBuilds: {
-    buildId: string;
-    revisionId: string;
-    error: string;
-  }[] = [];
-
-  const buildScript = {
-    current_build: null as string | null,
-    total_builds: 0,
-    successful_builds: 0,
-    failed_builds: 0,
-    all_builds: [] as string[],
-    successfully_built: [] as string[],
-    failed_to_build: [] as string[]
-  };
-
-  for (const rev of revisionList) {
-    if (!rev.data_table_id && rev.revision_index === 1) continue;
-    try {
-      buildScript.all_builds.push(rev.id);
-      buildScript.current_build = rev.id;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      buildLogEntry.status = CubeBuildStatus.Building;
-      await buildLogEntry.save();
-      await updateFilterTableToLatest(rev.dataset_id, rev.id);
-      buildScript.successful_builds++;
-      buildScript.successfully_built.push(rev.id);
-    } catch (err) {
-      logger.error(err);
-      buildScript.failed_builds++;
-      buildScript.failed_to_build.push(rev.id);
-      failedBuilds.push({
-        revisionId: rev.id,
-        buildId: rev.id,
-        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-      });
-    }
-    buildScript.total_builds++;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-    await buildLogEntry.save();
-  }
-  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-  await buildLogEntry.save();
-  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
-}

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -538,13 +538,20 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
     }
   }
 
-  const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
+
 
   const updatedDataset = await DatasetRepository.getById(dataset.id);
-  res.json({
-    dataset: DatasetDTO.fromDataset(updatedDataset),
-    build_id: build.id
-  });
+  const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
+
+  try {
+    res.status(202);
+    res.json({
+      dataset: DatasetDTO.fromDataset(updatedDataset),
+      build_id: build.id
+    });
+  } catch (_) {
+    await build.remove();
+  }
 
   void createAllCubeFiles(updatedDataset.id, revision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(err, `Failed to create cube files for build ${build.id}`);

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -71,7 +71,7 @@ import { OutputFormats } from '../enums/output-formats';
 import { buildDataQuery, sendCsv, sendExcel, sendFrontendView, sendJson } from '../services/consumer-view-v2';
 import { QueryStore } from '../entities/query-store';
 import { PageOptions } from '../interfaces/page-options';
-import { rebuildAllFilterTablesForRevisions, rebuildDatasetList } from '../services/dataset';
+import { rebuildAllFilterTablesForRevisions, rebuildCubesForRevisions } from '../services/revision';
 
 export const listUserDatasets = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -699,7 +699,7 @@ export const rebuildAll = async (req: Request, res: Response): Promise<void> => 
   const revisionIds = await RevisionRepository.getAllRevisionIds();
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.AllCubes, user.id);
   res.status(202).json({ build_id: buildLogEntry.id }).end();
-  rebuildDatasetList(buildLogEntry, revisionIds, user).catch(async (err) => {
+  void rebuildCubesForRevisions(buildLogEntry, revisionIds, user).catch(async (err) => {
     logger.error(err, `[${buildLogEntry.id}]: Unhandled error in rebuildAll background task`);
     buildLogEntry.completeBuild(
       CubeBuildStatus.Failed,
@@ -728,7 +728,7 @@ export const rebuildDrafts = async (req: Request, res: Response): Promise<void> 
   const revisionIds = await RevisionRepository.getAllDraftRevisionIds();
   const buildLogEntry = await BuildLog.startBuild(null, CubeBuildType.DraftCubes, user.id);
   res.status(202).json({ build_id: buildLogEntry.id }).end();
-  rebuildDatasetList(buildLogEntry, revisionIds, user).catch(async (err) => {
+  void rebuildCubesForRevisions(buildLogEntry, revisionIds, user).catch(async (err) => {
     logger.error(err, `[${buildLogEntry.id}]: Unhandled error in rebuildDrafts background task`);
     buildLogEntry.completeBuild(
       CubeBuildStatus.Failed,

--- a/src/controllers/dimension.ts
+++ b/src/controllers/dimension.ts
@@ -147,11 +147,11 @@ export const attachLookupTableToDimension = async (req: Request, res: Response, 
       res.json(result);
       return;
     }
+    await updateRevisionTasks(dataset, dimension.id, 'dimension');
     build = await BuildLog.startBuild(draftRevision, CubeBuildType.FullCube, userId);
     result.extension = {
       build_id: build.id
     };
-    await updateRevisionTasks(dataset, dimension.id, 'dimension');
     res.json(result);
   } catch (err) {
     logger.error(err, `An error occurred trying to handle the lookup table`);

--- a/src/controllers/dimension.ts
+++ b/src/controllers/dimension.ts
@@ -30,8 +30,8 @@ import { getFileService } from '../utils/get-file-service';
 import { TempFile } from '../interfaces/temp-file';
 import { cleanupTmpFile, uploadAvScan } from '../services/virus-scanner';
 import { updateRevisionTasks } from '../utils/update-revision-tasks';
-import { randomUUID } from 'node:crypto';
 import { CubeBuildType } from '../enums/cube-build-type';
+import { BuildLog } from '../entities/dataset/build-log';
 
 export const getDimensionInfo = async (req: Request, res: Response): Promise<void> => {
   res.json(DimensionDTO.fromDimension(res.locals.dimension));
@@ -135,7 +135,7 @@ export const attachLookupTableToDimension = async (req: Request, res: Response, 
     return;
   }
 
-  const buildId = randomUUID();
+  let build: BuildLog;
 
   try {
     const dataTable = await validateAndUpload(tmpFile, datasetId, 'lookup_table');
@@ -147,23 +147,23 @@ export const attachLookupTableToDimension = async (req: Request, res: Response, 
       res.json(result);
       return;
     }
+    build = await BuildLog.startBuild(draftRevision, CubeBuildType.FullCube, userId);
     result.extension = {
-      build_id: buildId
+      build_id: build.id
     };
     await updateRevisionTasks(dataset, dimension.id, 'dimension');
     res.json(result);
   } catch (err) {
     logger.error(err, `An error occurred trying to handle the lookup table`);
     next(new UnknownException('errors.upload_error'));
+    return;
   } finally {
     void cleanupTmpFile(tmpFile);
   }
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, buildId).catch(
-    (err) => {
-      logger.error(err, 'Something went wrong trying to build the cube after attaching a lookup table');
-    }
-  );
+  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(err, 'Something went wrong trying to build the cube after attaching a lookup table');
+  });
 };
 
 export const updateDimension = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -173,12 +173,12 @@ export const updateDimension = async (req: Request, res: Response, next: NextFun
   const dimensionPatchRequest = req.body as DimensionPatchDto;
   let preview: ViewDTO | ViewErrDTO;
 
-  const buildId = randomUUID();
-
   const dataset = await DatasetRepository.getById(res.locals.datasetId, {
     factTable: true,
     draftRevision: { dataTable: { dataTableDescriptions: true } }
   });
+
+  let build: BuildLog;
 
   try {
     const draftRevision = dataset.draftRevision;
@@ -234,21 +234,21 @@ export const updateDimension = async (req: Request, res: Response, next: NextFun
     } else {
       await updateRevisionTasks(dataset, dimension.id, 'dimension');
     }
+    build = await BuildLog.startBuild(draftRevision, CubeBuildType.FullCube, userId);
     preview.extension = {
-      build_id: buildId
+      build_id: build.id
     };
     res.status(202);
     res.json(preview);
   } catch (err) {
     logger.error(err, `An error occurred trying to update the dimension`);
     next(new UnknownException('errors.dimension_update'));
+    return;
   }
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, buildId).catch(
-    (err) => {
-      logger.error(err, 'Something went wrong trying to build the cube when updating the dimension');
-    }
-  );
+  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(err, 'Something went wrong trying to build the cube when updating the dimension');
+  });
 };
 
 export const updateDimensionMetadata = async (req: Request, res: Response): Promise<void> => {
@@ -274,17 +274,15 @@ export const updateDimensionMetadata = async (req: Request, res: Response): Prom
   await metadata.save();
   const updatedDimension = await Dimension.findOneByOrFail({ id: dimension.id });
   await updateRevisionTasks(dataset, dimension.id, 'dimension');
-  const buildId = randomUUID();
+  const build = await BuildLog.startBuild(dataset.draftRevision!, CubeBuildType.FullCube, userId);
   res.status(202);
   res.json({
     dimension: DimensionDTO.fromDimension(updatedDimension),
-    build_id: buildId
+    build_id: build.id
   });
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, buildId).catch(
-    (err) => {
-      logger.error(err, 'Something went wrong trying to build the cube after updating the dimensions metadata');
-    }
-  );
+  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(err, 'Something went wrong trying to build the cube after updating the dimensions metadata');
+  });
 };
 
 export const getDimensionLookupTableInfo = async (req: Request, res: Response): Promise<void> => {

--- a/src/controllers/dimension.ts
+++ b/src/controllers/dimension.ts
@@ -161,7 +161,7 @@ export const attachLookupTableToDimension = async (req: Request, res: Response, 
     void cleanupTmpFile(tmpFile);
   }
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+  void createAllCubeFiles(dataset.id, draftRevision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(err, 'Something went wrong trying to build the cube after attaching a lookup table');
   });
 };
@@ -180,15 +180,15 @@ export const updateDimension = async (req: Request, res: Response, next: NextFun
 
   let build: BuildLog;
 
+  const draftRevision = dataset.draftRevision;
+
+  if (!draftRevision) {
+    logger.error('No draft revision found on dataset');
+    next(new UnknownException('errors.no_revision'));
+    return;
+  }
+
   try {
-    const draftRevision = dataset.draftRevision;
-
-    if (!draftRevision) {
-      logger.error('No draft revision found on dataset');
-      next(new UnknownException('errors.no_revision'));
-      return;
-    }
-
     switch (dimensionPatchRequest.dimension_type) {
       case DimensionType.DatePeriod:
       case DimensionType.Date:
@@ -246,17 +246,26 @@ export const updateDimension = async (req: Request, res: Response, next: NextFun
     return;
   }
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+  void createAllCubeFiles(dataset.id, draftRevision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(err, 'Something went wrong trying to build the cube when updating the dimension');
   });
 };
 
-export const updateDimensionMetadata = async (req: Request, res: Response): Promise<void> => {
+export const updateDimensionMetadata = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const dimension = res.locals.dimension;
   const userId = req.user?.id;
   const dataset = await DatasetRepository.getById(res.locals.datasetId, {
     draftRevision: { dataTable: { dataTableDescriptions: true } }
   });
+
+  const draftRevision = dataset.draftRevision;
+
+  if (!draftRevision) {
+    logger.error('No draft revision found on dataset');
+    next(new UnknownException('errors.no_revision'));
+    return;
+  }
+
   const update = req.body as DimensionMetadataDTO;
   let metadata = dimension.metadata.find((meta: DimensionMetadata) => meta.language === update.language);
 
@@ -280,7 +289,7 @@ export const updateDimensionMetadata = async (req: Request, res: Response): Prom
     dimension: DimensionDTO.fromDimension(updatedDimension),
     build_id: build.id
   });
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+  void createAllCubeFiles(dataset.id, draftRevision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(err, 'Something went wrong trying to build the cube after updating the dimensions metadata');
   });
 };

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -164,6 +164,7 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
   await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
   const build = await BuildLog.startBuild(dataset.draftRevision!, CubeBuildType.FullCube, userId);
 
+  res.status(202);
   res.json({
     dimension: DimensionMetadataDTO.fromDimensionMetadata(updatedMeasureMetadata),
     build_id: build.id

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -20,8 +20,8 @@ import { createAllCubeFiles } from '../services/cube-builder';
 import { cleanupTmpFile, uploadAvScan } from '../services/virus-scanner';
 import { TempFile } from '../interfaces/temp-file';
 import { updateRevisionTasks } from '../utils/update-revision-tasks';
-import { randomUUID } from 'node:crypto';
 import { CubeBuildType } from '../enums/cube-build-type';
+import { BuildLog } from '../entities/dataset/build-log';
 
 export const resetMeasure = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const dataset = res.locals.dataset;
@@ -74,7 +74,7 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
     draftRevision: { dataTable: true }
   });
 
-  const buildID = randomUUID();
+  let build: BuildLog;
 
   try {
     const dataTable = await validateAndUpload(tmpFile, dataset.id, 'lookup_table');
@@ -87,8 +87,9 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
       res.json(result);
       return;
     }
+    build = await BuildLog.startBuild(dataset.draftRevision, CubeBuildType.FullCube, userId);
     result.extension = {
-      build_id: buildID
+      build_id: build.id
     };
     await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
     res.status((result as ViewErrDTO).status || 200);
@@ -96,15 +97,14 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
   } catch (err) {
     logger.error(err, `An error occurred trying to process and upload the file`);
     next(new UnknownException('errors.upload_error'));
+    return;
   } finally {
     void cleanupTmpFile(tmpFile);
   }
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, buildID).catch(
-    (err) => {
-      logger.error(err, 'Something went wrong trying to build the cube when attaching a measure lookup');
-    }
-  );
+  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(err, 'Something went wrong trying to build the cube when attaching a measure lookup');
+  });
 };
 
 export const getPreviewOfMeasure = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -162,19 +162,18 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
 
   const updatedMeasureMetadata = await metadata.save();
   await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
-  const buildID = randomUUID();
-  await createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, buildID).catch(
-    (err) => {
-      logger.error(
-        err,
-        `Something went wrong trying to build the cube after buildID=${buildID} for datasetId=${dataset.id} and revisionId=${dataset.draftRevision!.id}`
-      );
-    }
-  );
+  const build = await BuildLog.startBuild(dataset.draftRevision!, CubeBuildType.FullCube, userId);
 
   res.json({
     dimension: DimensionMetadataDTO.fromDimensionMetadata(updatedMeasureMetadata),
-    build_id: buildID
+    build_id: build.id
+  });
+
+  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.error(
+      err,
+      `Something went wrong trying to build the cube after buildID=${build.id} for datasetId=${dataset.id} and revisionId=${dataset.draftRevision!.id}`
+    );
   });
 };
 

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -87,11 +87,16 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
       res.json(result);
       return;
     }
+    await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
     build = await BuildLog.startBuild(dataset.draftRevision, CubeBuildType.FullCube, userId);
     result.extension = {
       build_id: build.id
     };
-    await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
+    void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch(
+      (err) => {
+        logger.error(err, 'Something went wrong trying to build the cube when attaching a measure lookup');
+      }
+    );
     res.status((result as ViewErrDTO).status || 200);
     res.json(result);
   } catch (err) {
@@ -101,10 +106,6 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
   } finally {
     void cleanupTmpFile(tmpFile);
   }
-
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
-    logger.error(err, 'Something went wrong trying to build the cube when attaching a measure lookup');
-  });
 };
 
 export const getPreviewOfMeasure = async (req: Request, res: Response, next: NextFunction): Promise<void> => {

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -144,6 +144,14 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
     next(new NotFoundException('errors.measure_invalid'));
   }
 
+  const draftRevision = dataset.draftRevision;
+
+  if (!draftRevision) {
+    logger.error('No draft revision found on dataset');
+    next(new UnknownException('errors.no_revision'));
+    return;
+  }
+
   const update = req.body as DimensionMetadataDTO;
   let metadata = measure.metadata.find((meta: MeasureMetadata) => meta.language === update.language);
 
@@ -163,7 +171,7 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
 
   const updatedMeasureMetadata = await metadata.save();
   await updateRevisionTasks(dataset, dataset.measure.id, 'measure');
-  const build = await BuildLog.startBuild(dataset.draftRevision!, CubeBuildType.FullCube, userId);
+  const build = await BuildLog.startBuild(draftRevision, CubeBuildType.FullCube, userId);
 
   res.status(202);
   res.json({
@@ -171,7 +179,7 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
     build_id: build.id
   });
 
-  void createAllCubeFiles(dataset.id, dataset.draftRevision!.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+  void createAllCubeFiles(dataset.id, draftRevision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
     logger.error(
       err,
       `Something went wrong trying to build the cube after buildID=${build.id} for datasetId=${dataset.id} and revisionId=${dataset.draftRevision!.id}`

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -457,6 +457,8 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
   } catch (err) {
     logger.error(err, `Something went wrong trying to bootstrap the cube build process`);
     const exception = new UnknownException('errors.cube_builder.cube_build_failed');
+    build.completeBuild(CubeBuildStatus.Failed, `Boot strap failed.`, JSON.stringify(err, null, 2));
+    await build.save();
     next(exception);
     return;
   }

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -1,6 +1,5 @@
 import { Readable } from 'node:stream';
 import { performance } from 'node:perf_hooks';
-import { randomUUID } from 'node:crypto';
 
 import { NextFunction, Request, Response } from 'express';
 import { t } from 'i18next';
@@ -48,6 +47,7 @@ import { buildStatusValidator, buildTypeValidator, hasError } from '../validator
 import { CubeBuildType } from '../enums/cube-build-type';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 import { BuildLogRepository } from '../repositories/build-log';
+import { BuildLog } from '../entities/dataset/build-log';
 
 export const getDataTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const revision: Revision = res.locals.revision;
@@ -450,7 +450,8 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
   const datasetId: string = res.locals.datasetId;
   const revision: Revision = res.locals.revision;
   const userId = req.user?.id;
-  const buildId = randomUUID();
+  const build = await BuildLog.startBuild(revision, CubeBuildType.FullCube, userId);
+
   try {
     await bootstrapCubeBuildProcess(datasetId, revision.id);
   } catch (err) {
@@ -459,12 +460,13 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
     next(exception);
     return;
   }
-  void createAllCubeFiles(datasetId, revision.id, userId, CubeBuildType.FullCube, buildId).catch((err) => {
-    logger.warn(err, `Async cube build with build id ${buildId} failed with an error.`);
-  });
   res.status(202);
   res.json({
-    build_id: buildId
+    build_id: build.id
+  });
+
+  void createAllCubeFiles(datasetId, revision.id, userId, CubeBuildType.FullCube, build).catch((err) => {
+    logger.warn(err, `Async cube build with build id ${build.id} failed with an error.`);
   });
 };
 

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -458,7 +458,7 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
     logger.error(err, `Something went wrong trying to bootstrap the cube build process`);
     const exception = new UnknownException('errors.cube_builder.cube_build_failed');
     const buildErrorDetails = err instanceof Error ? (err.stack ?? err.message) : String(err);
-    build.completeBuild(CubeBuildStatus.Failed, `Boot strap failed.`, buildErrorDetails);
+    build.completeBuild(CubeBuildStatus.Failed, `Bootstrap failed.`, buildErrorDetails);
     await build.save();
     next(exception);
     return;

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -457,7 +457,8 @@ export const regenerateRevisionCube = async (req: Request, res: Response, next: 
   } catch (err) {
     logger.error(err, `Something went wrong trying to bootstrap the cube build process`);
     const exception = new UnknownException('errors.cube_builder.cube_build_failed');
-    build.completeBuild(CubeBuildStatus.Failed, `Boot strap failed.`, JSON.stringify(err, null, 2));
+    const buildErrorDetails = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    build.completeBuild(CubeBuildStatus.Failed, `Boot strap failed.`, buildErrorDetails);
     await build.save();
     next(exception);
     return;

--- a/src/entities/dataset/build-log.ts
+++ b/src/entities/dataset/build-log.ts
@@ -2,7 +2,6 @@ import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, Pr
 import { Revision } from './revision';
 import { CubeBuildStatus } from '../../enums/cube-build-status';
 import { CubeBuildType } from '../../enums/cube-build-type';
-import { RevisionList } from '../../repositories/revision';
 
 export const CompleteStatus = [CubeBuildStatus.Completed, CubeBuildStatus.Failed];
 
@@ -53,7 +52,7 @@ export class BuildLog extends BaseEntity {
   revision: Revision | null;
 
   public static async startBuild(
-    revision: Revision | RevisionList | null,
+    revision: { id: string } | Revision | null,
     type: CubeBuildType,
     userId?: string,
     buildId?: string

--- a/src/entities/dataset/build-log.ts
+++ b/src/entities/dataset/build-log.ts
@@ -2,6 +2,7 @@ import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, Pr
 import { Revision } from './revision';
 import { CubeBuildStatus } from '../../enums/cube-build-status';
 import { CubeBuildType } from '../../enums/cube-build-type';
+import { RevisionList } from '../../repositories/revision';
 
 export const CompleteStatus = [CubeBuildStatus.Completed, CubeBuildStatus.Failed];
 
@@ -52,7 +53,7 @@ export class BuildLog extends BaseEntity {
   revision: Revision | null;
 
   public static async startBuild(
-    revision: Revision | null,
+    revision: Revision | RevisionList | null,
     type: CubeBuildType,
     userId?: string,
     buildId?: string

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -55,7 +55,7 @@ export const createAllCubeFiles = async (
   datasetId: string,
   buildRevisionId: string,
   userId?: string,
-  buildType: CubeBuildType | undefined = CubeBuildType.FullCube,
+  buildType: CubeBuildType = CubeBuildType.FullCube,
   build?: BuildLog,
   awaitMaterialisation = false
 ): Promise<void> => {

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -56,7 +56,7 @@ export const createAllCubeFiles = async (
   buildRevisionId: string,
   userId?: string,
   buildType = CubeBuildType.FullCube,
-  buildId = crypto.randomUUID(),
+  build?: BuildLog,
   awaitMaterialisation = false
 ): Promise<void> => {
   // const datasetRelations: FindOptionsRelations<Dataset> = {
@@ -84,7 +84,7 @@ export const createAllCubeFiles = async (
     throw new CubeValidationException('Failed to find buildRevision in dataset.');
   }
 
-  const build = await BuildLog.startBuild(buildRevision, buildType, userId, buildId);
+  if (!build) build = await BuildLog.startBuild(buildRevision, buildType, userId);
 
   if (!buildRevision.dataTable && buildRevision.revisionIndex === 1) {
     logger.warn(`First revision for revision ${buildRevision.id} has no data table.  Unable to proceed with build.`);

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -55,7 +55,7 @@ export const createAllCubeFiles = async (
   datasetId: string,
   buildRevisionId: string,
   userId?: string,
-  buildType = CubeBuildType.FullCube,
+  buildType: CubeBuildType | undefined = CubeBuildType.FullCube,
   build?: BuildLog,
   awaitMaterialisation = false
 ): Promise<void> => {

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -532,6 +532,14 @@ export async function rebuildDatasetList(
       await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
     } catch (err) {
       logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+      build.completeBuild(CubeBuildStatus.Failed, JSON.stringify(err));
+      await build.save();
+      buildScript.failed_to_build.push(build.id);
+      buildScript.failed_builds++;
+      buildScript.current_build = null;
+      buildScript.total_builds++;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      await buildLogEntry.save();
       failedBuilds.push({
         buildId: build.id.toString(),
         revisionId: rev.id,

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -552,11 +552,29 @@ export async function rebuildDatasetList(
       continue;
     }
 
-    await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true).catch(
-      (err: Error) => {
-        logger.warn(err, 'Cube builder threw an error while trying to rebuild the cube');
-      }
-    );
+    try {
+      await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true);
+    } catch (err) {
+      logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+      build.completeBuild(
+        CubeBuildStatus.Failed,
+        undefined,
+        err instanceof Error ? (err.stack ?? err.message) : String(err)
+      );
+      await build.save();
+      buildScript.failed_to_build.push(build.id);
+      buildScript.failed_builds++;
+      buildScript.current_build = null;
+      buildScript.total_builds++;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      await buildLogEntry.save();
+      failedBuilds.push({
+        buildId: build.id.toString(),
+        revisionId: rev.id,
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+      });
+      continue;
+    }
 
     await build.reload();
     if (build.status === CubeBuildStatus.Failed) {

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -543,7 +543,7 @@ export async function rebuildDatasetList(
       failedBuilds.push({
         buildId: build.id.toString(),
         revisionId: rev.id,
-        error: JSON.stringify(err)
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
       });
       continue;
     }

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -556,7 +556,7 @@ export async function rebuildDatasetList(
 
     await build.reload();
     if (build.status === CubeBuildStatus.Failed) {
-      logger.warn(`[${buildLogEntry}]: Cube for revision ${rev.id} has been failed to rebuild.`);
+      logger.warn(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been failed to rebuild.`);
       buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;
       failedBuilds.push({

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -582,11 +582,8 @@ export async function rebuildDatasetList(
       buildScript.successful_builds++;
       logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
     } else {
-      const buildError =
-        build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
-      logger.warn(
-        `[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`
-      );
+      const buildError = build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
+      logger.warn(`[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`);
       buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;
       failedBuilds.push({

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -532,7 +532,11 @@ export async function rebuildDatasetList(
       await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
     } catch (err) {
       logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-      build.completeBuild(CubeBuildStatus.Failed, undefined, JSON.stringify(err));
+      build.completeBuild(
+        CubeBuildStatus.Failed,
+        undefined,
+        err instanceof Error ? (err.stack ?? err.message) : String(err)
+      );
       await build.save();
       buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -577,19 +577,23 @@ export async function rebuildDatasetList(
     }
 
     await build.reload();
-    if (build.status === CubeBuildStatus.Failed) {
-      logger.warn(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been failed to rebuild.`);
+    if (build.status === CubeBuildStatus.Completed) {
+      buildScript.successfully_built.push(build.id);
+      buildScript.successful_builds++;
+      logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
+    } else {
+      const buildError =
+        build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
+      logger.warn(
+        `[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`
+      );
       buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;
       failedBuilds.push({
         buildId: build.id,
         revisionId: rev.id,
-        error: build.errors ?? ''
+        error: buildError
       });
-    } else {
-      buildScript.successfully_built.push(build.id);
-      buildScript.successful_builds++;
-      logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
     }
     buildScript.current_build = null;
     buildScript.total_builds++;

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -505,102 +505,114 @@ export async function rebuildDatasetList(
   }
 
   logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr} cubes`);
-  const failedBuilds: {
-    buildId: string;
-    revisionId: string;
-    error: string;
-  }[] = [];
+  try {
+    const failedBuilds: {
+      buildId: string;
+      revisionId: string;
+      error: string;
+    }[] = [];
 
-  const buildScript = {
-    current_build: null as string | null,
-    total_builds: 0,
-    successful_builds: 0,
-    failed_builds: 0,
-    all_builds: [] as string[],
-    successfully_built: [] as string[],
-    failed_to_build: [] as string[]
-  };
+    const buildScript = {
+      current_build: null as string | null,
+      total_builds: 0,
+      successful_builds: 0,
+      failed_builds: 0,
+      all_builds: [] as string[],
+      successfully_built: [] as string[],
+      failed_to_build: [] as string[]
+    };
 
-  for (const rev of revisionList) {
-    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
-    buildScript.all_builds.push(build.id);
-    buildScript.current_build = build.id;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-    buildLogEntry.status = CubeBuildStatus.Building;
+    for (const rev of revisionList) {
+      const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
+      buildScript.all_builds.push(build.id);
+      buildScript.current_build = build.id;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      buildLogEntry.status = CubeBuildStatus.Building;
+      await buildLogEntry.save();
+      try {
+        await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
+      } catch (err) {
+        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+        build.completeBuild(
+          CubeBuildStatus.Failed,
+          undefined,
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        );
+        await build.save();
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        buildScript.current_build = null;
+        buildScript.total_builds++;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        await buildLogEntry.save();
+        failedBuilds.push({
+          buildId: build.id.toString(),
+          revisionId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+        continue;
+      }
+
+      try {
+        await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true);
+      } catch (err) {
+        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+        build.completeBuild(
+          CubeBuildStatus.Failed,
+          undefined,
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        );
+        await build.save();
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        buildScript.current_build = null;
+        buildScript.total_builds++;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        await buildLogEntry.save();
+        failedBuilds.push({
+          buildId: build.id.toString(),
+          revisionId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+        continue;
+      }
+
+      await build.reload();
+      if (build.status === CubeBuildStatus.Completed) {
+        buildScript.successfully_built.push(build.id);
+        buildScript.successful_builds++;
+        logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
+      } else {
+        const buildError = build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
+        logger.warn(
+          `[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`
+        );
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        failedBuilds.push({
+          buildId: build.id,
+          revisionId: rev.id,
+          error: buildError
+        });
+      }
+      buildScript.current_build = null;
+      buildScript.total_builds++;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      await buildLogEntry.save();
+    }
+    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
     await buildLogEntry.save();
-    try {
-      await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
-    } catch (err) {
-      logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-      build.completeBuild(
-        CubeBuildStatus.Failed,
-        undefined,
-        err instanceof Error ? (err.stack ?? err.message) : String(err)
-      );
-      await build.save();
-      buildScript.failed_to_build.push(build.id);
-      buildScript.failed_builds++;
-      buildScript.current_build = null;
-      buildScript.total_builds++;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      await buildLogEntry.save();
-      failedBuilds.push({
-        buildId: build.id.toString(),
-        revisionId: rev.id,
-        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-      });
-      continue;
-    }
-
-    try {
-      await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true);
-    } catch (err) {
-      logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-      build.completeBuild(
-        CubeBuildStatus.Failed,
-        undefined,
-        err instanceof Error ? (err.stack ?? err.message) : String(err)
-      );
-      await build.save();
-      buildScript.failed_to_build.push(build.id);
-      buildScript.failed_builds++;
-      buildScript.current_build = null;
-      buildScript.total_builds++;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      await buildLogEntry.save();
-      failedBuilds.push({
-        buildId: build.id.toString(),
-        revisionId: rev.id,
-        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-      });
-      continue;
-    }
-
-    await build.reload();
-    if (build.status === CubeBuildStatus.Completed) {
-      buildScript.successfully_built.push(build.id);
-      buildScript.successful_builds++;
-      logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
-    } else {
-      const buildError = build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
-      logger.warn(`[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`);
-      buildScript.failed_to_build.push(build.id);
-      buildScript.failed_builds++;
-      failedBuilds.push({
-        buildId: build.id,
-        revisionId: rev.id,
-        error: buildError
-      });
-    }
-    buildScript.current_build = null;
-    buildScript.total_builds++;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
+  } catch (err) {
+    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr} cubes`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
     await buildLogEntry.save();
   }
-  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-  await buildLogEntry.save();
-  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
 }
 
 export async function rebuildAllFilterTablesForRevisions(
@@ -610,49 +622,59 @@ export async function rebuildAllFilterTablesForRevisions(
   const buildTypeStr = 'all filter tables';
 
   logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr}`);
-  const failedBuilds: {
-    buildId: string;
-    revisionId: string;
-    error: string;
-  }[] = [];
+  try {
+    const failedBuilds: {
+      buildId: string;
+      revisionId: string;
+      error: string;
+    }[] = [];
 
-  const buildScript = {
-    current_build: null as string | null,
-    total_builds: 0,
-    successful_builds: 0,
-    failed_builds: 0,
-    all_builds: [] as string[],
-    successfully_built: [] as string[],
-    failed_to_build: [] as string[]
-  };
+    const buildScript = {
+      current_build: null as string | null,
+      total_builds: 0,
+      successful_builds: 0,
+      failed_builds: 0,
+      all_builds: [] as string[],
+      successfully_built: [] as string[],
+      failed_to_build: [] as string[]
+    };
 
-  for (const rev of revisionList) {
-    if (!rev.data_table_id && rev.revision_index === 1) continue;
-    try {
-      buildScript.all_builds.push(rev.id);
-      buildScript.current_build = rev.id;
+    for (const rev of revisionList) {
+      if (!rev.data_table_id && rev.revision_index === 1) continue;
+      try {
+        buildScript.all_builds.push(rev.id);
+        buildScript.current_build = rev.id;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        buildLogEntry.status = CubeBuildStatus.Building;
+        await buildLogEntry.save();
+        await updateFilterTableToLatest(rev.dataset_id, rev.id);
+        buildScript.successful_builds++;
+        buildScript.successfully_built.push(rev.id);
+      } catch (err) {
+        logger.error(err);
+        buildScript.failed_builds++;
+        buildScript.failed_to_build.push(rev.id);
+        failedBuilds.push({
+          revisionId: rev.id,
+          buildId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+      }
+      buildScript.total_builds++;
       buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      buildLogEntry.status = CubeBuildStatus.Building;
       await buildLogEntry.save();
-      await updateFilterTableToLatest(rev.dataset_id, rev.id);
-      buildScript.successful_builds++;
-      buildScript.successfully_built.push(rev.id);
-    } catch (err) {
-      logger.error(err);
-      buildScript.failed_builds++;
-      buildScript.failed_to_build.push(rev.id);
-      failedBuilds.push({
-        revisionId: rev.id,
-        buildId: rev.id,
-        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-      });
     }
-    buildScript.total_builds++;
-    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
+    await buildLogEntry.save();
+    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
+  } catch (err) {
+    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr}`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
     await buildLogEntry.save();
   }
-  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-  await buildLogEntry.save();
-  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
 }

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -532,7 +532,7 @@ export async function rebuildDatasetList(
       await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
     } catch (err) {
       logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-      build.completeBuild(CubeBuildStatus.Failed, JSON.stringify(err));
+      build.completeBuild(CubeBuildStatus.Failed, undefined, JSON.stringify(err));
       await build.save();
       buildScript.failed_to_build.push(build.id);
       buildScript.failed_builds++;

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -12,7 +12,7 @@ import {
   withDraftAndProviders,
   withDraftAndTopics
 } from '../repositories/dataset';
-import { RevisionRepository } from '../repositories/revision';
+import { RevisionList, RevisionRepository } from '../repositories/revision';
 import { logger } from '../utils/logger';
 import { DataTableAction } from '../enums/data-table-action';
 import { RevisionProviderDTO } from '../dtos/revision-provider-dto';
@@ -25,7 +25,7 @@ import { BadRequestException } from '../exceptions/bad-request.exception';
 import { TasklistStateDTO } from '../dtos/tasklist-state-dto';
 import { EventLog } from '../entities/event-log';
 
-import { createAllCubeFiles } from './cube-builder';
+import { createAllCubeFiles, updateFilterTableToLatest } from './cube-builder';
 import { validateAndUpload } from './incoming-file-processor';
 import { removeAllDimensions, removeMeasure } from './dimension-processor';
 import { UserGroupRepository } from '../repositories/user-group';
@@ -47,6 +47,9 @@ import { TempFile } from '../interfaces/temp-file';
 import { dbManager } from '../db/database-manager';
 import { getFileService } from '../utils/get-file-service';
 import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
+import { BuildLog } from '../entities/dataset/build-log';
+import { CubeBuildType } from '../enums/cube-build-type';
+import { CubeBuildStatus } from '../enums/cube-build-status';
 
 export class DatasetService {
   lang: Locale;
@@ -489,4 +492,136 @@ export class DatasetService {
     dataset = await this.createRevision(datasetId, user);
     await createAllCubeFiles(dataset.id, dataset.draftRevision!.id, user.id);
   }
+}
+
+export async function rebuildDatasetList(
+  buildLogEntry: BuildLog,
+  revisionList: RevisionList[],
+  user: User
+): Promise<void> {
+  let buildTypeStr = 'all';
+  if (buildLogEntry.type === CubeBuildType.DraftCubes) {
+    buildTypeStr = 'all draft';
+  }
+
+  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr} cubes`);
+  const failedBuilds: {
+    buildId: string;
+    revisionId: string;
+    error: string;
+  }[] = [];
+
+  const buildScript = {
+    current_build: null as string | null,
+    total_builds: 0,
+    successful_builds: 0,
+    failed_builds: 0,
+    all_builds: [] as string[],
+    successfully_built: [] as string[],
+    failed_to_build: [] as string[]
+  };
+
+  for (const rev of revisionList) {
+    const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
+    buildScript.all_builds.push(build.id);
+    buildScript.current_build = build.id;
+    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    buildLogEntry.status = CubeBuildStatus.Building;
+    await buildLogEntry.save();
+    try {
+      await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
+    } catch (err) {
+      logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+      failedBuilds.push({
+        buildId: build.id.toString(),
+        revisionId: rev.id,
+        error: JSON.stringify(err)
+      });
+      continue;
+    }
+
+    await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true).catch(
+      (err: Error) => {
+        logger.warn(err, 'Cube builder threw an error while trying to rebuild the cube');
+      }
+    );
+
+    await build.reload();
+    if (build.status === CubeBuildStatus.Failed) {
+      logger.warn(`[${buildLogEntry}]: Cube for revision ${rev.id} has been failed to rebuild.`);
+      buildScript.failed_to_build.push(build.id);
+      buildScript.failed_builds++;
+      failedBuilds.push({
+        buildId: build.id,
+        revisionId: rev.id,
+        error: JSON.stringify(build.errors)
+      });
+    } else {
+      buildScript.successfully_built.push(build.id);
+      buildScript.successful_builds++;
+      logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
+    }
+    buildScript.current_build = null;
+    buildScript.total_builds++;
+    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    await buildLogEntry.save();
+  }
+  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
+  await buildLogEntry.save();
+  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
+}
+
+export async function rebuildAllFilterTablesForRevisions(
+  buildLogEntry: BuildLog,
+  revisionList: RevisionList[]
+): Promise<void> {
+  const buildTypeStr = 'all filter tables';
+
+  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr}`);
+  const failedBuilds: {
+    buildId: string;
+    revisionId: string;
+    error: string;
+  }[] = [];
+
+  const buildScript = {
+    current_build: null as string | null,
+    total_builds: 0,
+    successful_builds: 0,
+    failed_builds: 0,
+    all_builds: [] as string[],
+    successfully_built: [] as string[],
+    failed_to_build: [] as string[]
+  };
+
+  for (const rev of revisionList) {
+    if (!rev.data_table_id && rev.revision_index === 1) continue;
+    try {
+      buildScript.all_builds.push(rev.id);
+      buildScript.current_build = rev.id;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      buildLogEntry.status = CubeBuildStatus.Building;
+      await buildLogEntry.save();
+      await updateFilterTableToLatest(rev.dataset_id, rev.id);
+      buildScript.successful_builds++;
+      buildScript.successfully_built.push(rev.id);
+    } catch (err) {
+      logger.error(err);
+      buildScript.failed_builds++;
+      buildScript.failed_to_build.push(rev.id);
+      failedBuilds.push({
+        revisionId: rev.id,
+        buildId: rev.id,
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+      });
+    }
+    buildScript.total_builds++;
+    buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+    await buildLogEntry.save();
+  }
+  if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+  buildLogEntry.completeBuild(CubeBuildStatus.Completed);
+  await buildLogEntry.save();
+  logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
 }

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -562,7 +562,7 @@ export async function rebuildDatasetList(
       failedBuilds.push({
         buildId: build.id,
         revisionId: rev.id,
-        error: JSON.stringify(build.errors)
+        error: build.errors ?? ''
       });
     } else {
       buildScript.successfully_built.push(build.id);

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -12,7 +12,7 @@ import {
   withDraftAndProviders,
   withDraftAndTopics
 } from '../repositories/dataset';
-import { RevisionList, RevisionRepository } from '../repositories/revision';
+import { RevisionRepository } from '../repositories/revision';
 import { logger } from '../utils/logger';
 import { DataTableAction } from '../enums/data-table-action';
 import { RevisionProviderDTO } from '../dtos/revision-provider-dto';
@@ -25,7 +25,7 @@ import { BadRequestException } from '../exceptions/bad-request.exception';
 import { TasklistStateDTO } from '../dtos/tasklist-state-dto';
 import { EventLog } from '../entities/event-log';
 
-import { createAllCubeFiles, updateFilterTableToLatest } from './cube-builder';
+import { createAllCubeFiles } from './cube-builder';
 import { validateAndUpload } from './incoming-file-processor';
 import { removeAllDimensions, removeMeasure } from './dimension-processor';
 import { UserGroupRepository } from '../repositories/user-group';
@@ -47,9 +47,6 @@ import { TempFile } from '../interfaces/temp-file';
 import { dbManager } from '../db/database-manager';
 import { getFileService } from '../utils/get-file-service';
 import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
-import { BuildLog } from '../entities/dataset/build-log';
-import { CubeBuildType } from '../enums/cube-build-type';
-import { CubeBuildStatus } from '../enums/cube-build-status';
 
 export class DatasetService {
   lang: Locale;
@@ -491,190 +488,5 @@ export class DatasetService {
     // create a new draft revision based on the now unpublished revision
     dataset = await this.createRevision(datasetId, user);
     await createAllCubeFiles(dataset.id, dataset.draftRevision!.id, user.id);
-  }
-}
-
-export async function rebuildDatasetList(
-  buildLogEntry: BuildLog,
-  revisionList: RevisionList[],
-  user: User
-): Promise<void> {
-  let buildTypeStr = 'all';
-  if (buildLogEntry.type === CubeBuildType.DraftCubes) {
-    buildTypeStr = 'all draft';
-  }
-
-  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr} cubes`);
-  try {
-    const failedBuilds: {
-      buildId: string;
-      revisionId: string;
-      error: string;
-    }[] = [];
-
-    const buildScript = {
-      current_build: null as string | null,
-      total_builds: 0,
-      successful_builds: 0,
-      failed_builds: 0,
-      all_builds: [] as string[],
-      successfully_built: [] as string[],
-      failed_to_build: [] as string[]
-    };
-
-    for (const rev of revisionList) {
-      const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
-      buildScript.all_builds.push(build.id);
-      buildScript.current_build = build.id;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      buildLogEntry.status = CubeBuildStatus.Building;
-      await buildLogEntry.save();
-      try {
-        await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
-      } catch (err) {
-        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-        build.completeBuild(
-          CubeBuildStatus.Failed,
-          undefined,
-          err instanceof Error ? (err.stack ?? err.message) : String(err)
-        );
-        await build.save();
-        buildScript.failed_to_build.push(build.id);
-        buildScript.failed_builds++;
-        buildScript.current_build = null;
-        buildScript.total_builds++;
-        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-        await buildLogEntry.save();
-        failedBuilds.push({
-          buildId: build.id.toString(),
-          revisionId: rev.id,
-          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-        });
-        continue;
-      }
-
-      try {
-        await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true);
-      } catch (err) {
-        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
-        build.completeBuild(
-          CubeBuildStatus.Failed,
-          undefined,
-          err instanceof Error ? (err.stack ?? err.message) : String(err)
-        );
-        await build.save();
-        buildScript.failed_to_build.push(build.id);
-        buildScript.failed_builds++;
-        buildScript.current_build = null;
-        buildScript.total_builds++;
-        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-        await buildLogEntry.save();
-        failedBuilds.push({
-          buildId: build.id.toString(),
-          revisionId: rev.id,
-          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-        });
-        continue;
-      }
-
-      await build.reload();
-      if (build.status === CubeBuildStatus.Completed) {
-        buildScript.successfully_built.push(build.id);
-        buildScript.successful_builds++;
-        logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
-      } else {
-        const buildError = build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
-        logger.warn(
-          `[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`
-        );
-        buildScript.failed_to_build.push(build.id);
-        buildScript.failed_builds++;
-        failedBuilds.push({
-          buildId: build.id,
-          revisionId: rev.id,
-          error: buildError
-        });
-      }
-      buildScript.current_build = null;
-      buildScript.total_builds++;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      await buildLogEntry.save();
-    }
-    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-    await buildLogEntry.save();
-    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
-  } catch (err) {
-    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr} cubes`);
-    buildLogEntry.completeBuild(
-      CubeBuildStatus.Failed,
-      undefined,
-      err instanceof Error ? (err.stack ?? err.message) : String(err)
-    );
-    await buildLogEntry.save();
-  }
-}
-
-export async function rebuildAllFilterTablesForRevisions(
-  buildLogEntry: BuildLog,
-  revisionList: RevisionList[]
-): Promise<void> {
-  const buildTypeStr = 'all filter tables';
-
-  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr}`);
-  try {
-    const failedBuilds: {
-      buildId: string;
-      revisionId: string;
-      error: string;
-    }[] = [];
-
-    const buildScript = {
-      current_build: null as string | null,
-      total_builds: 0,
-      successful_builds: 0,
-      failed_builds: 0,
-      all_builds: [] as string[],
-      successfully_built: [] as string[],
-      failed_to_build: [] as string[]
-    };
-
-    for (const rev of revisionList) {
-      if (!rev.data_table_id && rev.revision_index === 1) continue;
-      try {
-        buildScript.all_builds.push(rev.id);
-        buildScript.current_build = rev.id;
-        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-        buildLogEntry.status = CubeBuildStatus.Building;
-        await buildLogEntry.save();
-        await updateFilterTableToLatest(rev.dataset_id, rev.id);
-        buildScript.successful_builds++;
-        buildScript.successfully_built.push(rev.id);
-      } catch (err) {
-        logger.error(err);
-        buildScript.failed_builds++;
-        buildScript.failed_to_build.push(rev.id);
-        failedBuilds.push({
-          revisionId: rev.id,
-          buildId: rev.id,
-          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
-        });
-      }
-      buildScript.total_builds++;
-      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
-      await buildLogEntry.save();
-    }
-    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
-    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
-    await buildLogEntry.save();
-    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
-  } catch (err) {
-    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr}`);
-    buildLogEntry.completeBuild(
-      CubeBuildStatus.Failed,
-      undefined,
-      err instanceof Error ? (err.stack ?? err.message) : String(err)
-    );
-    await buildLogEntry.save();
   }
 }

--- a/src/services/revision.ts
+++ b/src/services/revision.ts
@@ -34,6 +34,7 @@ import { DateExtractor } from '../extractors/date-extractor';
 import { config } from '../config';
 import { revisionStartAndEndDateFinder, widenCoverageRange } from '../utils/revision';
 import { factTableValidatorFromSource, sourceAssignmentFromFactTable } from './fact-table-validator';
+import { BuildLog } from '../entities/dataset/build-log';
 
 export async function attachUpdateDataTableToRevision(
   datasetId: string,
@@ -110,10 +111,10 @@ export async function attachUpdateDataTableToRevision(
   dataTable.action = updateAction;
   revision.dataTable = dataTable;
   await revision.save();
-  const buildId = crypto.randomUUID();
+  const build = await BuildLog.startBuild(revision, CubeBuildType.ValidationCube, userId);
 
   try {
-    await createAllCubeFiles(dataset.id, revision.id, userId, CubeBuildType.ValidationCube, buildId);
+    await createAllCubeFiles(dataset.id, revision.id, userId, CubeBuildType.ValidationCube, build);
   } catch (err) {
     const error = err as CubeValidationException;
     const end = performance.now();
@@ -128,12 +129,12 @@ export async function attachUpdateDataTableToRevision(
   dataset.draftRevision = revision;
   const validatedSourceAssignment = sourceAssignmentFromFactTable(dataset.factTable!);
   try {
-    await factTableValidatorFromSource(dataset, validatedSourceAssignment, buildId);
+    await factTableValidatorFromSource(dataset, validatedSourceAssignment, build.id);
   } catch (err) {
     const end = performance.now();
     const time = Math.round(end - start);
     logger.info(`Cube update validation took ${time}ms`);
-    if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(buildId);
+    if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(build.id);
     await dataTable.remove();
     throw err;
   }
@@ -151,7 +152,7 @@ export async function attachUpdateDataTableToRevision(
   });
 
   try {
-    await validateMeasure(buildId, dataset, measureColumn, dataset.measure.measureTable!);
+    await validateMeasure(build.id, dataset, measureColumn, dataset.measure.measureTable!);
   } catch (err) {
     logger.warn(err, 'Validating measure failed.  Adding it to the revision tasks');
     revisionTasks.measure = { id: dataset.measure.id, lookupTableUpdated: false };
@@ -174,12 +175,12 @@ export async function attachUpdateDataTableToRevision(
       let updateDimension: Dimension | undefined;
       switch (dimension.type) {
         case DimensionType.LookupTable:
-          await createLookupTableInValidationCube(buildId, dimension, factTableColumn);
+          await createLookupTableInValidationCube(build.id, dimension, factTableColumn);
           break;
         case DimensionType.DatePeriod:
         case DimensionType.Date:
           updateDimension = await createDateTableInValidationCube(
-            buildId,
+            build.id,
             datasetId,
             lookupTableName,
             factTableColumn,
@@ -188,7 +189,7 @@ export async function attachUpdateDataTableToRevision(
           break;
       }
       await validateDimension(
-        buildId,
+        build.id,
         dataset,
         factTableColumn.columnName,
         factTableColumn.columnName,
@@ -208,7 +209,7 @@ export async function attachUpdateDataTableToRevision(
         const time = Math.round(end - start);
         logger.info(`Cube update validation took ${time}ms`);
         logger.error(err, `An error occurred trying to validate the file`);
-        if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(buildId);
+        if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(build.id);
         throw new BadRequestException('errors.data_table_validation_error');
       }
     }
@@ -229,7 +230,7 @@ export async function attachUpdateDataTableToRevision(
 
   dataTable.revision = revision;
   await dataTable.save();
-  if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(buildId);
+  if (!config.cube_builder.preserve_failed) void cleanUpValidationCube(build.id);
 }
 
 async function cleanUpValidationCube(buildId: string): Promise<void> {

--- a/src/services/revision.ts
+++ b/src/services/revision.ts
@@ -23,18 +23,26 @@ import {
   createAllCubeFiles,
   createLookupTableDimension,
   createMeasureLookupTable,
-  makeCubeSafeString
+  makeCubeSafeString,
+  updateFilterTableToLatest
 } from './cube-builder';
 import { CubeBuildType } from '../enums/cube-build-type';
 import { Dimension } from '../entities/dataset/dimension';
 import { Dataset } from '../entities/dataset/dataset';
-import { validateLookupTableHierarchyValues, validateLookupTableReferenceValues } from '../utils/lookup-table-utils';
+import {
+  bootstrapCubeBuildProcess,
+  validateLookupTableHierarchyValues,
+  validateLookupTableReferenceValues
+} from '../utils/lookup-table-utils';
 import { MeasureRow } from '../entities/dataset/measure-row';
 import { DateExtractor } from '../extractors/date-extractor';
 import { config } from '../config';
 import { revisionStartAndEndDateFinder, widenCoverageRange } from '../utils/revision';
 import { factTableValidatorFromSource, sourceAssignmentFromFactTable } from './fact-table-validator';
 import { BuildLog } from '../entities/dataset/build-log';
+import { RevisionList } from '../repositories/revision';
+import { User } from '../entities/user/user';
+import { CubeBuildStatus } from '../enums/cube-build-status';
 
 export async function attachUpdateDataTableToRevision(
   datasetId: string,
@@ -351,5 +359,190 @@ async function validateDimension(
     const err = new CubeValidationException('Validation failed');
     err.type = CubeValidationType.HierarchyError;
     throw err;
+  }
+}
+
+export async function rebuildCubesForRevisions(
+  buildLogEntry: BuildLog,
+  revisionList: RevisionList[],
+  user: User
+): Promise<void> {
+  let buildTypeStr = 'all';
+  if (buildLogEntry.type === CubeBuildType.DraftCubes) {
+    buildTypeStr = 'all draft';
+  }
+
+  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr} cubes`);
+  try {
+    const failedBuilds: {
+      buildId: string;
+      revisionId: string;
+      error: string;
+    }[] = [];
+
+    const buildScript = {
+      current_build: null as string | null,
+      total_builds: 0,
+      successful_builds: 0,
+      failed_builds: 0,
+      all_builds: [] as string[],
+      successfully_built: [] as string[],
+      failed_to_build: [] as string[]
+    };
+
+    for (const rev of revisionList) {
+      const build = await BuildLog.startBuild(rev, CubeBuildType.FullCube, user.id);
+      buildScript.all_builds.push(build.id);
+      buildScript.current_build = build.id;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      buildLogEntry.status = CubeBuildStatus.Building;
+      await buildLogEntry.save();
+      try {
+        await bootstrapCubeBuildProcess(rev.dataset_id, rev.id);
+      } catch (err) {
+        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+        build.completeBuild(
+          CubeBuildStatus.Failed,
+          undefined,
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        );
+        await build.save();
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        buildScript.current_build = null;
+        buildScript.total_builds++;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        await buildLogEntry.save();
+        failedBuilds.push({
+          buildId: build.id,
+          revisionId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+        continue;
+      }
+
+      try {
+        await createAllCubeFiles(rev.dataset_id, rev.id, user.id, CubeBuildType.FullCube, build, true);
+      } catch (err) {
+        logger.warn(err, `[${buildLogEntry.id}]: Failed to rebuild cube for revision ${rev.id}`);
+        build.completeBuild(
+          CubeBuildStatus.Failed,
+          undefined,
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        );
+        await build.save();
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        buildScript.current_build = null;
+        buildScript.total_builds++;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        await buildLogEntry.save();
+        failedBuilds.push({
+          buildId: build.id,
+          revisionId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+        continue;
+      }
+
+      await build.reload();
+      if (build.status === CubeBuildStatus.Completed) {
+        buildScript.successfully_built.push(build.id);
+        buildScript.successful_builds++;
+        logger.info(`[${buildLogEntry.id}]: Cube for revision ${rev.id} has been rebuilt successfully.`);
+      } else {
+        const buildError = build.errors ?? `Cube build finished with unexpected status: ${build.status}`;
+        logger.warn(
+          `[${buildLogEntry.id}]: Cube for revision ${rev.id} failed to rebuild with status ${build.status}.`
+        );
+        buildScript.failed_to_build.push(build.id);
+        buildScript.failed_builds++;
+        failedBuilds.push({
+          buildId: build.id,
+          revisionId: rev.id,
+          error: buildError
+        });
+      }
+      buildScript.current_build = null;
+      buildScript.total_builds++;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      await buildLogEntry.save();
+    }
+    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
+    await buildLogEntry.save();
+    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
+  } catch (err) {
+    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr} cubes`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
+    await buildLogEntry.save();
+  }
+}
+
+export async function rebuildAllFilterTablesForRevisions(
+  buildLogEntry: BuildLog,
+  revisionList: RevisionList[]
+): Promise<void> {
+  const buildTypeStr = 'all filter tables';
+
+  logger.info(`[${buildLogEntry.id}]: Starting process to rebuild ${buildTypeStr}`);
+  try {
+    const failedBuilds: {
+      buildId: string;
+      revisionId: string;
+      error: string;
+    }[] = [];
+
+    const buildScript = {
+      current_build: null as string | null,
+      total_builds: 0,
+      successful_builds: 0,
+      failed_builds: 0,
+      all_builds: [] as string[],
+      successfully_built: [] as string[],
+      failed_to_build: [] as string[]
+    };
+
+    for (const rev of revisionList) {
+      if (!rev.data_table_id && rev.revision_index === 1) continue;
+      try {
+        buildScript.all_builds.push(rev.id);
+        buildScript.current_build = rev.id;
+        buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+        buildLogEntry.status = CubeBuildStatus.Building;
+        await buildLogEntry.save();
+        await updateFilterTableToLatest(rev.dataset_id, rev.id);
+        buildScript.successful_builds++;
+        buildScript.successfully_built.push(rev.id);
+      } catch (err) {
+        logger.error(err);
+        buildScript.failed_builds++;
+        buildScript.failed_to_build.push(rev.id);
+        failedBuilds.push({
+          revisionId: rev.id,
+          buildId: rev.id,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err)
+        });
+      }
+      buildScript.total_builds++;
+      buildLogEntry.buildScript = JSON.stringify(buildScript, null, 2);
+      await buildLogEntry.save();
+    }
+    if (failedBuilds.length > 0) buildLogEntry.errors = JSON.stringify(failedBuilds, null, 2);
+    buildLogEntry.completeBuild(CubeBuildStatus.Completed);
+    await buildLogEntry.save();
+    logger.info(`[${buildLogEntry.id}]: Finished rebuild of ${buildTypeStr} cubes`);
+  } catch (err) {
+    logger.error(err, `[${buildLogEntry.id}]: Unexpected error rebuilding ${buildTypeStr}`);
+    buildLogEntry.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    );
+    await buildLogEntry.save();
   }
 }

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,5 +1,0 @@
-export const sleep = async (ms: number): Promise<void> => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-};

--- a/test/integration/routes/fact-table-validation.test.ts
+++ b/test/integration/routes/fact-table-validation.test.ts
@@ -73,7 +73,7 @@ describe('Fact table validation (integration)', () => {
         .patch(`/dataset/${datasetId}/sources`)
         .set(getAuthHeader(user))
         .send(minimalSourceAssignment());
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       expect(res.body.dataset).toBeDefined();
       expect(res.body.build_id).toBeDefined();
     });
@@ -153,7 +153,7 @@ describe('Fact table validation (integration)', () => {
         .patch(`/dataset/${datasetId}/sources`)
         .set(getAuthHeader(user))
         .send(minimalSourceAssignment());
-      expect(assignRes.status).toBe(200);
+      expect(assignRes.status).toBe(202);
 
       // Step 2: Simulate publication
       const revision = await Revision.findOneOrFail({ where: { id: revisionId } });
@@ -195,7 +195,7 @@ describe('Fact table validation (integration)', () => {
         .patch(`/dataset/${datasetId}/sources`)
         .set(getAuthHeader(user))
         .send(minimalSourceAssignment());
-      expect(assignRes.status).toBe(200);
+      expect(assignRes.status).toBe(202);
 
       // Step 2: Simulate publication by directly updating the database
       // Mark the revision as approved/published

--- a/test/integration/routes/publisher-journey.test.ts
+++ b/test/integration/routes/publisher-journey.test.ts
@@ -467,7 +467,7 @@ describe('API Endpoints', () => {
   });
 
   describe('Step 4 - Create dimensions', () => {
-    test('Create dimensions from user supplied JSON returns 200 and updated dataset with dimensions attached', async () => {
+    test('Create dimensions from user supplied JSON returns 202 and updated dataset with dimensions attached', async () => {
       const testDatasetId = uuidV4();
       const testRevisionId = uuidV4();
       const testFileImportId = uuidV4();
@@ -539,7 +539,7 @@ describe('API Endpoints', () => {
         .send(sourceAssignment)
         .set(getAuthHeader(user));
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       const updatedDataset = await DatasetRepository.getById(testDatasetId, { dimensions: true });
       if (!updatedDataset) {
         throw new Error('Dataset not found');

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -101,17 +101,17 @@ describe('POST /dataset/:dataset_id/revision/by-id/:revision_id', () => {
       revisionId,
       expect.anything(),
       CubeBuildType.FullCube,
-      res.body.build_id
+      expect.objectContaining({ id: res.body.build_id })
     );
   });
 
   test('creates a BuildLog row in the database for the returned build_id', async () => {
     let createAllCubeFilesPromise: Promise<void> | undefined;
 
-    jest.mocked(createAllCubeFiles).mockImplementation((_datasetId, _revisionId, userId, buildType, buildId) => {
+    jest.mocked(createAllCubeFiles).mockImplementation((_datasetId, _revisionId, userId, buildType, _build) => {
       createAllCubeFilesPromise = (async () => {
         const revision = await Revision.findOneBy({ id: _revisionId });
-        await BuildLog.startBuild(revision, buildType!, userId, buildId);
+        await BuildLog.startBuild(revision, buildType!, userId);
       })();
 
       return createAllCubeFilesPromise;

--- a/test/integration/routes/regenerate-revision-cube.test.ts
+++ b/test/integration/routes/regenerate-revision-cube.test.ts
@@ -108,10 +108,10 @@ describe('POST /dataset/:dataset_id/revision/by-id/:revision_id', () => {
   test('creates a BuildLog row in the database for the returned build_id', async () => {
     let createAllCubeFilesPromise: Promise<void> | undefined;
 
-    jest.mocked(createAllCubeFiles).mockImplementation((_datasetId, _revisionId, userId, buildType, _build) => {
+    jest.mocked(createAllCubeFiles).mockImplementation((_datasetId, _revisionId, userId, buildType, build) => {
       createAllCubeFilesPromise = (async () => {
         const revision = await Revision.findOneBy({ id: _revisionId });
-        await BuildLog.startBuild(revision, buildType!, userId);
+        if (!build) await BuildLog.startBuild(revision, buildType!, userId);
       })();
 
       return createAllCubeFilesPromise;

--- a/test/unit/controllers/dataset.test.ts
+++ b/test/unit/controllers/dataset.test.ts
@@ -1297,6 +1297,7 @@ describe('Dataset controller', () => {
       mockFactTableValidatorFromSource.mockResolvedValue(undefined);
       mockCreateDimensionsFromSourceAssignment.mockResolvedValue(undefined);
       mockFromDataset.mockReturnValue(mockDto);
+      mockStartBuild.mockResolvedValue({ id: 'test-build-id' });
 
       const req = createMockRequest({ body: { col: 'dimension' } });
       const res = createMockResponse({ locals: { datasetId } });

--- a/test/unit/controllers/dataset.test.ts
+++ b/test/unit/controllers/dataset.test.ts
@@ -12,15 +12,18 @@ import { TaskAction } from '../../../src/enums/task-action';
 import { OutputFormats } from '../../../src/enums/output-formats';
 
 // Mock logger
-jest.mock('../../../src/utils/logger', () => ({
-  logger: {
+jest.mock('../../../src/utils/logger', () => {
+  const logger = {
     debug: jest.fn(),
     info: jest.fn(),
     error: jest.fn(),
     warn: jest.fn(),
-    trace: jest.fn()
-  }
-}));
+    trace: jest.fn(),
+    child: jest.fn()
+  };
+  logger.child.mockReturnValue(logger);
+  return { logger };
+});
 
 // Mock blob storage
 jest.mock('../../../src/services/blob-storage', () => {
@@ -259,11 +262,6 @@ jest.mock('../../../src/utils/file-utils', () => ({
   addDirectoryToZip: jest.fn()
 }));
 
-// Mock sleep
-jest.mock('../../../src/utils/sleep', () => ({
-  sleep: jest.fn().mockResolvedValue(undefined)
-}));
-
 // Mock BuildLog entity
 const mockStartBuild = jest.fn();
 jest.mock('../../../src/entities/dataset/build-log', () => ({
@@ -283,9 +281,14 @@ jest.mock('../../../src/dtos/revision-metadata-dto', () => ({
 }));
 
 // Mock i18next
-jest.mock('i18next', () => ({
-  t: jest.fn((key: string) => key)
-}));
+jest.mock('i18next', () => {
+  const mock = {
+    t: jest.fn((key: string) => key),
+    use: jest.fn().mockReturnThis(),
+    init: jest.fn().mockReturnThis()
+  };
+  return { ...mock, default: mock };
+});
 
 import {
   listUserDatasets,

--- a/test/unit/controllers/dimension.test.ts
+++ b/test/unit/controllers/dimension.test.ts
@@ -98,6 +98,15 @@ jest.mock('../../../src/services/cube-builder', () => ({
   createAllCubeFiles: jest.fn().mockResolvedValue(undefined)
 }));
 
+// Mock BuildLog entity
+const mockStartBuild = jest.fn().mockResolvedValue({ id: 'test-build-id' });
+jest.mock('../../../src/entities/dataset/build-log', () => ({
+  BuildLog: {
+    startBuild: (...args: unknown[]) => mockStartBuild(...args)
+  },
+  CompleteStatus: ['completed', 'failed']
+}));
+
 // Mock view-error-generators
 const mockViewErrorGenerators = jest.fn();
 jest.mock('../../../src/utils/view-error-generators', () => ({


### PR DESCRIPTION
The Cube Builder has always been responsible for creating its own build log entities.  However most end points which use the cube builder need to return the build ID back to the frotnend.  There are two places where the actual build log entity itself is needed immediatly after the cube builder has kicked off its build.  To prevent a race condition and sleep patterns the build log entity can now be created outside of the cube builder and passed in instead of passing in an ID when the entity might not have been created.

As the QueryStore clean up logic has now moved to be inside of the cube builder I've additionally removed the logic around doing this when doing cube rebuilds.

Cleaned up the code to no longer use sleep.  AS the cube builder can run synchronously or asynchronous when rebuilding all revisions we can run this synchronously and remove the need to sleep and poll the results of the build.  Also refactored the associated service functions to live inside of `services/dataset.ts`