### PR TITLE
SW-1276: Hide archived datasets with an active redirect from taxonomy & search

### DIFF
--- a/src/repositories/published-dataset.ts
+++ b/src/repositories/published-dataset.ts
@@ -48,6 +48,11 @@ export const withPublishedRevision: FindOptionsRelations<Dataset> = {
   replacementDataset: { publishedRevision: { metadata: true } }
 };
 
+// a dataset archived with an auto-redirect to a replacement is hidden from all
+// consumer listings — see SW-1276
+const HIDE_REDIRECTED_ARCHIVED =
+  'NOT (d.archived_at IS NOT NULL AND d.replacement_dataset_id IS NOT NULL AND d.replacement_auto_redirect = TRUE)';
+
 export const PublishedDatasetRepository = dataSource.getRepository(Dataset).extend({
   async getById(id: string, relations: FindOptionsRelations<Dataset> = {}): Promise<Dataset> {
     const start = performance.now();
@@ -131,6 +136,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       )
       .andWhere('d.first_published_at IS NOT NULL')
       .andWhere('d.first_published_at < NOW()')
+      .andWhere(HIDE_REDIRECTED_ARCHIVED)
       .groupBy('d.id, r.id, r.title, d.first_published_at, r.publish_at, d.archived_at');
 
     const offset = (page - 1) * limit;
@@ -146,9 +152,11 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       .getRepository(Revision)
       .createQueryBuilder('r')
       .select('DISTINCT ON (r.dataset_id) r.id AS id')
+      .innerJoin('r.dataset', 'd')
       .where('r.publish_at < NOW()')
       .andWhere('r.approved_at < NOW()')
       .andWhere('r.unpublished_at IS NULL')
+      .andWhere(HIDE_REDIRECTED_ARCHIVED)
       .orderBy('r.dataset_id')
       .addOrderBy('r.publish_at', 'DESC')
       .getRawMany();
@@ -219,6 +227,7 @@ export const PublishedDatasetRepository = dataSource.getRepository(Dataset).exte
       .andWhere('r.topic_ids @> ARRAY[:topicId]', { topicId })
       .andWhere('d.first_published_at IS NOT NULL')
       .andWhere('d.first_published_at < NOW()')
+      .andWhere(HIDE_REDIRECTED_ARCHIVED)
       .groupBy('d.id, r.id, r.title, d.first_published_at, r.publish_at, d.archived_at');
 
     const offset = (page - 1) * limit;
@@ -502,7 +511,8 @@ const getBaseSearchQuery = (lang: Locale): SelectQueryBuilder<Dataset> => {
     .addCommonTableExpression(latestPublishedRevisionCte, 'published_rev')
     .innerJoin('published_rev', 'pr', 'pr.dataset_id = d.id')
     .andWhere('d.first_published_at IS NOT NULL')
-    .andWhere('d.first_published_at < NOW()');
+    .andWhere('d.first_published_at < NOW()')
+    .andWhere(HIDE_REDIRECTED_ARCHIVED);
 
   return baseQb;
 };

--- a/test/integration/repositories/published-dataset.test.ts
+++ b/test/integration/repositories/published-dataset.test.ts
@@ -5,7 +5,9 @@ import { Dataset } from '../../../src/entities/dataset/dataset';
 import { Revision } from '../../../src/entities/dataset/revision';
 import { RevisionMetadata } from '../../../src/entities/dataset/revision-metadata';
 import { PublishedDatasetRepository, withPublishedRevision } from '../../../src/repositories/published-dataset';
+import { RevisionTopic } from '../../../src/entities/dataset/revision-topic';
 import { getTestUser } from '../../helpers/get-test-user';
+import { seedTopic } from '../../helpers/seed-published-dataset';
 import { User } from '../../../src/entities/user/user';
 import { uuidV4 } from '../../../src/utils/uuid';
 import { Locale } from '../../../src/enums/locale';
@@ -667,6 +669,142 @@ describe('PublishedDatasetRepository', () => {
       );
       const ids = result.data.map((d) => d.id);
       expect(ids).not.toContain(unpubDs.id);
+    });
+  });
+
+  // SW-1276: a dataset that is archived AND has a replacement AND has the auto-redirect flag set
+  // is hidden from every consumer listing. Archived datasets without an auto-redirect stay visible
+  // (there is no replacement to send the user to).
+  describe('SW-1276 — hides archived datasets with an auto-redirect', () => {
+    let replacementDs: Dataset;
+
+    // Publishes a dataset (firstPublishedAt + a single approved, past-dated revision with metadata).
+    const createPublished = async (title: string, lang: Locale = Locale.EnglishGb): Promise<Revision> => {
+      const ds = await createDataset(user, { firstPublishedAt: pastDate(48) });
+      return createRevisionWithMetadata(
+        ds,
+        user,
+        1,
+        title,
+        lang,
+        { publishAt: pastDate(24), approvedAt: pastDate(48) },
+        `${title} summary`
+      );
+    };
+
+    // Archives a dataset. `replacement` defaults to true (points at replacementDs); `autoRedirect`
+    // defaults to false. Only archived + replacement + autoRedirect should be hidden.
+    const archive = async (
+      datasetId: string,
+      opts: { replacement?: boolean; autoRedirect?: boolean } = {}
+    ): Promise<void> => {
+      await Dataset.update(datasetId, {
+        archivedAt: pastDate(1),
+        replacementDatasetId: opts.replacement === false ? null : replacementDs.id,
+        replacementAutoRedirect: opts.autoRedirect ?? false
+      });
+    };
+
+    beforeAll(async () => {
+      const replacementRev = await createPublished('SW1276 Replacement Dataset');
+      replacementDs = (await PublishedDatasetRepository.findOneByOrFail({ id: replacementRev.datasetId })) as Dataset;
+    });
+
+    describe('listPublishedByLanguage', () => {
+      it('hides a dataset archived with a replacement and an auto-redirect', async () => {
+        const rev = await createPublished('SW1276 Lang Hidden');
+        await archive(rev.datasetId, { replacement: true, autoRedirect: true });
+
+        const result = await PublishedDatasetRepository.listPublishedByLanguage(Locale.EnglishGb, 1, 1000);
+        expect(result.data.map((d: any) => d.id)).not.toContain(rev.datasetId);
+      });
+
+      it('keeps an archived dataset that has no replacement', async () => {
+        const rev = await createPublished('SW1276 Lang Archived No Replacement');
+        await archive(rev.datasetId, { replacement: false });
+
+        const result = await PublishedDatasetRepository.listPublishedByLanguage(Locale.EnglishGb, 1, 1000);
+        expect(result.data.map((d: any) => d.id)).toContain(rev.datasetId);
+      });
+
+      it('keeps an archived dataset with a replacement but no auto-redirect', async () => {
+        const rev = await createPublished('SW1276 Lang Archived No Auto-redirect');
+        await archive(rev.datasetId, { replacement: true, autoRedirect: false });
+
+        const result = await PublishedDatasetRepository.listPublishedByLanguage(Locale.EnglishGb, 1, 1000);
+        expect(result.data.map((d: any) => d.id)).toContain(rev.datasetId);
+      });
+    });
+
+    // searchBasic, searchBasicSplit, searchFTS and searchFuzzy all share getBaseSearchQuery,
+    // so exercising one search method covers the filter for all four.
+    describe('search (getBaseSearchQuery)', () => {
+      it('hides a redirected, archived dataset from search results', async () => {
+        const rev = await createPublished('SW1276search Hidden Result');
+        await archive(rev.datasetId, { replacement: true, autoRedirect: true });
+
+        const result = await PublishedDatasetRepository.searchBasic(Locale.EnglishGb, 'SW1276search', 1, 100);
+        expect(result.data.map((d) => d.id)).not.toContain(rev.datasetId);
+      });
+
+      it('keeps an archived dataset without an auto-redirect in search results', async () => {
+        const rev = await createPublished('SW1276search Visible Result');
+        await archive(rev.datasetId, { replacement: true, autoRedirect: false });
+
+        const result = await PublishedDatasetRepository.searchBasic(Locale.EnglishGb, 'SW1276search', 1, 100);
+        expect(result.data.map((d) => d.id)).toContain(rev.datasetId);
+      });
+    });
+
+    describe('listPublishedByTopic / listPublishedTopics', () => {
+      const TOPIC_MIXED = 9200; // tagged by one hidden and one visible dataset
+      const TOPIC_HIDDEN_ONLY = 9201; // tagged only by a hidden dataset
+
+      let hiddenDsId: string;
+      let visibleDsId: string;
+
+      beforeAll(async () => {
+        await seedTopic({ id: TOPIC_MIXED, path: `${TOPIC_MIXED}`, nameEN: 'SW1276 Mixed', nameCY: 'SW1276 Cymysg' });
+        await seedTopic({
+          id: TOPIC_HIDDEN_ONLY,
+          path: `${TOPIC_HIDDEN_ONLY}`,
+          nameEN: 'SW1276 Hidden Only',
+          nameCY: 'SW1276 Cudd yn Unig'
+        });
+
+        const hiddenRev = await createPublished('SW1276 Topic Hidden');
+        hiddenDsId = hiddenRev.datasetId;
+        await RevisionTopic.save(RevisionTopic.create({ revisionId: hiddenRev.id, topicId: TOPIC_MIXED }));
+        await archive(hiddenDsId, { replacement: true, autoRedirect: true });
+
+        const visibleRev = await createPublished('SW1276 Topic Visible');
+        visibleDsId = visibleRev.datasetId;
+        await RevisionTopic.save(RevisionTopic.create({ revisionId: visibleRev.id, topicId: TOPIC_MIXED }));
+        await archive(visibleDsId, { replacement: true, autoRedirect: false });
+
+        const hiddenOnlyRev = await createPublished('SW1276 Topic Hidden Only');
+        await RevisionTopic.save(RevisionTopic.create({ revisionId: hiddenOnlyRev.id, topicId: TOPIC_HIDDEN_ONLY }));
+        await archive(hiddenOnlyRev.datasetId, { replacement: true, autoRedirect: true });
+      });
+
+      it('listPublishedByTopic hides redirected datasets but keeps the rest', async () => {
+        const result = await PublishedDatasetRepository.listPublishedByTopic(
+          String(TOPIC_MIXED),
+          Locale.EnglishGb,
+          1,
+          1000
+        );
+        const ids = result.data.map((d: any) => d.id);
+        expect(ids).toContain(visibleDsId);
+        expect(ids).not.toContain(hiddenDsId);
+      });
+
+      it('listPublishedTopics omits a topic whose only dataset is hidden', async () => {
+        const topics = await PublishedDatasetRepository.listPublishedTopics(Locale.EnglishGb);
+        const ids = topics.map((t) => t.id);
+        expect(ids).toContain(TOPIC_MIXED);
+        expect(ids).not.toContain(TOPIC_HIDDEN_ONLY);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Hides datasets that are **archived and have an auto-redirect to a replacement** from all consumer-facing dataset listings (SW-1276). These datasets cause confusion: a user picks one in search or the taxonomy, gets auto-redirected to the replacement, and is unsure whether they're looking at the dataset they chose. As more teams adopt the archive feature, these duplicate entries would increasingly pollute search results and the taxonomy.

Archived datasets *without* an auto-redirect remain visible — there is no replacement to send the user to.

## Hide condition

A dataset is hidden from consumer listings when **all** of:

- `archived_at IS NOT NULL`
- `replacement_dataset_id IS NOT NULL`
- `replacement_auto_redirect = TRUE`

## Changes

All in `src/repositories/published-dataset.ts` — the consumer-side repository, shared by both v1 and v2 consumer APIs. A single SQL fragment constant (`HIDE_REDIRECTED_ARCHIVED`) is applied to:

- `listPublishedByLanguage` — the general "list all published datasets" endpoint
- `listPublishedByTopic` — datasets on a topic page
- `getBaseSearchQuery` — shared base for `searchBasic`, `searchBasicSplit`, `searchFTS`, `searchFuzzy`
- `listPublishedTopics` — joins the dataset so a topic does not appear solely because of a hidden dataset

## Tests

Added a `SW-1276` block to `test/integration/repositories/published-dataset.test.ts` (7 tests) covering all four queries: hidden datasets are excluded; archived datasets with no replacement, or with a replacement but no auto-redirect, stay visible; and a topic whose only dataset is hidden drops off the taxonomy.

`npm run check` passes — build, format, and all 1315 tests.
