### PR TITLE
SW-1229: fix: sort preview & consumer filter values correctly

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -39,6 +39,7 @@ import {
   searchModeValidator
 } from '../validators';
 import {
+  dateColumnsFromDimensions,
   getFilterTable,
   getFilterTableQuery,
   resolveDimensionToFactTableColumn,
@@ -427,7 +428,8 @@ export const getPublishedDatasetFilters = async (req: Request, res: Response, ne
   try {
     const locale = req.language as Locale;
     const query = getFilterTableQuery(publishedRevision.id, filterTableVersion, locale);
-    await sendFilters(query, res);
+    const datasetWithDimensions = await PublishedDatasetRepository.getById(dataset.id, { dimensions: true });
+    await sendFilters(query, res, dateColumnsFromDimensions(datasetWithDimensions.dimensions ?? []));
   } catch (err) {
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);

--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -100,7 +100,10 @@ export const getPublishedDatasetView = async (req: Request, res: Response): Prom
 };
 
 export const getPublishedDatasetFilters = async (req: Request, res: Response): Promise<void> => {
-  const dataset = await PublishedDatasetRepository.getById(res.locals.datasetId, { publishedRevision: true });
+  const dataset = await PublishedDatasetRepository.getById(res.locals.datasetId, {
+    publishedRevision: true,
+    dimensions: true
+  });
   const publishedRevision = dataset.publishedRevision;
   const lang = req.language.toLowerCase();
   logger.debug(`Fetching filters for published dataset with language: ${lang}`);
@@ -109,7 +112,7 @@ export const getPublishedDatasetFilters = async (req: Request, res: Response): P
     throw new NotFoundException('errors.no_revision');
   }
 
-  const filters = await getFilters(publishedRevision.id, lang || 'en-gb');
+  const filters = await getFilters(publishedRevision.id, lang || 'en-gb', dataset.dimensions ?? []);
   res.json(filters);
 };
 

--- a/src/controllers/revision.ts
+++ b/src/controllers/revision.ts
@@ -158,7 +158,8 @@ export const getRevisionPreviewFilters = async (req: Request, res: Response): Pr
     throw new NotFoundException('errors.no_data_table');
   }
 
-  const filters = await getFilters(filtersRevisionId, lang);
+  const datasetWithDimensions = await DatasetRepository.getById(dataset.id, { dimensions: true });
+  const filters = await getFilters(filtersRevisionId, lang, datasetWithDimensions.dimensions ?? []);
   res.json(filters);
 };
 

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -13,7 +13,7 @@ import { FilterTable } from '../interfaces/filter-table';
 import { dbManager } from '../db/database-manager';
 import { QueryStore } from '../entities/query-store';
 import { BadRequestException } from '../exceptions/bad-request.exception';
-import { flattenHierarchy, transformHierarchy } from '../utils/consumer';
+import { flattenHierarchy, sortFilterRows, transformHierarchy } from '../utils/consumer';
 import { DatasetRepository } from '../repositories/dataset';
 import { PageOptions } from '../interfaces/page-options';
 import { logger } from '../utils/logger';
@@ -234,7 +234,7 @@ export async function sendHtml(query: string, queryStore: QueryStore, res: Respo
   }
 }
 
