### PR TITLE
Add sort order to filter table creation

### DIFF
--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -40,7 +40,11 @@ interface FilterTable {
 export const getFilters = async (revisionId: string, language: string): Promise<FilterTable[]> => {
   const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
   try {
-    const filterTableQuery = pgformat('SELECT * FROM %I.filter_table WHERE language = %L;', revisionId, language);
+    const filterTableQuery = pgformat(
+      'SELECT * FROM %I.filter_table WHERE language = %L ORDER BY sort_order, reference;',
+      revisionId,
+      language
+    );
     const filterTable: FilterRow[] = await cubeDB.query(filterTableQuery);
     const columnData = new Map<string, FilterRow[]>();
 

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -213,19 +213,23 @@ export function getFilterTableQuery(revisionId: string, version: number, locale?
   // reference_count defaults to 1 otherwise we'll disable all filters on the frontend
   let columns =
     'reference, language, fact_table_column, dimension_name, description, NULL as sort_order, hierarchy, CAST(1 as BIGINT) as reference_count';
+  let sortBy = 'SORT BY sort_order, description';
   if (version > 1) {
+    logger.debug('V1 cube no filter sort');
     columns =
       'reference, language, fact_table_column, dimension_name, description, sort_order, hierarchy, reference_count';
+    sortBy = 'description, reference';
   }
   if (!locale) {
     return pgformat('SELECT %s FROM %I.%I;', columns, revisionId, FILTER_TABLE_NAME);
   }
   return pgformat(
-    'SELECT %s FROM %I.%I WHERE language LIKE %L;',
+    'SELECT %s FROM %I.%I WHERE language LIKE %L %s;',
     columns,
     revisionId,
     FILTER_TABLE_NAME,
-    `${locale.toLowerCase().split('-')[0]}%`
+    `${locale.toLowerCase().split('-')[0]}%`,
+    sortBy
   );
 }
 


### PR DESCRIPTION
The filter tables values aren't going in as they are ordered from their lookup or obeying the sort by clause on the insert.  This resolves the issue by now using the sort by on the filter table itself when pulling out values.