### PR TITLE
SW-1244: cache v1 datatable total_records in query_store

### DIFF
--- a/src/repositories/query-store.ts
+++ b/src/repositories/query-store.ts
@@ -5,20 +5,48 @@ import { customAlphabet } from 'nanoid';
 
 import { dataSource } from '../db/data-source';
 import { dbManager } from '../db/database-manager';
-import { DataOptionsDTO } from '../dtos/data-options-dto';
+import { DataOptionsDTO, FRONTEND_DATA_OPTIONS } from '../dtos/data-options-dto';
 import { QueryStore } from '../entities/query-store';
 import { logger } from '../utils/logger';
 import { Locale } from '../enums/locale';
 import { FactTableToDimensionName } from '../interfaces/fact-table-column-to-dimension-name';
+import { FilterInterface, FilterV2 } from '../interfaces/filterInterface';
 import { SUPPORTED_LOCALES } from '../middleware/translation';
 import { checkAvailableViews, getFilterTable, coreViewChooser, getColumns, createBaseQuery } from '../utils/consumer';
 
 const nanoId = customAlphabet('1234567890abcdefghjklmnpqrstuvwxy', 12);
 
-function generateHash(datasetId: string, revisionId: string, options: DataOptionsDTO): string {
+function generateHash(datasetId: string, revisionId: string, options: DataOptionsDTO, namespace?: string): string {
+  const prefix = namespace ? `${namespace}:` : '';
   return createHash('sha256')
-    .update(`${datasetId}:${revisionId}:${JSON.stringify(options)}`)
+    .update(`${prefix}${datasetId}:${revisionId}:${JSON.stringify(options)}`)
     .digest('hex');
+}
+
+// Marker prefix for v1 cache entries so their hashes can never collide with v2.
+const V1_HASH_NAMESPACE = 'v1';
+
+// Translates a v1 filter list into a DataOptionsDTO whose hash is stable across
+// client-side reorderings. Sort matters here, not for SQL correctness, but to
+// guarantee that two v1 requests with the same filter set produce the same
+// query_store hash regardless of how the client laid out the query string.
+//
+// `use_raw_column_names: true` is required because v1's `filter` query param
+// uses fact-table column names; v2's `createBaseQuery` only resolves them
+// correctly when this flag is set. View selection is irrelevant to the count.
+export function v1FilterToDataOptions(filter?: FilterInterface[]): DataOptionsDTO {
+  const filters: FilterV2[] = (filter ?? [])
+    .map((f) => ({ columnName: f.columnName, values: [...f.values].sort() }))
+    .sort((a, b) => a.columnName.localeCompare(b.columnName))
+    .map(({ columnName, values }) => ({ [columnName]: values }));
+
+  return {
+    filters,
+    options: {
+      ...FRONTEND_DATA_OPTIONS.options,
+      use_raw_column_names: true
+    }
+  };
 }
 
 interface QueryStoreUpdate {
@@ -72,6 +100,17 @@ async function generateQuery(dataOptions: DataOptionsDTO, revisionId: string): P
   };
 }
 