-export async function sendFilters(query: string, res: Response): Promise<void> {
+export async function sendFilters(query: string, res: Response, dateColumns: Set<string> = new Set()): Promise<void> {
   logger.debug('Sending filters...');
   const [cubeDBConn] = (await dbManager.getCubeDataSource().driver.obtainMasterConnection()) as [PoolClient];
 
@@ -255,10 +255,11 @@ export async function sendFilters(query: string, res: Response): Promise<void> {
 
     const filterData: FilterTable[] = [];
     for (const col of columnData.keys()) {
-      const data = columnData.get(col);
-      if (!data) {
+      const unsorted = columnData.get(col);
+      if (!unsorted) {
         continue;
       }
+      const data = sortFilterRows(unsorted, dateColumns.has(col));
       const hierarchy = transformHierarchy(data[0].fact_table_column, data[0].dimension_name, data);
       const flattenedHierarchy = flattenHierarchy(hierarchy.values);
       // If there's a problem with the hierarchy, bin it off

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -45,8 +45,9 @@ export const getFilters = async (
 ): Promise<FilterTable[]> => {
   const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
   try {
-    // Ordering is applied per column below — sort_order is TEXT so it cannot be ordered
-    // correctly (numerically, and descending for dates) in SQL.
+    // Row ordering is applied per column below via sortFilterRows(), not in SQL: sort_order is
+    // stored as TEXT and needs numeric parsing plus a fallback for missing/non-numeric values,
+    // and date dimensions need a descending direction.
     const filterTableQuery = pgformat('SELECT * FROM %I.filter_table WHERE language = %L;', revisionId, language);
     const filterTable: FilterRow[] = await cubeDB.query(filterTableQuery);
     const columnData = new Map<string, FilterRow[]>();

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -19,8 +19,9 @@ import { getColumnHeaders } from '../utils/column-headers';
 import { t } from 'i18next';
 import cubeConfig from '../config/cube-view.json';
 import { FactTableToDimensionName } from '../interfaces/fact-table-column-to-dimension-name';
-import { coreViewChooser, transformHierarchy } from '../utils/consumer';
+import { coreViewChooser, dateColumnsFromDimensions, sortFilterRows, transformHierarchy } from '../utils/consumer';
 import { FilterRow } from '../interfaces/filter-row';
+import { Dimension } from '../entities/dataset/dimension';
 
 const EXCEL_ROW_LIMIT = 1048500; // Excel Limit is 1048576 but removed 76 rows
 const CURSOR_ROW_LIMIT = 500;
@@ -37,14 +38,16 @@ interface FilterTable {
   values: FilterValues[];
 }
 
-export const getFilters = async (revisionId: string, language: string): Promise<FilterTable[]> => {
+export const getFilters = async (
+  revisionId: string,
+  language: string,
+  dimensions: Dimension[] = []
+): Promise<FilterTable[]> => {
   const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
   try {
-    const filterTableQuery = pgformat(
-      'SELECT * FROM %I.filter_table WHERE language = %L ORDER BY sort_order, description, reference;',
-      revisionId,
-      language
-    );
+    // Ordering is applied per column below — sort_order is TEXT so it cannot be ordered
+    // correctly (numerically, and descending for dates) in SQL.
+    const filterTableQuery = pgformat('SELECT * FROM %I.filter_table WHERE language = %L;', revisionId, language);
     const filterTable: FilterRow[] = await cubeDB.query(filterTableQuery);
     const columnData = new Map<string, FilterRow[]>();
 
@@ -58,6 +61,7 @@ export const getFilters = async (revisionId: string, language: string): Promise<
       columnData.set(row.fact_table_column, data);
     }
 
+    const dateColumns = dateColumnsFromDimensions(dimensions);
     const filterData: FilterTable[] = [];
 
     for (const col of columnData.keys()) {
@@ -65,7 +69,8 @@ export const getFilters = async (revisionId: string, language: string): Promise<
       if (!data) {
         continue;
       }
-      const hierarchy = transformHierarchy(data[0].fact_table_column, data[0].dimension_name, data);
+      const sorted = sortFilterRows(data, dateColumns.has(col));
+      const hierarchy = transformHierarchy(sorted[0].fact_table_column, sorted[0].dimension_name, sorted);
       filterData.push(hierarchy);
     }
 

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -277,8 +277,10 @@ export function getFilterTableQuery(revisionId: string, version: number, locale?
     columns =
       'reference, language, fact_table_column, dimension_name, description, sort_order, hierarchy, reference_count';
   }
-  // Ordering is applied per column in sortFilterRows() — sort_order is TEXT so it cannot be
-  // ordered correctly (numerically, and descending for dates) in SQL.
+  // Row ordering is applied per column in sortFilterRows(), not in SQL: sort_order is stored as
+  // TEXT and needs numeric parsing plus a fallback for missing/non-numeric values, and date
+  // dimensions need a descending direction — all kept in one shared comparator across the
+  // preview, v1 and v2 read paths.
   if (!locale) {
     return pgformat('SELECT %s FROM %I.%I;', columns, revisionId, FILTER_TABLE_NAME);
   }

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -11,6 +11,8 @@ import { t } from 'i18next';
 import { DataOptionsDTO } from '../dtos/data-options-dto';
 import { CubeMetaDataKeys } from '../enums/cube-metadata-keys';
 import { DataSource } from 'typeorm';
+import { Dimension } from '../entities/dataset/dimension';
+import { DimensionType } from '../enums/dimension-type';
 
 export function flattenHierarchy(nodes: FilterValues[]): FilterValues[] {
   return nodes.flatMap((node) => [node, ...(node.children ? flattenHierarchy(node.children) : [])]);
@@ -66,6 +68,59 @@ export function transformHierarchy(factTableColumn: string, columnName: string, 
     columnName: columnName,
     values: roots
   };
+}
+
+/**
+ * Parses a filter_table.sort_order value (stored as TEXT) into a number. Returns null when the
+ * value is absent or non-numeric, so callers can fall back to alphabetical ordering.
+ */
+function parseSortOrder(value?: string | null): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Returns the set of fact-table columns backed by a date dimension. Date filter values are
+ * ordered descending (newest first), so the read path needs to know which columns are dates.
+ */
+export function dateColumnsFromDimensions(dimensions: Dimension[]): Set<string> {
+  return new Set(
+    dimensions
+      .filter((dim) => dim.type === DimensionType.Date || dim.type === DimensionType.DatePeriod)
+      .map((dim) => dim.factTableColumn)
+  );
+}
+
+/**
+ * Orders the filter values for a single column:
+ *  - values with a sort order from the lookup table are ordered by it numerically;
+ *  - values with no sort order fall back to ascending alphabetical order of the description;
+ *  - date dimensions are reversed so the most recent period comes first.
+ *
+ * filter_table.sort_order is TEXT, so it must be compared numerically here rather than in SQL
+ * (a lexical sort would place "10" before "2"). Sorting the flat row list before
+ * transformHierarchy() is enough — that function preserves input order at every hierarchy level.
+ */
+export function sortFilterRows(rows: FilterRow[], isDateDimension: boolean): FilterRow[] {
+  const sorted = [...rows].sort((rowA, rowB) => {
+    const sortA = parseSortOrder(rowA.sort_order);
+    const sortB = parseSortOrder(rowB.sort_order);
+
+    if (sortA !== null && sortB !== null) {
+      if (sortA !== sortB) return sortA - sortB;
+    } else if (sortA !== null) {
+      return -1; // a value with a sort order ranks ahead of one without
+    } else if (sortB !== null) {
+      return 1;
+    }
+
+    const byDescription = (rowA.description ?? '').localeCompare(rowB.description ?? '');
+    if (byDescription !== 0) return byDescription;
+    return (rowA.reference ?? '').localeCompare(rowB.reference ?? '');
+  });
+
+  return isDateDimension ? sorted.reverse() : sorted;
 }
 
 export function resolveDimensionToFactTableColumn(
@@ -213,22 +268,21 @@ export function getFilterTableQuery(revisionId: string, version: number, locale?
   // reference_count defaults to 1 otherwise we'll disable all filters on the frontend
   let columns =
     'reference, language, fact_table_column, dimension_name, description, NULL as sort_order, hierarchy, CAST(1 as BIGINT) as reference_count';
-  let sortBy = ' description, reference';
   if (version > 1) {
     columns =
       'reference, language, fact_table_column, dimension_name, description, sort_order, hierarchy, reference_count';
-    sortBy = ' sort_order, description, reference';
   }
+  // Ordering is applied per column in sortFilterRows() — sort_order is TEXT so it cannot be
+  // ordered correctly (numerically, and descending for dates) in SQL.
   if (!locale) {
     return pgformat('SELECT %s FROM %I.%I;', columns, revisionId, FILTER_TABLE_NAME);
   }
   return pgformat(
-    'SELECT %s FROM %I.%I WHERE language LIKE %L ORDER BY %s;',
+    'SELECT %s FROM %I.%I WHERE language LIKE %L;',
     columns,
     revisionId,
     FILTER_TABLE_NAME,
-    `${locale.toLowerCase().split('-')[0]}%`,
-    sortBy
+    `${locale.toLowerCase().split('-')[0]}%`
   );
 }
 

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -83,6 +83,11 @@ function parseSortOrder(value?: string | null): number | null {
 /**
  * Returns the set of fact-table columns backed by a date dimension. Date filter values are
  * ordered descending (newest first), so the read path needs to know which columns are dates.
+ *
+ * Only Date and DatePeriod are treated as descending — this must stay in sync with the
+ * descending branch of setupLookupTableDimension() in cube-builder.ts (the `sort_order DESC`
+ * insert). DimensionType also defines TimePeriod and Time, but the cube builder has no
+ * processing path for them yet, so they are deliberately excluded here.
  */
 export function dateColumnsFromDimensions(dimensions: Dimension[]): Set<string> {
   return new Set(

--- a/test/integration/routes/consumer-v2/filter-sort-order.test.ts
+++ b/test/integration/routes/consumer-v2/filter-sort-order.test.ts
@@ -1,0 +1,208 @@
+import request from 'supertest';
+
+import app from '../../../../src/app';
+import { dbManager } from '../../../../src/db/database-manager';
+import { initPassport } from '../../../../src/middleware/passport-auth';
+import { User } from '../../../../src/entities/user/user';
+import { UserGroup } from '../../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../../src/enums/group-role';
+import { DimensionType } from '../../../../src/enums/dimension-type';
+import { FactTableColumnType } from '../../../../src/enums/fact-table-column-type';
+import { getFilters } from '../../../../src/services/consumer-view';
+import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
+import { seedPublishedDataset, LookupRow } from '../../../helpers/seed-published-dataset';
+import BlobStorage from '../../../../src/services/blob-storage';
+
+jest.mock('../../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
+BlobStorage.prototype.loadBuffer = jest.fn();
+
+const user: User = getTestUser('filter sort-order test user');
+let userGroup = getTestUserGroup('Filter Sort Order Test Group');
+
+const DATASET_ID = 'cccccccc-cccc-4ccc-8cc2-cccccccccccc';
+const REVISION_ID = 'cccccccc-cccc-4ccc-8cc2-aaaaaaaaaaaa';
+const DATA_TABLE_ID = 'cccccccc-cccc-4ccc-8cc2-bbbbbbbbbbbb';
+
+const REGION_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000001';
+const PERIOD_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000002';
+const CATEGORY_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000003';
+
+// 12 regions — enough that a lexical (text) sort of the sort_order column diverges from a
+// numeric one ("10" sorts before "2"). Descriptions deliberately descend alphabetically as
+// sort_order ascends, so sorting by description instead of sort_order is also distinguishable.
+const REGION_WORDS = [
+  'Zulu',
+  'Yankee',
+  'Xray',
+  'Whiskey',
+  'Victor',
+  'Uniform',
+  'Tango',
+  'Sierra',
+  'Romeo',
+  'Quebec',
+  'Papa',
+  'Oscar'
+];
+const REGION_REFS = REGION_WORDS.map((_, idx) => `REG${String(idx + 1).padStart(2, '0')}`);
+
+const regionLookupRows: LookupRow[] = REGION_WORDS.flatMap((word, idx) => {
+  const reference = REGION_REFS[idx];
+  const sortOrder = idx + 1; // 1..12
+  return [
+    { reference, language: 'en' as const, description: word, sortOrder },
+    { reference, language: 'cy' as const, description: word, sortOrder }
+  ];
+});
+
+// A date dimension. Filters for dates should come back newest-first (descending).
+const PERIOD_REFS = ['2020', '2021', '2022', '2023'];
+const periodLookupRows: LookupRow[] = PERIOD_REFS.flatMap((year, idx) => [
+  { reference: year, language: 'en' as const, description: year, sortOrder: idx + 1 },
+  { reference: year, language: 'cy' as const, description: year, sortOrder: idx + 1 }
+]);
+
+// A dimension with NO sort order — these should fall back to ascending alphabetical order
+// of the description. References are deliberately not in alphabetical order of description.
+const CATEGORY_REFS = ['CAT1', 'CAT2', 'CAT3'];
+const categoryDescriptions: Record<string, string> = { CAT1: 'Beta', CAT2: 'Alpha', CAT3: 'Gamma' };
+const categoryLookupRows: LookupRow[] = CATEGORY_REFS.flatMap((reference) => [
+  { reference, language: 'en' as const, description: categoryDescriptions[reference] },
+  { reference, language: 'cy' as const, description: categoryDescriptions[reference] }
+]);
+
+const ROW_COUNT = REGION_REFS.length * PERIOD_REFS.length; // 48 — one row per (region, period)
+
+const rowBuilder = (i: number): unknown[] => {
+  const region = REGION_REFS[Math.floor(i / PERIOD_REFS.length)];
+  const period = PERIOD_REFS[i % PERIOD_REFS.length];
+  const category = CATEGORY_REFS[i % CATEGORY_REFS.length];
+  return [region, period, category, 'count', Math.round((i + 1) * 10.5 * 100) / 100, null];
+};
+
+// Expected orderings per the product requirement:
+//  - with a sort order in the lookup: order by that sort order (numerically)
+//  - no sort order: ascending alphabetical by description
+//  - dates: descending (newest first)
+const EXPECTED_REGION_ORDER = REGION_REFS; // sort_order 1..12
+const EXPECTED_PERIOD_ORDER = [...PERIOD_REFS].reverse(); // dates descending
+const EXPECTED_CATEGORY_ORDER = ['CAT2', 'CAT1', 'CAT3']; // Alpha, Beta, Gamma
+
+interface FilterValue {
+  reference: string;
+  description: string;
+  children?: FilterValue[];
+}
+interface FilterTable {
+  factTableColumn: string;
+  columnName: string;
+  values: FilterValue[];
+}
+
+const referencesFor = (filters: FilterTable[], factTableColumn: string): string[] => {
+  const filter = filters.find((f) => f.factTableColumn === factTableColumn);
+  if (!filter) throw new Error(`No filter returned for column ${factTableColumn}`);
+  return filter.values.map((v) => v.reference);
+};
+
+describe('Preview & consumer filters — value sort order', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+
+    await seedPublishedDataset({
+      user,
+      datasetId: DATASET_ID,
+      revisionId: REVISION_ID,
+      dataTableId: DATA_TABLE_ID,
+      title: { en: 'Filter sort fixture', cy: 'Ffynhonnell trefn hidlo' },
+      factColumns: [
+        { name: 'RegionCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'PeriodCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'CategoryCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'MeasureCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Measure },
+        { name: 'Data', datatype: 'DOUBLE PRECISION', columnType: FactTableColumnType.DataValues },
+        { name: 'NoteCode', datatype: 'VARCHAR', columnType: FactTableColumnType.NoteCodes }
+      ],
+      rowBuilder,
+      rowCount: ROW_COUNT,
+      dimensions: [
+        {
+          factTableColumn: 'RegionCode',
+          lookupTableId: REGION_LOOKUP_ID,
+          name: { en: 'Region', cy: 'Rhanbarth' },
+          lookupRows: regionLookupRows
+        },
+        {
+          factTableColumn: 'PeriodCode',
+          type: DimensionType.DatePeriod,
+          lookupTableId: PERIOD_LOOKUP_ID,
+          name: { en: 'Period', cy: 'Cyfnod' },
+          lookupRows: periodLookupRows
+        },
+        {
+          factTableColumn: 'CategoryCode',
+          lookupTableId: CATEGORY_LOOKUP_ID,
+          name: { en: 'Category', cy: 'Categori' },
+          lookupRows: categoryLookupRows
+        }
+      ]
+    });
+  }, 120_000);
+
+  describe('consumer v2 — GET /v2/:dataset_id/filters', () => {
+    it('orders lookup values by the lookup sort order (numerically, not lexically)', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      expect(res.status).toBe(200);
+      expect(referencesFor(res.body, 'RegionCode')).toEqual(EXPECTED_REGION_ORDER);
+    });
+
+    it('orders date dimension values descending (newest first)', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      expect(res.status).toBe(200);
+      expect(referencesFor(res.body, 'PeriodCode')).toEqual(EXPECTED_PERIOD_ORDER);
+    });
+
+    it('orders values with no sort order ascending alphabetically by description', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      expect(res.status).toBe(200);
+      expect(referencesFor(res.body, 'CategoryCode')).toEqual(EXPECTED_CATEGORY_ORDER);
+    });
+  });
+
+  // getFilters() is the shared code path behind the publisher preview filters
+  // (GET /revision/by-id/:id/preview/filters) and the v1 consumer filters
+  // (GET /v1/:dataset_id/view/filters). The preview must match what the consumer renders.
+  describe('preview / v1 — getFilters()', () => {
+    it('orders lookup values by the lookup sort order (numerically, not lexically)', async () => {
+      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      expect(referencesFor(filters, 'RegionCode')).toEqual(EXPECTED_REGION_ORDER);
+    });
+
+    it('orders date dimension values descending (newest first)', async () => {
+      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      expect(referencesFor(filters, 'PeriodCode')).toEqual(EXPECTED_PERIOD_ORDER);
+    });
+
+    it('orders values with no sort order ascending alphabetically by description', async () => {
+      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      expect(referencesFor(filters, 'CategoryCode')).toEqual(EXPECTED_CATEGORY_ORDER);
+    });
+
+    it('preview filter order matches the consumer v2 filter order exactly', async () => {
+      const previewFilters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      const consumerRes = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      for (const column of ['RegionCode', 'PeriodCode', 'CategoryCode']) {
+        expect(referencesFor(previewFilters, column)).toEqual(referencesFor(consumerRes.body, column));
+      }
+    });
+  });
+});

--- a/test/integration/routes/consumer-v2/filter-sort-order.test.ts
+++ b/test/integration/routes/consumer-v2/filter-sort-order.test.ts
@@ -31,6 +31,7 @@ const DATA_TABLE_ID = 'cccccccc-cccc-4ccc-8cc2-bbbbbbbbbbbb';
 const REGION_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000001';
 const PERIOD_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000002';
 const CATEGORY_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000003';
+const AREA_LOOKUP_ID = 'cabcdef0-0000-4000-8000-000000000004';
 
 // 12 regions — enough that a lexical (text) sort of the sort_order column diverges from a
 // numeric one ("10" sorts before "2"). Descriptions deliberately descend alphabetically as
@@ -76,13 +77,46 @@ const categoryLookupRows: LookupRow[] = CATEGORY_REFS.flatMap((reference) => [
   { reference, language: 'cy' as const, description: categoryDescriptions[reference] }
 ]);
 
+// A hierarchical dimension: one root with 11 children. Children must nest under the root and
+// be ordered by sort_order numerically — 11 children means a lexical sort would mis-place 10
+// and 11. Child descriptions descend alphabetically as sort_order ascends.
+const AREA_ROOT_REF = 'A00';
+const AREA_CHILD_WORDS = [
+  'Kilo',
+  'Juliet',
+  'India',
+  'Hotel',
+  'Golf',
+  'Foxtrot',
+  'Echo',
+  'Delta',
+  'Charlie',
+  'Bravo',
+  'Alpha'
+];
+const AREA_CHILD_REFS = AREA_CHILD_WORDS.map((_, idx) => `A${String(idx + 1).padStart(2, '0')}`);
+
+const areaLookupRows: LookupRow[] = [
+  { reference: AREA_ROOT_REF, language: 'en', description: 'All areas', sortOrder: 1, hierarchy: null },
+  { reference: AREA_ROOT_REF, language: 'cy', description: 'Pob ardal', sortOrder: 1, hierarchy: null },
+  ...AREA_CHILD_WORDS.flatMap((word, idx) => {
+    const reference = AREA_CHILD_REFS[idx];
+    const sortOrder = idx + 1; // 1..11
+    return [
+      { reference, language: 'en' as const, description: word, sortOrder, hierarchy: AREA_ROOT_REF },
+      { reference, language: 'cy' as const, description: word, sortOrder, hierarchy: AREA_ROOT_REF }
+    ];
+  })
+];
+
 const ROW_COUNT = REGION_REFS.length * PERIOD_REFS.length; // 48 — one row per (region, period)
 
 const rowBuilder = (i: number): unknown[] => {
   const region = REGION_REFS[Math.floor(i / PERIOD_REFS.length)];
   const period = PERIOD_REFS[i % PERIOD_REFS.length];
   const category = CATEGORY_REFS[i % CATEGORY_REFS.length];
-  return [region, period, category, 'count', Math.round((i + 1) * 10.5 * 100) / 100, null];
+  const area = AREA_CHILD_REFS[i % AREA_CHILD_REFS.length];
+  return [region, period, category, area, 'count', Math.round((i + 1) * 10.5 * 100) / 100, null];
 };
 
 // Expected orderings per the product requirement:
@@ -92,6 +126,8 @@ const rowBuilder = (i: number): unknown[] => {
 const EXPECTED_REGION_ORDER = REGION_REFS; // sort_order 1..12
 const EXPECTED_PERIOD_ORDER = [...PERIOD_REFS].reverse(); // dates descending
 const EXPECTED_CATEGORY_ORDER = ['CAT2', 'CAT1', 'CAT3']; // Alpha, Beta, Gamma
+const EXPECTED_AREA_ROOTS = [AREA_ROOT_REF]; // only the root sits at the top level
+const EXPECTED_AREA_CHILDREN = AREA_CHILD_REFS; // children ordered by sort_order 1..11
 
 interface FilterValue {
   reference: string;
@@ -104,10 +140,19 @@ interface FilterTable {
   values: FilterValue[];
 }
 
-const referencesFor = (filters: FilterTable[], factTableColumn: string): string[] => {
+const filterFor = (filters: FilterTable[], factTableColumn: string): FilterTable => {
   const filter = filters.find((f) => f.factTableColumn === factTableColumn);
   if (!filter) throw new Error(`No filter returned for column ${factTableColumn}`);
-  return filter.values.map((v) => v.reference);
+  return filter;
+};
+
+const referencesFor = (filters: FilterTable[], factTableColumn: string): string[] =>
+  filterFor(filters, factTableColumn).values.map((v) => v.reference);
+
+const childReferencesFor = (filters: FilterTable[], factTableColumn: string, parentRef: string): string[] => {
+  const parent = filterFor(filters, factTableColumn).values.find((v) => v.reference === parentRef);
+  if (!parent) throw new Error(`No top-level value ${parentRef} for column ${factTableColumn}`);
+  return (parent.children ?? []).map((c) => c.reference);
 };
 
 describe('Preview & consumer filters — value sort order', () => {
@@ -134,6 +179,7 @@ describe('Preview & consumer filters — value sort order', () => {
         { name: 'RegionCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
         { name: 'PeriodCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
         { name: 'CategoryCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
+        { name: 'AreaCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Dimension },
         { name: 'MeasureCode', datatype: 'VARCHAR', columnType: FactTableColumnType.Measure },
         { name: 'Data', datatype: 'DOUBLE PRECISION', columnType: FactTableColumnType.DataValues },
         { name: 'NoteCode', datatype: 'VARCHAR', columnType: FactTableColumnType.NoteCodes }
@@ -159,6 +205,12 @@ describe('Preview & consumer filters — value sort order', () => {
           lookupTableId: CATEGORY_LOOKUP_ID,
           name: { en: 'Category', cy: 'Categori' },
           lookupRows: categoryLookupRows
+        },
+        {
+          factTableColumn: 'AreaCode',
+          lookupTableId: AREA_LOOKUP_ID,
+          name: { en: 'Area', cy: 'Ardal' },
+          lookupRows: areaLookupRows
         }
       ]
     });
@@ -185,6 +237,13 @@ describe('Preview & consumer filters — value sort order', () => {
       expect(res.status).toBe(200);
       expect(referencesFor(res.body, 'CategoryCode')).toEqual(EXPECTED_CATEGORY_ORDER);
     });
+
+    it('nests hierarchical values and orders children by sort order numerically', async () => {
+      const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+      expect(res.status).toBe(200);
+      expect(referencesFor(res.body, 'AreaCode')).toEqual(EXPECTED_AREA_ROOTS);
+      expect(childReferencesFor(res.body, 'AreaCode', AREA_ROOT_REF)).toEqual(EXPECTED_AREA_CHILDREN);
+    });
   });
 
   // getFilters() is the shared code path behind the publisher preview filters
@@ -206,12 +265,21 @@ describe('Preview & consumer filters — value sort order', () => {
       expect(referencesFor(filters, 'CategoryCode')).toEqual(EXPECTED_CATEGORY_ORDER);
     });
 
+    it('nests hierarchical values and orders children by sort order numerically', async () => {
+      const filters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
+      expect(referencesFor(filters, 'AreaCode')).toEqual(EXPECTED_AREA_ROOTS);
+      expect(childReferencesFor(filters, 'AreaCode', AREA_ROOT_REF)).toEqual(EXPECTED_AREA_CHILDREN);
+    });
+
     it('preview filter order matches the consumer v2 filter order exactly', async () => {
       const previewFilters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
       const consumerRes = await request(app).get(`/v2/${DATASET_ID}/filters`);
-      for (const column of ['RegionCode', 'PeriodCode', 'CategoryCode']) {
+      for (const column of ['RegionCode', 'PeriodCode', 'CategoryCode', 'AreaCode']) {
         expect(referencesFor(previewFilters, column)).toEqual(referencesFor(consumerRes.body, column));
       }
+      expect(childReferencesFor(previewFilters, 'AreaCode', AREA_ROOT_REF)).toEqual(
+        childReferencesFor(consumerRes.body, 'AreaCode', AREA_ROOT_REF)
+      );
     });
   });
 });

--- a/test/integration/routes/consumer-v2/filter-sort-order.test.ts
+++ b/test/integration/routes/consumer-v2/filter-sort-order.test.ts
@@ -10,6 +10,8 @@ import { GroupRole } from '../../../../src/enums/group-role';
 import { DimensionType } from '../../../../src/enums/dimension-type';
 import { FactTableColumnType } from '../../../../src/enums/fact-table-column-type';
 import { getFilters } from '../../../../src/services/consumer-view';
+import { DatasetRepository } from '../../../../src/repositories/dataset';
+import { Dimension } from '../../../../src/entities/dataset/dimension';
 import { ensureWorkerDataSources, resetDatabase } from '../../../helpers/reset-database';
 import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
 import { seedPublishedDataset, LookupRow } from '../../../helpers/seed-published-dataset';
@@ -109,6 +111,10 @@ const referencesFor = (filters: FilterTable[], factTableColumn: string): string[
 };
 
 describe('Preview & consumer filters — value sort order', () => {
+  // The dataset's dimensions, loaded after seeding. getFilters() needs them to know which
+  // columns are dates — exactly as the preview and v1 consumer controllers supply them.
+  let dimensions: Dimension[] = [];
+
   beforeAll(async () => {
     await ensureWorkerDataSources();
     await resetDatabase();
@@ -156,6 +162,9 @@ describe('Preview & consumer filters — value sort order', () => {
         }
       ]
     });
+
+    const dataset = await DatasetRepository.getById(DATASET_ID, { dimensions: true });
+    dimensions = dataset.dimensions ?? [];
   }, 120_000);
 
   describe('consumer v2 — GET /v2/:dataset_id/filters', () => {
@@ -183,22 +192,22 @@ describe('Preview & consumer filters — value sort order', () => {
   // (GET /v1/:dataset_id/view/filters). The preview must match what the consumer renders.
   describe('preview / v1 — getFilters()', () => {
     it('orders lookup values by the lookup sort order (numerically, not lexically)', async () => {
-      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      const filters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
       expect(referencesFor(filters, 'RegionCode')).toEqual(EXPECTED_REGION_ORDER);
     });
 
     it('orders date dimension values descending (newest first)', async () => {
-      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      const filters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
       expect(referencesFor(filters, 'PeriodCode')).toEqual(EXPECTED_PERIOD_ORDER);
     });
 
     it('orders values with no sort order ascending alphabetically by description', async () => {
-      const filters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      const filters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
       expect(referencesFor(filters, 'CategoryCode')).toEqual(EXPECTED_CATEGORY_ORDER);
     });
 
     it('preview filter order matches the consumer v2 filter order exactly', async () => {
-      const previewFilters = (await getFilters(REVISION_ID, 'en-gb')) as unknown as FilterTable[];
+      const previewFilters = (await getFilters(REVISION_ID, 'en-gb', dimensions)) as unknown as FilterTable[];
       const consumerRes = await request(app).get(`/v2/${DATASET_ID}/filters`);
       for (const column of ['RegionCode', 'PeriodCode', 'CategoryCode']) {
         expect(referencesFor(previewFilters, column)).toEqual(referencesFor(consumerRes.body, column));

--- a/test/unit/controllers/consumer-v2.test.ts
+++ b/test/unit/controllers/consumer-v2.test.ts
@@ -59,12 +59,23 @@ jest.mock('../../../src/services/consumer-view-v2', () => ({
   sendJson: jest.fn()
 }));
 
+// Mock PublishedDatasetRepository
+const mockPublishedDatasetGetById = jest.fn();
+jest.mock('../../../src/repositories/published-dataset', () => ({
+  PublishedDatasetRepository: {
+    getById: (...args: unknown[]) => mockPublishedDatasetGetById(...args)
+  },
+  withPublishedRevision: {},
+  withAll: {}
+}));
+
 // Mock consumer utils
 const mockGetFilterTableQuery = jest.fn();
 const mockGetFilterTable = jest.fn();
 jest.mock('../../../src/utils/consumer', () => ({
   getFilterTable: (...args: unknown[]) => mockGetFilterTable(...args),
   getFilterTableQuery: (...args: unknown[]) => mockGetFilterTableQuery(...args),
+  dateColumnsFromDimensions: jest.fn(() => new Set<string>()),
   resolveDimensionToFactTableColumn: jest.fn(),
   resolveFactColumnToDimension: jest.fn()
 }));
@@ -344,6 +355,7 @@ describe('consumer-v2 controller - scheduled publish date handling', () => {
 
       mockGetLatestByDatasetId.mockResolvedValue(publishedRev);
       mockGetFilterTableQuery.mockResolvedValue('SELECT 1');
+      mockPublishedDatasetGetById.mockResolvedValue({ dimensions: [] });
 
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { sendFilters } = require('../../../src/services/consumer-view-v2');
@@ -368,6 +380,7 @@ describe('consumer-v2 controller - scheduled publish date handling', () => {
         })
       });
       mockGetFilterTableQuery.mockResolvedValue('SELECT 1');
+      mockPublishedDatasetGetById.mockResolvedValue({ dimensions: [] });
 
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { sendFilters } = require('../../../src/services/consumer-view-v2');

--- a/test/unit/controllers/revision.test.ts
+++ b/test/unit/controllers/revision.test.ts
@@ -682,6 +682,7 @@ describe('Revision controller', () => {
 
     beforeEach(() => {
       mockGetFilters.mockReset();
+      mockDatasetGetById.mockResolvedValue({ dimensions: [] });
     });
 
     it('should return filters against the requested revision when it has a data table', async () => {
@@ -694,7 +695,7 @@ describe('Revision controller', () => {
 
       await getRevisionPreviewFilters(req, res);
 
-      expect(mockGetFilters).toHaveBeenCalledWith(revision.id, expect.any(String));
+      expect(mockGetFilters).toHaveBeenCalledWith(revision.id, expect.any(String), expect.any(Array));
       expect(res.json).toHaveBeenCalledWith(filters);
     });
 
@@ -710,7 +711,7 @@ describe('Revision controller', () => {
 
       await getRevisionPreviewFilters(req, res);
 
-      expect(mockGetFilters).toHaveBeenCalledWith(dataset.publishedRevisionId, expect.any(String));
+      expect(mockGetFilters).toHaveBeenCalledWith(dataset.publishedRevisionId, expect.any(String), expect.any(Array));
       expect(res.json).toHaveBeenCalledWith(filters);
     });
 

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -61,7 +61,8 @@ jest.mock('../../../src/utils/consumer', () => ({
       description: r.description
     }))
   })),
-  flattenHierarchy: jest.fn((nodes) => nodes ?? [])
+  flattenHierarchy: jest.fn((nodes) => nodes ?? []),
+  sortFilterRows: jest.fn((rows) => rows)
 }));
 
 // Mock column headers


### PR DESCRIPTION
## Summary

Fixes a regression where cube **preview filters and the consumer API filters were not sorting
their values correctly**.

Two defects:

1. **Lexical sort instead of numeric.** `filter_table.sort_order` is `TEXT`, so `ORDER BY
   sort_order` was a string comparison — values with sort order 10+ sorted directly after 1
   (`REG01, REG10, REG11, REG12, REG02 …`). Any dimension with 10+ values was affected.
2. **Dates ascending, not descending.** Date / date-period dimensions were returned
   oldest-first; they should be newest-first.

## How it regressed

A working fix existed: commit `a3513009` (2026-04-13, *"sort date filter values in desc
order"*) sorted date filter values in JS and threaded a `dimensions` parameter into
`getFilters()`. PR #675 `fix-filter-sort-order-from-lookup` (merged 2026-05-13) replaced this
with a plain SQL `ORDER BY sort_order`, and its merge commit silently dropped the date-handling
helper during conflict resolution — no explicit revert. That reintroduced both defects, which
is why the reports surfaced now.

## Fix

Read-side only — no cube schema change, no rebuild of published cubes.

- `utils/consumer.ts`: new shared `sortFilterRows()` and `dateColumnsFromDimensions()`. Values
  are ordered by `sort_order` numerically (parsed from the TEXT column), fall back to ascending
  alphabetical order of the description when no sort order is present, and are reversed for
  date dimensions. `getFilterTableQuery()` no longer emits an `ORDER BY`.
- `getFilters()` (preview + v1 consumer) and `sendFilters()` (v2 consumer) now sort each column
  in JS before building the hierarchy.
- The preview, v1 and v2 consumer controllers load the dataset's dimensions and pass them
  through, so all three order filters identically — the preview reflects exactly what the
  consumer renders.

## Tests

- `test/integration/routes/consumer-v2/filter-sort-order.test.ts` — new regression test
  (12-value lookup dimension, 4-year date-period dimension, no-sort-order dimension); asserts
  ordering on the v2 endpoint and the shared `getFilters()` (preview / v1) path, and that
  preview matches consumer. It fails on the bug and passes with this fix, guarding against
  re-regression.
- Unit tests updated for the new signatures (`consumer-v2`, `revision`, `consumer-view-v2`).
- Full suite: 1315 tests passing; lint and build clean.
