### PR TITLE
SW-1245: tighten v2 /data unbounded-fetch handling

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -116,7 +116,12 @@ async function parsePivotPageOptions(req: Request, validateXY = true): Promise<P
     if (yAxis.length === 1) yAxis = yAxis[0];
   }
 
-  const format = (params.format as OutputFormats) ?? OutputFormats.Json;
+  const formatParam = params.format as OutputFormats | undefined;
+  if (!formatParam) {
+    throw new BadRequestException('errors.output_format_required');
+  }
+
+  const format = formatParam;
   const pageSize = params.page_size ?? (isDownloadFormat(format) ? undefined : DEFAULT_PAGE_SIZE);
 
   if (!isDownloadFormat(format) && pageSize !== undefined && pageSize > MAX_PAGE_SIZE) {
@@ -143,7 +148,7 @@ export const getPublishedDatasetData = async (req: Request, res: Response, next:
   if (!publishedRevision) return next(new NotFoundException('errors.no_published_revision'));
 
   try {
-    const pageOptions = await parsePageOptions(req);
+    const pageOptions = await parsePageOptions(req, { requireFormat: true });
     const dataOptions = pageOptions.format === OutputFormats.Frontend ? FRONTEND_DATA_OPTIONS : DEFAULT_DATA_OPTIONS;
 
     const queryStore = filterId

--- a/src/enums/output-formats.ts
+++ b/src/enums/output-formats.ts
@@ -7,11 +7,7 @@ export enum OutputFormats {
   // Parquet = 'parquet'
 }
 
-const DOWNLOAD_FORMATS: ReadonlySet<OutputFormats> = new Set([
-  OutputFormats.Csv,
-  OutputFormats.Excel,
-  OutputFormats.Json
-]);
+const DOWNLOAD_FORMATS: ReadonlySet<OutputFormats> = new Set([OutputFormats.Csv, OutputFormats.Excel]);
 
 export function isDownloadFormat(format: OutputFormats): boolean {
   return DOWNLOAD_FORMATS.has(format);

--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -34,8 +34,8 @@
     "name_missing": "Mae Enw’r Set Ddata ar Goll",
     "page_size": "Rhaid i faint y dudalen fod rhwng {{min_page_size}} a {{max_page_size}}",
     "output_format_required": "Mae angen darparu fformat allbwn",
-    "page_number_to_high": "Rhaid i rif y dudalen fod yn llai na {{page_number}} neu’n {{page_number}} tudalen",
-    "page_number_to_low": "Rhaid i rif y dudalen fod yn fwy na 0",
+    "page_number_too_high": "Rhaid i rif y dudalen fod yn llai na {{page_number}} neu’n {{page_number}} tudalen",
+    "page_number_too_low": "Rhaid i rif y dudalen fod yn fwy na 0",
     "no_datafile": "Nid oes ffeil ddata wedi’i hatodi i’r Set ddata",
     "download_from_filestore": "Gwall wrth lawrlwytho’r ffeil o’r storfa ffeiliau",
     "upload": {

--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -33,6 +33,7 @@
     "problem": "Mae problem wedi codi",
     "name_missing": "Mae Enw’r Set Ddata ar Goll",
     "page_size": "Rhaid i faint y dudalen fod rhwng {{min_page_size}} a {{max_page_size}}",
+    "output_format_required": "Mae angen darparu fformat allbwn",
     "page_number_to_high": "Rhaid i rif y dudalen fod yn llai na {{page_number}} neu’n {{page_number}} tudalen",
     "page_number_to_low": "Rhaid i rif y dudalen fod yn fwy na 0",
     "no_datafile": "Nid oes ffeil ddata wedi’i hatodi i’r Set ddata",

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -35,6 +35,7 @@
     "problem": "There is a problem",
     "name_missing": "Dataset Name Missing",
     "page_size": "Page size must be between {{min_page_size}} and {{max_page_size}}",
+    "output_format_required": "Output format is required",
     "page_number_to_high": "Page number must be less than or equal to {{page_number}}",
     "page_number_to_low": "Page number must be greater than 0",
     "no_datafile": "No datafile attached to Dataset",

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -36,8 +36,8 @@
     "name_missing": "Dataset Name Missing",
     "page_size": "Page size must be between {{min_page_size}} and {{max_page_size}}",
     "output_format_required": "Output format is required",
-    "page_number_to_high": "Page number must be less than or equal to {{page_number}}",
-    "page_number_to_low": "Page number must be greater than 0",
+    "page_number_too_high": "Page number must be less than or equal to {{page_number}}",
+    "page_number_too_low": "Page number must be greater than 0",
     "no_datafile": "No datafile attached to Dataset",
     "download_from_filestore": "Error downloading file from file store",
     "upload": {

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -367,10 +367,11 @@ publicApiV2Router.get(
   /*
     #swagger.tags = ['Data']
     #swagger.summary = "Get paginated data for a dataset"
-    #swagger.description = "Returns rows for the latest published revision as a
-      JSON array of objects. Each object has column names as keys. The
-      response includes a Content-Disposition header for download. To apply
-      filters, first create a filter via POST /{dataset_id}/data, then use
+    #swagger.description = "Returns rows for the latest published revision in the format
+      specified by the required <code>format</code> parameter. <code>csv</code> and <code>xlsx</code>
+      return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code>
+      and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).
+      To apply filters, first create a filter via POST /{dataset_id}/data, then use
       GET /{dataset_id}/data/{filter_id}."
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = [
@@ -401,7 +402,10 @@ publicApiV2Router.get(
     #swagger.tags = ['Data']
     #swagger.summary = "Get a filtered data table for a dataset"
     #swagger.description = "Returns current data for a published dataset, filtered and displayed according to the
-      chosen options for a specific filter ID."
+      chosen options for a specific filter ID. The required <code>format</code> parameter selects the response shape:
+      <code>csv</code> and <code>xlsx</code> stream the full filtered dataset, while <code>json</code>,
+      <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100,
+      max 10,000)."
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = [
       '#/components/parameters/language',

--- a/src/routes/consumer/v2/openapi-cy.json
+++ b/src/routes/consumer/v2/openapi-cy.json
@@ -549,8 +549,8 @@
       "output_format": {
         "name": "format",
         "in": "query",
-        "description": "Output format for the response. Download formats (csv, xlsx, json) return the full dataset as a file attachment. Frontend and html return paginated or streamed responses.",
-        "required": false,
+        "description": "Output format for the response. <code>csv</code> and <code>xlsx</code> return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).",
+        "required": true,
         "schema": {
           "type": "string",
           "enum": [
@@ -559,8 +559,7 @@
             "xlsx",
             "frontend",
             "html"
-          ],
-          "default": "json"
+          ]
         }
       },
       "sort_by": {

--- a/src/routes/consumer/v2/openapi-en.json
+++ b/src/routes/consumer/v2/openapi-en.json
@@ -272,7 +272,7 @@
           "Data"
         ],
         "summary": "Get paginated data for a dataset",
-        "description": "Returns rows for the latest published revision as a  JSON array of objects. Each object has column names as keys. The  response includes a Content-Disposition header for download. To apply  filters, first create a filter via POST /{dataset_id}/data, then use  GET /{dataset_id}/data/{filter_id}.",
+        "description": "Returns rows for the latest published revision in the format  specified by the required <code>format</code> parameter. <code>csv</code> and <code>xlsx</code>  return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code>  and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).  To apply filters, first create a filter via POST /{dataset_id}/data, then use  GET /{dataset_id}/data/{filter_id}.",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"
@@ -354,7 +354,7 @@
           "Data"
         ],
         "summary": "Get a filtered data table for a dataset",
-        "description": "Returns current data for a published dataset, filtered and displayed according to the  chosen options for a specific filter ID.",
+        "description": "Returns current data for a published dataset, filtered and displayed according to the  chosen options for a specific filter ID. The required <code>format</code> parameter selects the response shape:  <code>csv</code> and <code>xlsx</code> stream the full filtered dataset, while <code>json</code>,  <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100,  max 10,000).",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"
@@ -549,8 +549,8 @@
       "output_format": {
         "name": "format",
         "in": "query",
-        "description": "Output format for the response. Download formats (csv, xlsx, json) return the full dataset as a file attachment. Frontend and html return paginated or streamed responses.",
-        "required": false,
+        "description": "Output format for the response. <code>csv</code> and <code>xlsx</code> return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).",
+        "required": true,
         "schema": {
           "type": "string",
           "enum": [
@@ -559,8 +559,7 @@
             "xlsx",
             "frontend",
             "html"
-          ],
-          "default": "json"
+          ]
         }
       },
       "sort_by": {

--- a/src/routes/consumer/v2/schema.ts
+++ b/src/routes/consumer/v2/schema.ts
@@ -78,9 +78,9 @@ export const schemaV2 = {
         name: 'format',
         in: 'query',
         description:
-          'Output format for the response. Download formats (csv, xlsx, json) return the full dataset as a file attachment. Frontend and html return paginated or streamed responses.',
-        required: false,
-        schema: { type: 'string', enum: Object.values(OutputFormats), default: 'json' }
+          'Output format for the response. <code>csv</code> and <code>xlsx</code> return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).',
+        required: true,
+        schema: { type: 'string', enum: Object.values(OutputFormats) }
       },
       sort_by: {
         name: 'sort_by',

--- a/src/routes/consumer/v2/schema.ts
+++ b/src/routes/consumer/v2/schema.ts
@@ -3,7 +3,7 @@
 import { DownloadFormat } from '../../../enums/download-format';
 import { DataValueType } from '../../../enums/data-value-type';
 import { OutputFormats } from '../../../enums/output-formats';
-import { DEFAULT_PAGE_SIZE } from '../../../utils/page-defaults';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../../utils/page-defaults';
 
 export const schemaV2 = {
   info: {
@@ -78,7 +78,10 @@ export const schemaV2 = {
         name: 'format',
         in: 'query',
         description:
-          'Output format for the response. <code>csv</code> and <code>xlsx</code> return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).',
+          `Output format for the response. <code>csv</code> and <code>xlsx</code> return the full dataset as a ` +
+          `streamed file attachment. <code>json</code>, <code>frontend</code> and <code>html</code> return ` +
+          `paginated responses (default <code>page_size</code> ${DEFAULT_PAGE_SIZE}, ` +
+          `max ${MAX_PAGE_SIZE.toLocaleString('en-GB')}).`,
         required: true,
         schema: { type: 'string', enum: Object.values(OutputFormats) }
       },

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -417,19 +417,18 @@ export async function buildDataQuery(queryStore: QueryStore, pageOptions: PageOp
     query = pgformat('%s ORDER BY %s', query, sortBy.join(', '));
   }
 
-  // if no page size is provided we return all rows (which may be zero for the current query)
-  const limit = pageSize || queryStore.totalLines;
-  const offset = (pageNumber - 1) * limit;
+  // if no page size is provided we return all rows (bulk CSV/Excel export path)
+  if (pageSize !== undefined) {
+    const offset = (pageNumber - 1) * pageSize;
 
-  // prevent div by zero
-  const totalPages = limit <= 0 ? 0 : Math.ceil(queryStore.totalLines / limit);
+    // prevent div by zero
+    const totalPages = pageSize <= 0 ? 0 : Math.ceil(queryStore.totalLines / pageSize);
 
-  if (totalPages > 0 && pageNumber > totalPages) {
-    throw new BadRequestException('errors.page_number_too_high');
-  }
+    if (totalPages > 0 && pageNumber > totalPages) {
+      throw new BadRequestException('errors.page_number_too_high');
+    }
 
-  if (pageNumber) {
-    query = pgformat(`%s LIMIT %L OFFSET %L;`, query, limit, offset);
+    query = pgformat(`%s LIMIT %L OFFSET %L;`, query, pageSize, offset);
   }
 
   logger.debug(`Query = ${query}`);

--- a/src/utils/parse-page-options.ts
+++ b/src/utils/parse-page-options.ts
@@ -14,7 +14,11 @@ const defaultPageSize = (format: OutputFormats): number | undefined => {
   return isDownloadFormat(format) ? undefined : DEFAULT_PAGE_SIZE;
 };
 
-export async function parsePageOptions(req: Request): Promise<PageOptions> {
+export interface ParsePageOptionsOpts {
+  requireFormat?: boolean;
+}
+
+export async function parsePageOptions(req: Request, opts: ParsePageOptionsOpts = {}): Promise<PageOptions> {
   logger.debug('Parsing page options from request...');
   const validations = [format2Validator(), pageNumberValidator(), pageSizeValidator()];
 
@@ -27,7 +31,13 @@ export async function parsePageOptions(req: Request): Promise<PageOptions> {
   }
 
   const params = matchedData(req);
-  const format = (params.format as OutputFormats) ?? OutputFormats.Json;
+  const formatParam = params.format as OutputFormats | undefined;
+
+  if (opts.requireFormat && !formatParam) {
+    throw new BadRequestException('errors.output_format_required');
+  }
+
+  const format = formatParam ?? OutputFormats.Json;
   const pageNumber = params.page_number ?? 1;
   const pageSize = params.page_size ?? defaultPageSize(format);
   const locale = req.language as Locale;

--- a/src/validators/preview-validator.ts
+++ b/src/validators/preview-validator.ts
@@ -52,15 +52,15 @@ export function validateParams(page_number: number, max_page_number: number, pag
       user_message: [
         {
           lang: Locale.English,
-          message: t('errors.page_number_to_high', { lng: Locale.English, page_number: max_page_number })
+          message: t('errors.page_number_too_high', { lng: Locale.English, page_number: max_page_number })
         },
         {
           lang: Locale.Welsh,
-          message: t('errors.page_number_to_high', { lng: Locale.Welsh, page_number: max_page_number })
+          message: t('errors.page_number_too_high', { lng: Locale.Welsh, page_number: max_page_number })
         }
       ],
       message: {
-        key: 'errors.page_number_to_high',
+        key: 'errors.page_number_too_high',
         params: { page_number: max_page_number }
       }
     });
@@ -69,10 +69,10 @@ export function validateParams(page_number: number, max_page_number: number, pag
     errors.push({
       field: 'page_number',
       user_message: [
-        { lang: Locale.English, message: t('errors.page_number_to_low', { lng: Locale.English }) },
-        { lang: Locale.Welsh, message: t('errors.page_number_to_low', { lng: Locale.Welsh }) }
+        { lang: Locale.English, message: t('errors.page_number_too_low', { lng: Locale.English }) },
+        { lang: Locale.Welsh, message: t('errors.page_number_too_low', { lng: Locale.Welsh }) }
       ],
-      message: { key: 'errors.page_number_to_low', params: {} }
+      message: { key: 'errors.page_number_too_low', params: {} }
     });
   }
   return errors;

--- a/test/integration/routes/consumer-v2-download.test.ts
+++ b/test/integration/routes/consumer-v2-download.test.ts
@@ -22,7 +22,7 @@ import { ensureWorkerDataSources, resetDatabase } from '../../helpers/reset-data
 import { getTestUser, getTestUserGroup } from '../../helpers/get-test-user';
 import { cubeDataSource } from '../../../src/db/cube-source';
 import { createAllCubeFiles } from '../../../src/services/cube-builder';
-import { MAX_PAGE_SIZE } from '../../../src/utils/page-defaults';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../../src/utils/page-defaults';
 import BlobStorage from '../../../src/services/blob-storage';
 
 jest.mock('../../../src/services/blob-storage');
@@ -158,7 +158,7 @@ describe('Consumer V2 download format page_size tests', () => {
       expect(rows.length).toBe(TOTAL_ROWS);
     });
 
-    it('JSON download returns all rows', async () => {
+    it('JSON returns DEFAULT_PAGE_SIZE rows when page_size omitted', async () => {
       const res = await request(app).get(`/v2/${datasetId}/data`).query({ format: 'json' });
 
       expect(res.status).toBe(200);
@@ -167,7 +167,7 @@ describe('Consumer V2 download format page_size tests', () => {
 
       const data = JSON.parse(res.text);
       expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBe(TOTAL_ROWS);
+      expect(data.length).toBe(DEFAULT_PAGE_SIZE);
     });
 
     it('Excel download succeeds with correct content type', async () => {
@@ -197,13 +197,18 @@ describe('Consumer V2 download format page_size tests', () => {
       expect(rows.length).toBe(TOTAL_ROWS);
     });
 
-    it('accepts page_size above MAX_PAGE_SIZE for json', async () => {
+    it('rejects page_size above MAX_PAGE_SIZE for json', async () => {
       const res = await request(app).get(`/v2/${datasetId}/data`).query({ format: 'json', page_size: 50_000 });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(400);
+    });
 
+    it('returns up to MAX_PAGE_SIZE rows when json page_size = MAX_PAGE_SIZE', async () => {
+      const res = await request(app).get(`/v2/${datasetId}/data`).query({ format: 'json', page_size: MAX_PAGE_SIZE });
+
+      expect(res.status).toBe(200);
       const data = JSON.parse(res.text);
-      expect(data.length).toBe(TOTAL_ROWS);
+      expect(data.length).toBe(MAX_PAGE_SIZE);
     });
   });
 

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -142,14 +142,32 @@ describe('Consumer V2 — data + pivot endpoints', () => {
       expect(rows.length).toBe(ROW_COUNT);
     });
 
-    it('JSON download returns all rows with attachment header', async () => {
+    it('JSON download returns rows up to DEFAULT_PAGE_SIZE with attachment header', async () => {
       const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'json' });
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toMatch(/application\/json/);
       expect(res.headers['content-disposition']).toMatch(/attachment/);
       const data = JSON.parse(res.text);
       expect(Array.isArray(data)).toBe(true);
+      // ROW_COUNT (12) is below DEFAULT_PAGE_SIZE (100) so the full set is returned.
       expect(data.length).toBe(ROW_COUNT);
+    });
+
+    it('returns 400 when output_format is missing', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when JSON page_size exceeds MAX_PAGE_SIZE', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'json', page_size: 10_001 });
+      expect(res.status).toBe(400);
+    });
+
+    it('JSON honours page_size when supplied', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'json', page_size: 5 });
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.text);
+      expect(data.length).toBe(5);
     });
 
     it('XLSX download returns a spreadsheetml zip', async () => {
@@ -218,12 +236,14 @@ describe('Consumer V2 — data + pivot endpoints', () => {
     });
 
     it('returns 404 for a non-existent filter_id', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/data/88888888-8888-4888-8888-888888888888`);
+      const res = await request(app)
+        .get(`/v2/${DATASET_ID}/data/88888888-8888-4888-8888-888888888888`)
+        .query({ format: 'frontend' });
       expect(res.status).toBe(404);
     });
 
     it('returns 404 for a malformed filter_id', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/data/not-a-uuid`);
+      const res = await request(app).get(`/v2/${DATASET_ID}/data/not-a-uuid`).query({ format: 'frontend' });
       expect(res.status).toBe(404);
     });
   });
@@ -235,12 +255,14 @@ describe('Consumer V2 — data + pivot endpoints', () => {
     });
 
     it('returns 400 (errors.not_a_pivot_filter) when filter_id was not created with pivot', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/${dataFilterId}`);
+      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/${dataFilterId}`).query({ format: 'json' });
       expect(res.status).toBe(400);
     });
 
     it('returns 404 for a non-existent filter_id', async () => {
-      const res = await request(app).get(`/v2/${DATASET_ID}/pivot/88888888-8888-4888-8888-888888888888`);
+      const res = await request(app)
+        .get(`/v2/${DATASET_ID}/pivot/88888888-8888-4888-8888-888888888888`)
+        .query({ format: 'json' });
       expect(res.status).toBe(404);
     });
   });

--- a/test/integration/routes/publisher-journey.test.ts
+++ b/test/integration/routes/publisher-journey.test.ts
@@ -136,15 +136,15 @@ describe('API Endpoints', () => {
             user_message: [
               {
                 lang: Locale.English,
-                message: t('errors.page_number_to_high', { lng: Locale.English, page_number: 15 })
+                message: t('errors.page_number_too_high', { lng: Locale.English, page_number: 15 })
               },
               {
                 lang: Locale.Welsh,
-                message: t('errors.page_number_to_high', { lng: Locale.Welsh, page_number: 15 })
+                message: t('errors.page_number_too_high', { lng: Locale.Welsh, page_number: 15 })
               }
             ],
             message: {
-              key: 'errors.page_number_to_high',
+              key: 'errors.page_number_too_high',
               params: { page_number: 15 }
             }
           }

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -901,13 +901,13 @@ describe('consumer-view-v2 service', () => {
       await expect(buildDataQuery(queryStore, pageOptions)).rejects.toThrow('No query found');
     });
 
-    it('should return all rows when no pageSize provided', async () => {
+    it('should omit LIMIT/OFFSET when no pageSize provided (bulk-export path)', async () => {
       const queryStore = createMockQueryStore({
         query: { 'en-GB': 'SELECT * FROM test_table' },
         totalLines: 100
       });
       const pageOptions: PageOptions = {
-        format: OutputFormats.Frontend,
+        format: OutputFormats.Csv,
         sort: [],
         locale: Locale.EnglishGb,
         pageNumber: 1
@@ -916,8 +916,8 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('LIMIT');
-      expect(result).toContain('100'); // Should use totalLines as limit
+      expect(result).not.toContain('LIMIT');
+      expect(result).not.toContain('OFFSET');
     });
 
     it('should handle zero total lines', async () => {

--- a/test/unit/utils/parse-page-options.test.ts
+++ b/test/unit/utils/parse-page-options.test.ts
@@ -43,7 +43,7 @@ describe('parsePageOptions', () => {
     mockRequest = {
       query: {},
       language: Locale.English
-    } as Partial<Request>;
+    } as MockRequest;
 
     mockValidationResult = {
       isEmpty: jest.fn().mockReturnValue(true),
@@ -66,13 +66,13 @@ describe('parsePageOptions', () => {
   });
 
   describe('successful parsing', () => {
-    it('should return default values when no query parameters are provided (json is a download format)', async () => {
+    it('should return default values when no query parameters are provided (json falls back to DEFAULT_PAGE_SIZE)', async () => {
       const result = await parsePageOptions(mockRequest as Request);
 
       expect(result).toEqual({
         format: OutputFormats.Json,
         pageNumber: 1,
-        pageSize: undefined,
+        pageSize: DEFAULT_PAGE_SIZE,
         sort: [],
         locale: Locale.English
       });
@@ -103,7 +103,7 @@ describe('parsePageOptions', () => {
       });
     });
 
-    it('should parse format as json when specified with undefined pageSize (download format)', async () => {
+    it('should parse format as json with DEFAULT_PAGE_SIZE when page_size omitted', async () => {
       mockRequest.query = {
         format: 'json'
       };
@@ -115,7 +115,7 @@ describe('parsePageOptions', () => {
       const result = await parsePageOptions(mockRequest as Request);
 
       expect(result.format).toBe(OutputFormats.Json);
-      expect(result.pageSize).toBeUndefined();
+      expect(result.pageSize).toBe(DEFAULT_PAGE_SIZE);
     });
 
     it('should parse format as csv when specified with undefined pageSize', async () => {
@@ -433,14 +433,16 @@ describe('parsePageOptions', () => {
       expect(result.pageSize).toBe(50_000);
     });
 
-    it('should accept page_size above MAX_PAGE_SIZE for json format', async () => {
+    it('should reject page_size above MAX_PAGE_SIZE for json format', async () => {
       (matchedData as jest.Mock).mockReturnValue({
         format: OutputFormats.Json,
-        page_size: 50_000
+        page_size: MAX_PAGE_SIZE + 1
       });
 
-      const result = await parsePageOptions(mockRequest as Request);
-      expect(result.pageSize).toBe(50_000);
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow(BadRequestException);
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow(
+        `page_size must not exceed ${MAX_PAGE_SIZE}`
+      );
     });
 
     it('should accept page_size above MAX_PAGE_SIZE for xlsx format', async () => {
@@ -461,6 +463,35 @@ describe('parsePageOptions', () => {
 
       const result = await parsePageOptions(mockRequest as Request);
       expect(result.pageSize).toBe(MAX_PAGE_SIZE);
+    });
+  });
+
+  describe('requireFormat option', () => {
+    it('should throw when format is missing and requireFormat is true', async () => {
+      (matchedData as jest.Mock).mockReturnValue({});
+
+      await expect(parsePageOptions(mockRequest as Request, { requireFormat: true })).rejects.toThrow(
+        BadRequestException
+      );
+      await expect(parsePageOptions(mockRequest as Request, { requireFormat: true })).rejects.toThrow(
+        'errors.output_format_required'
+      );
+    });
+
+    it('should accept a valid format when requireFormat is true', async () => {
+      (matchedData as jest.Mock).mockReturnValue({ format: OutputFormats.Csv });
+
+      const result = await parsePageOptions(mockRequest as Request, { requireFormat: true });
+
+      expect(result.format).toBe(OutputFormats.Csv);
+    });
+
+    it('should default to json when format is missing and requireFormat is false', async () => {
+      (matchedData as jest.Mock).mockReturnValue({});
+
+      const result = await parsePageOptions(mockRequest as Request);
+
+      expect(result.format).toBe(OutputFormats.Json);
     });
   });
 });


### PR DESCRIPTION
## Summary

The v2 `/data` endpoint could return an entire dataset when called with no `page_size`. 

### What changed

- `output_format` is now **required** on the v2 `/data` and pivot data endpoints. Missing format → `400 errors.output_format_required`.
- JSON is removed from `DOWNLOAD_FORMATS`. It now behaves like `frontend`/`html`: defaults to `page_size=100`, capped at `MAX_PAGE_SIZE=10_000`.
- CSV / xlsx still stream the full dataset (legitimate bulk-export contract). `page_size` is still honoured for those too if a consumer wants to chunk.
- `buildDataQuery` only appends `LIMIT/OFFSET` when `pageSize` is defined. The previous `if (pageNumber)` guard was always truthy and misleading.
- Swagger schema + endpoint descriptions updated; OpenAPI files regenerated.
- New translation key `errors.output_format_required` in en/cy locales.

### Behaviour matrix for existing `query_store` rows

No migration / no schema change — `output_format` and `page_size` were never stored. The base SQL stored per query_store is still appended with `LIMIT/OFFSET` at request time. Only the per-request behaviour changes:

| Request | Before | After |
|---|---|---|
| `/data` no params | 200, full dataset | **400** missing `output_format` |
| `…?format=json` no `page_size` | 200, full dataset | 200, first 100 rows |
| `…?format=json&page_size=50000` | 200, full dataset | **400** exceeds cap |
| `…?format=csv` / `xlsx` | 200, streamed | 200, streamed (unchanged) |
| `…?format=frontend` | 200, paginated | 200, paginated (unchanged) |

### Refactoring flagged (out of scope)

`parsePivotPageOptions` in `src/controllers/consumer-v2.ts` is a near-copy of `parsePageOptions` and now also enforces `requireFormat`. Worth folding into the shared utility in a follow-up.

## Test plan

- [x] `npm run check` — 1308 tests pass, build + swagger regenerate clean
- [x] Unit: new `requireFormat` cases in `parse-page-options.test.ts`; JSON cap + undefined-pageSize cases in `consumer-view-v2.test.ts`
- [x] Integration: new 400 cases in `data-and-pivot.test.ts`; JSON pagination + cap in `consumer-v2-download.test.ts`
- [ ] Smoke against a real dataset: missing format → 400, `format=json` → 100 rows, `format=json&page_size=10001` → 400, `format=csv` streams full dataset, `format=frontend` paginates as before
- [ ] Confirm frontend still loads dataset pages end-to-end (it sets `output_format=frontend` so should be untouched)