+async function runCountAgainstCube(baseQuery: string): Promise<number> {
+  const totalsQuery = pgformat('SELECT count(*) as "totalLines" from (%s);', baseQuery);
+  const connection = dbManager.getCubeDataSource().createQueryRunner();
+  try {
+    const totals: { totalLines: string }[] = await connection.query(totalsQuery);
+    return Number(totals[0].totalLines);
+  } finally {
+    void connection.release();
+  }
+}
+
 export const QueryStoreRepository = dataSource.getRepository(QueryStore).extend({
   async getById(id: string): Promise<QueryStore> {
     logger.debug(`Loading query store by id ${id}...`);
@@ -81,6 +120,68 @@ export const QueryStoreRepository = dataSource.getRepository(QueryStore).extend(
   async getByFullHash(hash: string): Promise<QueryStore> {
     logger.debug(`Loading query store by full hash ${hash}...`);
     return this.findOneByOrFail({ hash });
+  },
+
+  // Cache-or-compute helper for the v1 datatable count. v1's filter contract
+  // is broader than v2 (it permits any fact-table column, dimensioned or not),
+  // so we deliberately don't run the v1 request through v2's generateQuery —
+  // we wrap the COUNT directly here using v1's already-built baseQuery.
+  //
+  // The entry is persisted to query_store with placeholder `query`/`columnMapping`
+  // fields. On cube rebuild, `rebuildQueriesForRevision` will attempt to
+  // regenerate via generateQuery; if the filter references non-dimensioned
+  // columns that path will throw and the entry is removed (existing fallback
+  // in `rebuildQueriesForRevision`). The cache then repopulates on the next
+  // v1 request. Dimensioned filters survive the rebuild cleanly.
+  async getTotalLinesForV1(
+    datasetId: string,
+    revisionId: string,
+    filter: FilterInterface[] | undefined,
+    baseQuery: string
+  ): Promise<number> {
+    const dataOptions = v1FilterToDataOptions(filter);
+    const hash = generateHash(datasetId, revisionId, dataOptions, V1_HASH_NAMESPACE);
+
+    const cached = await QueryStore.findOneBy({ hash });
+    if (cached) {
+      return cached.totalLines;
+    }
+
+    const totalLines = await runCountAgainstCube(baseQuery);
+
+    let id = nanoId();
+    let remainingAttempts = 10;
+    while (remainingAttempts > 0) {
+      const existing = await QueryStore.findOneBy({ id });
+      if (!existing) break;
+      remainingAttempts--;
+      id = nanoId();
+    }
+    if (remainingAttempts === 0) {
+      logger.warn(`Failed to generate unique id for v1 query_store entry — skipping persistence`);
+      return totalLines;
+    }
+
+    const entry = QueryStore.create({
+      id,
+      datasetId,
+      revisionId,
+      requestObject: dataOptions,
+      hash,
+      query: {},
+      totalLines,
+      columnMapping: []
+    });
+
+    try {
+      await entry.save();
+    } catch (err) {
+      // Concurrent writers may have inserted the same hash between our lookup
+      // and save — that's fine, the cache is still warm. Log and continue.
+      logger.debug(err, `Failed to persist v1 query_store entry for hash ${hash} (likely a concurrent write)`);
+    }
+
+    return totalLines;
   },
 
   async getByRequest(datasetId: string, revisionId: string, dataOptions: DataOptionsDTO): Promise<QueryStore> {

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -11,6 +11,7 @@ import { DatasetDTO } from '../dtos/dataset-dto';
 import { Dataset } from '../entities/dataset/dataset';
 import { logger } from '../utils/logger';
 import { DatasetRepository } from '../repositories/dataset';
+import { QueryStoreRepository } from '../repositories/query-store';
 import { SortByInterface } from '../interfaces/sort-by-interface';
 import { FilterInterface } from '../interfaces/filterInterface';
 import { dbManager } from '../db/database-manager';
@@ -216,18 +217,7 @@ export const createFrontendView = async (
     filterBy
   );
 
-  const totalsQuery = pgformat('SELECT count(*) as "totalLines" from (%s);', baseQuery);
-  const totalsQueryConnection = dbManager.getCubeDataSource().createQueryRunner();
-  let totals: { totalLines: string }[];
-  try {
-    totals = await totalsQueryConnection.query(totalsQuery);
-  } catch (err) {
-    logger.error(err, 'Failed to extract totals using the base query');
-    throw err;
-  } finally {
-    void totalsQueryConnection.release();
-  }
-  const totalLines = Number(totals[0].totalLines);
+  const totalLines = await QueryStoreRepository.getTotalLinesForV1(dataset.id, revisionId, filterBy, baseQuery);
   const totalPages = Math.max(1, Math.ceil(totalLines / pageSize));
   const errors = validateParams(pageNumber, totalPages, pageSize);
 

--- a/test/integration/routes/consumer-v1/dataset-data.test.ts
+++ b/test/integration/routes/consumer-v1/dataset-data.test.ts
@@ -132,8 +132,8 @@ describe('Consumer V1 — dataset data endpoints (/view, /view/filters, /downloa
     });
 
     it('caches total_records across repeated requests for the same filter', async () => {
-      // Wipe any query_store entries left by earlier tests in this revision so the
-      // first request below is a guaranteed cache miss.
+      // Wipe any query_store entries left by earlier tests in this revision so we
+      // can pin the test's single expected row deterministically below.
       await QueryStore.delete({ revisionId: REVISION_ID });
 
       const filter = JSON.stringify([{ columnName: 'YearCode', values: ['2021'] }]);
@@ -142,11 +142,15 @@ describe('Consumer V1 — dataset data endpoints (/view, /view/filters, /downloa
       expect(miss.status).toBe(200);
       expect(Number(miss.body.page_info.total_records)).toBe(15);
 
+      // The view request should have written exactly one query_store row for this
+      // revision; assert that explicitly rather than picking an arbitrary match.
+      const entries = await QueryStore.findBy({ revisionId: REVISION_ID });
+      expect(entries).toHaveLength(1);
+
       // Mutate the cached row to a sentinel. If the next request hits the cube, we'd
       // see 15 again; if it hits the cache, we'll see the sentinel.
-      const entry = await QueryStore.findOneByOrFail({ revisionId: REVISION_ID });
-      entry.totalLines = 9999;
-      await entry.save();
+      entries[0].totalLines = 9999;
+      await entries[0].save();
 
       const hit = await request(app).get(`/v1/${DATASET_ID}/view`).query({ filter });
       expect(hit.status).toBe(200);

--- a/test/integration/routes/consumer-v1/dataset-data.test.ts
+++ b/test/integration/routes/consumer-v1/dataset-data.test.ts
@@ -12,6 +12,7 @@ import { GroupRole } from '../../../../src/enums/group-role';
 import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
 import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
 import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
+import { QueryStore } from '../../../../src/entities/query-store';
 import BlobStorage from '../../../../src/services/blob-storage';
 
 jest.mock('../../../../src/services/blob-storage');
@@ -128,6 +129,31 @@ describe('Consumer V1 — dataset data endpoints (/view, /view/filters, /downloa
     it('returns 404 for a non-existent dataset', async () => {
       const res = await request(app).get('/v1/99999999-9999-4999-8999-999999999999/view');
       expect(res.status).toBe(404);
+    });
+
+    it('caches total_records across repeated requests for the same filter', async () => {
+      // Wipe any query_store entries left by earlier tests in this revision so the
+      // first request below is a guaranteed cache miss.
+      await QueryStore.delete({ revisionId: REVISION_ID });
+
+      const filter = JSON.stringify([{ columnName: 'YearCode', values: ['2021'] }]);
+
+      const miss = await request(app).get(`/v1/${DATASET_ID}/view`).query({ filter });
+      expect(miss.status).toBe(200);
+      expect(Number(miss.body.page_info.total_records)).toBe(15);
+
+      // Mutate the cached row to a sentinel. If the next request hits the cube, we'd
+      // see 15 again; if it hits the cache, we'll see the sentinel.
+      const entry = await QueryStore.findOneByOrFail({ revisionId: REVISION_ID });
+      entry.totalLines = 9999;
+      await entry.save();
+
+      const hit = await request(app).get(`/v1/${DATASET_ID}/view`).query({ filter });
+      expect(hit.status).toBe(200);
+      expect(Number(hit.body.page_info.total_records)).toBe(9999);
+
+      // Leave the table clean for downstream tests.
+      await QueryStore.delete({ revisionId: REVISION_ID });
     });
   });
 

--- a/test/unit/repositories/query-store.test.ts
+++ b/test/unit/repositories/query-store.test.ts
@@ -1,0 +1,171 @@
+import 'reflect-metadata';
+import { createHash } from 'node:crypto';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+const mockFindOneBy = jest.fn();
+const mockSave = jest.fn();
+const mockCreate = jest.fn((data: unknown) => ({ ...(data as object), save: mockSave }));
+
+jest.mock('../../../src/entities/query-store', () => ({
+  QueryStore: {
+    findOneBy: (...args: unknown[]) => mockFindOneBy(...args),
+    create: (data: unknown) => mockCreate(data)
+  }
+}));
+
+jest.mock('../../../src/db/data-source', () => ({
+  dataSource: {
+    getRepository: () => ({ extend: (extension: Record<string, unknown>) => extension })
+  }
+}));
+
+const mockCubeQuery = jest.fn();
+const mockCubeRelease = jest.fn();
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: () => ({
+      createQueryRunner: () => ({ query: mockCubeQuery, release: mockCubeRelease })
+    })
+  }
+}));
+
+jest.mock('../../../src/utils/consumer', () => ({
+  checkAvailableViews: jest.fn(),
+  getFilterTable: jest.fn(),
+  coreViewChooser: jest.fn(),
+  getColumns: jest.fn(),
+  createBaseQuery: jest.fn()
+}));
+
+import { FilterInterface } from '../../../src/interfaces/filterInterface';
+import { v1FilterToDataOptions, QueryStoreRepository } from '../../../src/repositories/query-store';
+
+function hash(datasetId: string, revisionId: string, options: unknown, namespace = 'v1'): string {
+  return createHash('sha256')
+    .update(`${namespace}:${datasetId}:${revisionId}:${JSON.stringify(options)}`)
+    .digest('hex');
+}
+
+describe('v1FilterToDataOptions', () => {
+  it('returns identical hashes for filter entries in different order', () => {
+    const a: FilterInterface[] = [
+      { columnName: 'region', values: ['wales', 'england'] },
+      { columnName: 'year', values: ['2024', '2023'] }
+    ];
+    const b: FilterInterface[] = [
+      { columnName: 'year', values: ['2023', '2024'] },
+      { columnName: 'region', values: ['england', 'wales'] }
+    ];
+
+    expect(hash('d', 'r', v1FilterToDataOptions(a))).toEqual(hash('d', 'r', v1FilterToDataOptions(b)));
+  });
+
+  it('returns identical hashes for value arrays in different order', () => {
+    const a: FilterInterface[] = [{ columnName: 'region', values: ['c', 'a', 'b'] }];
+    const b: FilterInterface[] = [{ columnName: 'region', values: ['b', 'c', 'a'] }];
+
+    expect(hash('d', 'r', v1FilterToDataOptions(a))).toEqual(hash('d', 'r', v1FilterToDataOptions(b)));
+  });
+
+  it('returns different hashes for different filter values', () => {
+    const a: FilterInterface[] = [{ columnName: 'region', values: ['wales'] }];
+    const b: FilterInterface[] = [{ columnName: 'region', values: ['england'] }];
+
+    expect(hash('d', 'r', v1FilterToDataOptions(a))).not.toEqual(hash('d', 'r', v1FilterToDataOptions(b)));
+  });
+
+  it('treats undefined and empty filter lists as equivalent', () => {
+    expect(hash('d', 'r', v1FilterToDataOptions(undefined))).toEqual(hash('d', 'r', v1FilterToDataOptions([])));
+  });
+
+  it('uses options that match v1 contract (raw columns, reference values, no pivot)', () => {
+    const dto = v1FilterToDataOptions([]);
+    expect(dto.options?.use_raw_column_names).toBe(true);
+    expect(dto.options?.use_reference_values).toBe(true);
+    expect(dto.pivot).toBeUndefined();
+  });
+});
+
+describe('v1/v2 hash isolation', () => {
+  it('produces a different hash for v1 than for the same options without a namespace', () => {
+    // The v1 cache hashes its entries under a "v1:" namespace prefix so they can
+    // never collide with v2 entries — even if a v2 client happened to send a
+    // DataOptionsDTO that matched v1's canonicalised shape.
+    const dto = v1FilterToDataOptions([{ columnName: 'year', values: ['2020'] }]);
+    const v1Hash = hash('d', 'r', dto, 'v1');
+    const v2Hash = hash('d', 'r', dto, '');
+    expect(v1Hash).not.toEqual(v2Hash);
+  });
+});
+
+describe('QueryStoreRepository.getTotalLinesForV1', () => {
+  beforeEach(() => {
+    mockFindOneBy.mockReset();
+    mockSave.mockReset();
+    mockCreate.mockClear();
+    mockCubeQuery.mockReset();
+    mockCubeRelease.mockReset();
+  });
+
+  it('returns cached totalLines without hitting the cube when entry exists', async () => {
+    mockFindOneBy.mockResolvedValueOnce({ totalLines: 42 });
+
+    const result = await QueryStoreRepository.getTotalLinesForV1('d', 'r', [], 'SELECT 1');
+
+    expect(result).toBe(42);
+    expect(mockCubeQuery).not.toHaveBeenCalled();
+  });
+
+  it('runs COUNT once on cache miss and persists the result', async () => {
+    mockFindOneBy.mockResolvedValueOnce(null); // hash lookup miss
+    mockFindOneBy.mockResolvedValueOnce(null); // id collision check
+    mockCubeQuery.mockResolvedValueOnce([{ totalLines: '15' }]);
+    mockSave.mockResolvedValue(undefined);
+
+    const result = await QueryStoreRepository.getTotalLinesForV1(
+      'd',
+      'r',
+      [{ columnName: 'year', values: ['2020'] }],
+      'SELECT * FROM cube WHERE year = 2020'
+    );
+
+    expect(result).toBe(15);
+    expect(mockCubeQuery).toHaveBeenCalledTimes(1);
+    expect(mockCubeQuery.mock.calls[0][0]).toMatch(/SELECT count\(\*\)/i);
+    expect(mockCubeRelease).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId: 'd',
+        revisionId: 'r',
+        totalLines: 15,
+        query: {},
+        columnMapping: []
+      })
+    );
+  });
+
+  it('returns the computed totalLines even when persistence fails (concurrent write)', async () => {
+    mockFindOneBy.mockResolvedValueOnce(null);
+    mockFindOneBy.mockResolvedValueOnce(null);
+    mockCubeQuery.mockResolvedValueOnce([{ totalLines: '7' }]);
+    mockSave.mockRejectedValue(new Error('duplicate key'));
+
+    const result = await QueryStoreRepository.getTotalLinesForV1('d', 'r', undefined, 'SELECT 1');
+
+    expect(result).toBe(7);
+  });
+
+  it('releases the cube connection even when COUNT throws', async () => {
+    mockFindOneBy.mockResolvedValueOnce(null);
+    mockCubeQuery.mockRejectedValueOnce(new Error('column does not exist'));
+
+    await expect(QueryStoreRepository.getTotalLinesForV1('d', 'r', undefined, 'SELECT 1')).rejects.toThrow(
+      'column does not exist'
+    );
+    expect(mockCubeRelease).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/repositories/query-store.test.ts
+++ b/test/unit/repositories/query-store.test.ts
@@ -43,9 +43,13 @@ jest.mock('../../../src/utils/consumer', () => ({
 import { FilterInterface } from '../../../src/interfaces/filterInterface';
 import { v1FilterToDataOptions, QueryStoreRepository } from '../../../src/repositories/query-store';
 
+// Mirror of generateHash in src/repositories/query-store.ts — the prefix is only
+// prepended when a non-empty namespace is given, matching production behaviour
+// so the v1/v2 isolation test exercises the real branching.
 function hash(datasetId: string, revisionId: string, options: unknown, namespace = 'v1'): string {
+  const prefix = namespace ? `${namespace}:` : '';
   return createHash('sha256')
-    .update(`${namespace}:${datasetId}:${revisionId}:${JSON.stringify(options)}`)
+    .update(`${prefix}${datasetId}:${revisionId}:${JSON.stringify(options)}`)
     .digest('hex');
 }
 


### PR DESCRIPTION
## Summary

SW-1244 — caches the per-filter `total_records` on the v1 datatable view so repeated requests for the same `(dataset, revision, filter)` no longer re-run `SELECT count(*)` against the cube. The per-request COUNT was the dominant Postgres CPU cost during the 2026-04-23 incident; on a multi-million-row cube it scales linearly with the filtered row count regardless of `page_number`.

## Cache backend decision

Reuses the existing `query_store` table rather than introducing a new mechanism. v2 `/data` already caches `totalLines` here and `cube-builder.ts` already invalidates these entries on every rebuild — v1 simply wasn't participating. No Redis dependency, no in-process LRU, no extra invalidation wiring.

## Approach

- `getTotalLinesForV1(datasetId, revisionId, filter, baseQuery)` in `query-store.ts` does the cache lookup, runs the COUNT against the cube on miss, and persists a minimal `query_store` entry. The v1 request shape is canonicalised (sorted filters/values) so client-side ordering doesn't fragment the cache.
- v1 keeps its own base-query construction. v1's filter contract permits non-dimensioned fact columns (e.g. `YearCode` in the integration fixture) whereas v2's `generateQuery` resolver throws for those — so v1's count path stays out of `generateQuery`. Cache lookup is reused; cache write is reused; query building is not.
- v1 entries are hashed under a `v1:` namespace prefix so they cannot collide with v2 entries that happen to match the same canonicalised shape.
- Invalidation: nothing added. `rebuildQueriesForRevision` (and the unpublished-revision `QueryStore.delete`) at `cube-builder.ts:454-459` already covers v1 entries — entries with dimensioned filters rebuild cleanly; entries with non-dimensioned filters fall through to the existing remove-on-failure fallback and repopulate on the next request.

No v1 API change. The route, query params, and response envelope are unchanged.

## Test plan

- [x] Unit tests for canonicalisation hash stability (filter/value reordering produces the same hash) and v1/v2 namespace isolation.
- [x] Unit tests for cache hit (no COUNT issued), cache miss (COUNT + persist), persistence-failure tolerance (concurrent write), and connection release on COUNT failure.
- [x] Integration test that mutates the persisted `total_lines` to a sentinel between requests and asserts the second response uses the cached value — proves the hit path end-to-end through the HTTP boundary.
- [x] Pre-existing v1 integration coverage (`test/integration/routes/consumer-v1/dataset-data.test.ts`) still passes, including filter-on-non-dimensioned-column and bad-column 4xx mapping.
- [x] `npm run check` passes (1301 tests).

## Verification before close

End-to-end check against the dev stack:

1. `docker compose up -d && npm run dev`.
2. Hit `GET /v1/<id>/view?filter=<json>` twice; `total_records` identical, second request issues no `SELECT count(*)` (check `pg_stat_statements`).
3. Force a cube rebuild on the same revision; confirm the corresponding `query_store` row is removed/regenerated and the next request issues exactly one fresh COUNT.

## Out of scope

- v2 `/data` count caching (SW-1245 — already cached, unrelated work).
- Keyset/cursor pagination for deep `OFFSET` cost (SW-1246).
- v1 download endpoints (`/download/:format`) — these don't run a per-request COUNT.
