### PR TITLE
SW-1268 Fix bug in hierarchy code

### DIFF
--- a/src/interfaces/filter-row.ts
+++ b/src/interfaces/filter-row.ts
@@ -1,10 +1,10 @@
 export interface FilterRow {
-  reference: string;
+  reference: string | number;
   language: string;
   fact_table_column: string;
   dimension_name: string;
   description: string;
-  hierarchy: string;
+  hierarchy: string | number | null;
   sort_order?: string | null;
   reference_count?: string | null;
 }

--- a/src/migrations/1779210246623-fix-double-column-datatype.ts
+++ b/src/migrations/1779210246623-fix-double-column-datatype.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixDoubleColumnDatatype1779210246623 implements MigrationInterface {
+  name = 'FixDoubleColumnDatatype1779210246623';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "fact_table_column" SET "column_datatype" = 'DOUBLE PRECISION' WHERE "column_datatype" = 'DOUBLE'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "fact_table_column" SET "column_datatype" = 'DOUBLE' WHERE "column_datatype" = 'DOUBLE PRECISION'`
+    );
+  }
+}

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -4,6 +4,7 @@ import { FindOneOptions, FindOptionsRelations, QueryBuilder, SelectQueryBuilder 
 import { has, set } from 'lodash';
 
 import { logger } from '../utils/logger';
+import { normalizeSqlDatatype } from '../utils/sql-datatype';
 import { dataSource } from '../db/data-source';
 import { Dataset } from '../entities/dataset/dataset';
 import { DatasetListItemDTO } from '../dtos/dataset-list-item-dto';
@@ -180,7 +181,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
         id: dataset.id,
         columnName: dataTableCol.columnName,
         columnIndex: dataTableCol.columnIndex,
-        columnDatatype: dataTableCol.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : dataTableCol.columnDatatype,
+        columnDatatype: normalizeSqlDatatype(dataTableCol.columnDatatype),
         columnType: FactTableColumnType.Unknown
       });
 

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -180,7 +180,7 @@ export const DatasetRepository = dataSource.getRepository(Dataset).extend({
         id: dataset.id,
         columnName: dataTableCol.columnName,
         columnIndex: dataTableCol.columnIndex,
-        columnDatatype: dataTableCol.columnDatatype,
+        columnDatatype: dataTableCol.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : dataTableCol.columnDatatype,
         columnType: FactTableColumnType.Unknown
       });
 

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -265,7 +265,7 @@ export async function sendFilters(query: string, res: Response): Promise<void> {
       if (data.length != flattenedHierarchy.length) {
         hierarchy.values = data.map((val) => {
           return {
-            reference: val.reference,
+            reference: String(val.reference),
             description: val.description
           };
         });

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -9,6 +9,7 @@ import { SUPPORTED_LOCALES, t } from '../middleware/translation';
 import { CubeValidationException } from '../exceptions/cube-error-exception';
 import { CubeValidationType } from '../enums/cube-validation-type';
 import { performanceReporting } from '../utils/performance-reporting';
+import { normalizeSqlDatatype } from '../utils/sql-datatype';
 import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
 import { dbManager } from '../db/database-manager';
 import { DataTable } from '../entities/dataset/data-table';
@@ -515,11 +516,7 @@ export function setupCubeBuilder(dataset: Dataset, buildId: string): FactTableIn
         factIdentifiers.push(field);
       }
       factTableDef.push(field.columnName);
-      return pgformat(
-        '%I %s',
-        field.columnName,
-        field.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : field.columnDatatype
-      );
+      return pgformat('%I %s', field.columnName, normalizeSqlDatatype(field.columnDatatype));
     });
   const factTableCreationQuery = pgformat(
     `CREATE TABLE %I.%I (%s);`,
@@ -1293,7 +1290,7 @@ export const measureTableCreateStatement = (
   buildId?: string,
   tableName = 'measure'
 ): string => {
-  const normalizedType = joinColumnType === 'DOUBLE' ? 'DOUBLE PRECISION' : joinColumnType;
+  const normalizedType = normalizeSqlDatatype(joinColumnType);
   if (buildId) {
     tableName = pgformat('%I.%I', buildId, tableName);
   }

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1293,6 +1293,7 @@ export const measureTableCreateStatement = (
   buildId?: string,
   tableName = 'measure'
 ): string => {
+  const normalizedType = joinColumnType === 'DOUBLE' ? 'DOUBLE PRECISION' : joinColumnType;
   if (buildId) {
     tableName = pgformat('%I.%I', buildId, tableName);
   }
@@ -1311,8 +1312,8 @@ export const measureTableCreateStatement = (
       );
     `,
     tableName,
-    joinColumnType,
-    joinColumnType
+    normalizedType,
+    normalizedType
   );
 };
 

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -36,6 +36,8 @@ export const createDatePeriodTableQuery = (
   schemaId: string,
   tableName: string
 ): string => {
+  const normalizedDatatype =
+    factTableColumn.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : factTableColumn.columnDatatype;
   return pgformat(
     `
       CREATE TABLE %I.%I (
@@ -51,8 +53,8 @@ export const createDatePeriodTableQuery = (
     schemaId,
     tableName,
     factTableColumn.columnName,
-    factTableColumn.columnDatatype,
-    factTableColumn.columnDatatype
+    normalizedDatatype,
+    normalizedDatatype
   );
 };
 

--- a/src/services/date-matching.ts
+++ b/src/services/date-matching.ts
@@ -2,6 +2,7 @@ import { add, format, isBefore, isDate, isValid, parse, parseISO, sub, Duration 
 import { TZDate } from '@date-fns/tz';
 
 import { logger } from '../utils/logger';
+import { normalizeSqlDatatype } from '../utils/sql-datatype';
 import { YearType } from '../enums/year-type';
 import { DateExtractor } from '../extractors/date-extractor';
 import { SUPPORTED_LOCALES, t } from '../middleware/translation';
@@ -36,8 +37,7 @@ export const createDatePeriodTableQuery = (
   schemaId: string,
   tableName: string
 ): string => {
-  const normalizedDatatype =
-    factTableColumn.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : factTableColumn.columnDatatype;
+  const normalizedDatatype = normalizeSqlDatatype(factTableColumn.columnDatatype);
   return pgformat(
     `
       CREATE TABLE %I.%I (

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -10,6 +10,7 @@ import { SourceAssignmentException } from '../exceptions/source-assignment.excep
 import { Dataset } from '../entities/dataset/dataset';
 import { DimensionType } from '../enums/dimension-type';
 import { logger } from '../utils/logger';
+import { normalizeSqlDatatype } from '../utils/sql-datatype';
 import { Dimension } from '../entities/dataset/dimension';
 import { SUPPORTED_LOCALES } from '../middleware/translation';
 import { DimensionMetadata } from '../entities/dataset/dimension-metadata';
@@ -247,7 +248,7 @@ async function createBaseFactTable(dataset: Dataset, dataTable: DataTable): Prom
     const factTableCol = new FactTableColumn();
     factTableCol.columnType = FactTableColumnType.Unknown;
     factTableCol.columnName = col.columnName;
-    factTableCol.columnDatatype = col.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : col.columnDatatype;
+    factTableCol.columnDatatype = normalizeSqlDatatype(col.columnDatatype);
     factTableCol.columnIndex = col.columnIndex;
     factTableCol.id = dataset.id;
     factTableCol.dataset = dataset;

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -247,7 +247,7 @@ async function createBaseFactTable(dataset: Dataset, dataTable: DataTable): Prom
     const factTableCol = new FactTableColumn();
     factTableCol.columnType = FactTableColumnType.Unknown;
     factTableCol.columnName = col.columnName;
-    factTableCol.columnDatatype = col.columnDatatype;
+    factTableCol.columnDatatype = col.columnDatatype === 'DOUBLE' ? 'DOUBLE PRECISION' : col.columnDatatype;
     factTableCol.columnIndex = col.columnIndex;
     factTableCol.id = dataset.id;
     factTableCol.dataset = dataset;

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -116,7 +116,7 @@ export function resolveFactDescriptionToReference(referenceValues: string[], fil
   const resolvedValues: string[] = [];
   for (const val of referenceValues) {
     const resVal = filterTable.find((row) => row.description.toLowerCase() === val.toLowerCase());
-    if (resVal) resolvedValues.push(resVal?.reference);
+    if (resVal) resolvedValues.push(String(resVal.reference));
     else throw new Error('Value not found');
   }
   return resolvedValues;

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -24,18 +24,18 @@ export function transformHierarchy(factTableColumn: string, columnName: string, 
   // First, create node instances for all inputs
   for (const row of input) {
     const node: FilterValues = {
-      reference: row.reference,
+      reference: String(row.reference),
       description: row.description,
       count: row.reference_count != null ? row.reference_count : undefined
     };
-    nodeMap.set(row.reference, node);
+    nodeMap.set(String(row.reference), node);
 
     // Queue up children by parent ref
     if (row.hierarchy) {
-      if (!childrenMap.has(row.hierarchy)) {
-        childrenMap.set(row.hierarchy, []);
+      if (!childrenMap.has(String(row.hierarchy))) {
+        childrenMap.set(String(row.hierarchy), []);
       }
-      childrenMap.get(row.hierarchy)!.push(node);
+      childrenMap.get(String(row.hierarchy))!.push(node);
     }
   }
 

--- a/src/utils/consumer.ts
+++ b/src/utils/consumer.ts
@@ -33,7 +33,7 @@ export function transformHierarchy(factTableColumn: string, columnName: string, 
     nodeMap.set(String(row.reference), node);
 
     // Queue up children by parent ref
-    if (row.hierarchy) {
+    if (row.hierarchy !== null && row.hierarchy !== undefined) {
       if (!childrenMap.has(String(row.hierarchy))) {
         childrenMap.set(String(row.hierarchy), []);
       }

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -74,6 +74,7 @@ export const createLookupTableQuery = (
   referenceColumnType: string,
   otherColumns?: string[]
 ): string => {
+  const normalizedType = referenceColumnType === 'DOUBLE' ? 'DOUBLE PRECISION' : referenceColumnType;
   const otherColumnsStatement: string[] = [];
   if (otherColumns && otherColumns.length > 0) {
     otherColumns.forEach((column) => {
@@ -85,7 +86,7 @@ export const createLookupTableQuery = (
     schemaName,
     lookupTableName,
     referenceColumnName,
-    referenceColumnType,
+    normalizedType,
     otherColumnsStatement.length > 0 ? `, ${otherColumnsStatement.join(', ')}` : ''
   );
 };

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -8,6 +8,7 @@ import { format as pgformat } from '@scaleleap/pg-format';
 
 import { Dataset } from '../entities/dataset/dataset';
 import { FileImportInterface } from '../entities/dataset/file-import.interface';
+import { normalizeSqlDatatype } from './sql-datatype';
 import { FileType } from '../enums/file-type';
 import { logger } from './logger';
 import { getFileService } from './get-file-service';
@@ -74,7 +75,7 @@ export const createLookupTableQuery = (
   referenceColumnType: string,
   otherColumns?: string[]
 ): string => {
-  const normalizedType = referenceColumnType === 'DOUBLE' ? 'DOUBLE PRECISION' : referenceColumnType;
+  const normalizedType = normalizeSqlDatatype(referenceColumnType);
   const otherColumnsStatement: string[] = [];
   if (otherColumns && otherColumns.length > 0) {
     otherColumns.forEach((column) => {

--- a/src/utils/sql-datatype.ts
+++ b/src/utils/sql-datatype.ts
@@ -1,0 +1,3 @@
+// DuckDB reports DOUBLE for floating-point columns; PostgreSQL requires DOUBLE PRECISION.
+export const normalizeSqlDatatype = (datatype: string): string =>
+  datatype === 'DOUBLE' ? 'DOUBLE PRECISION' : datatype;

--- a/test/integration/repositories/dataset.test.ts
+++ b/test/integration/repositories/dataset.test.ts
@@ -224,6 +224,19 @@ describe('DatasetRepository', () => {
         expect(col.columnType).toBe(FactTableColumnType.Unknown);
       }
     });
+
+    it('should normalise DOUBLE to DOUBLE PRECISION when persisting fact table columns', async () => {
+      const freshDataset = await createDataset(user);
+      const dataTable = {
+        dataTableDescriptions: [{ columnName: 'measure_value', columnIndex: 0, columnDatatype: 'DOUBLE' }]
+      } as DataTable;
+
+      await DatasetRepository.replaceFactTable(freshDataset, dataTable);
+
+      const result = await DatasetRepository.getById(freshDataset.id, { factTable: true });
+      expect(result.factTable).toHaveLength(1);
+      expect(result.factTable![0].columnDatatype).toBe('DOUBLE PRECISION');
+    });
   });
 
   describe('publish', () => {

--- a/test/unit/services/cube-builder.test.ts
+++ b/test/unit/services/cube-builder.test.ts
@@ -404,6 +404,14 @@ describe('measureTableCreateStatement', () => {
     expect(sql1).toContain('measure');
     expect(sql2).toContain('custom_measure');
   });
+
+  it('normalises DOUBLE to DOUBLE PRECISION for both reference and hierarchy columns', () => {
+    const sql = measureTableCreateStatement('DOUBLE');
+    expect(sql).toContain('reference DOUBLE PRECISION');
+    expect(sql).toContain('hierarchy DOUBLE PRECISION');
+    expect(sql).not.toMatch(/reference DOUBLE(?! PRECISION)/);
+    expect(sql).not.toMatch(/hierarchy DOUBLE(?! PRECISION)/);
+  });
 });
 
 // ===========================================================================

--- a/test/unit/services/date-matching.test.ts
+++ b/test/unit/services/date-matching.test.ts
@@ -56,6 +56,18 @@ describe('date-matching', () => {
       expect(sql).toContain('lookup');
       expect(sql).toContain('hierarchy BIGINT');
     });
+
+    test('normalises DOUBLE to DOUBLE PRECISION for both the reference column and hierarchy', () => {
+      const doubleCol = {
+        columnName: 'measure_value',
+        columnDatatype: 'DOUBLE'
+      } as unknown as FactTableColumn;
+      const sql = createDatePeriodTableQuery(doubleCol, 'public', 'date_lookup');
+      expect(sql).toContain('measure_value DOUBLE PRECISION');
+      expect(sql).toContain('hierarchy DOUBLE PRECISION');
+      expect(sql).not.toMatch(/measure_value DOUBLE(?! PRECISION)/);
+      expect(sql).not.toMatch(/hierarchy DOUBLE(?! PRECISION)/);
+    });
   });
 
   describe('dateDimensionReferenceTableCreator - year format variants', () => {

--- a/test/unit/utils/consumer.test.ts
+++ b/test/unit/utils/consumer.test.ts
@@ -91,6 +91,46 @@ describe('transformHierarchy', () => {
       expect(result.values[0].children![0].children![0].reference).toBe('3');
     });
   });
+
+  describe('with mixed-type references (the real-world regression)', () => {
+    // The original bug: a DOUBLE PRECISION reference column returns numbers at runtime while
+    // a VARCHAR hierarchy column returns strings, so `reference === hierarchy` is always false
+    // even when the values are numerically equal (e.g. 2.0 !== '2').
+
+    it('links a numeric reference to a string hierarchy value', () => {
+      // reference comes back as number (DOUBLE col), hierarchy as string (VARCHAR col)
+      const rows: FilterRow[] = [
+        baseRow({ reference: 1, description: 'Parent', hierarchy: null }),
+        baseRow({ reference: 2.0, description: 'Child', hierarchy: '1' })
+      ];
+
+      const result = transformHierarchy('col', 'dim', rows);
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].reference).toBe('1');
+      expect(result.values[0].children).toHaveLength(1);
+      expect(result.values[0].children![0].reference).toBe('2');
+    });
+
+    it('links a string reference to a numeric hierarchy value', () => {
+      // reference comes back as string (VARCHAR col), hierarchy as number (DOUBLE col).
+      // hierarchy: 1.0 points to the parent whose reference is '1' — String(1.0) must equal '1'.
+      const rows: FilterRow[] = [
+        baseRow({ reference: '1', description: 'Root', hierarchy: null }),
+        baseRow({ reference: '2', description: 'Child', hierarchy: 1.0 }),
+        baseRow({ reference: '3', description: 'Grandchild', hierarchy: 2.0 })
+      ];
+
+      const result = transformHierarchy('col', 'dim', rows);
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].reference).toBe('1');
+      expect(result.values[0].children).toHaveLength(1);
+      expect(result.values[0].children![0].reference).toBe('2');
+      expect(result.values[0].children![0].children).toHaveLength(1);
+      expect(result.values[0].children![0].children![0].reference).toBe('3');
+    });
+  });
 });
 
 describe('flattenHierarchy', () => {

--- a/test/unit/utils/consumer.test.ts
+++ b/test/unit/utils/consumer.test.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+
 jest.mock('../../../src/utils/logger', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
 }));

--- a/test/unit/utils/consumer.test.ts
+++ b/test/unit/utils/consumer.test.ts
@@ -1,0 +1,116 @@
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+jest.mock('../../../src/db/database-manager', () => ({ dbManager: { getCubeDataSource: jest.fn() } }));
+
+jest.mock('../../../src/services/cube-builder', () => ({
+  CORE_VIEW_NAME: 'core_view',
+  FILTER_TABLE_NAME: 'filter_table',
+  METADATA_TABLE_NAME: 'metadata',
+  FACT_TABLE_NAME: 'fact_table',
+  VALIDATION_TABLE_NAME: 'validation_table',
+  setupValidationTableFromDataset: jest.fn()
+}));
+
+jest.mock('i18next', () => ({ t: jest.fn((key: string) => key) }));
+
+import { flattenHierarchy, transformHierarchy } from '../../../src/utils/consumer';
+import { FilterRow } from '../../../src/interfaces/filter-row';
+
+const baseRow = (overrides: Partial<FilterRow>): FilterRow => ({
+  reference: '',
+  language: 'en-GB',
+  fact_table_column: 'col',
+  dimension_name: 'dim',
+  description: '',
+  hierarchy: null as unknown as string,
+  ...overrides
+});
+
+describe('transformHierarchy', () => {
+  describe('with string references', () => {
+    it('builds a two-level hierarchy', () => {
+      const rows: FilterRow[] = [
+        baseRow({ reference: 'parent', description: 'Parent', hierarchy: null as unknown as string }),
+        baseRow({ reference: 'child', description: 'Child', hierarchy: 'parent' })
+      ];
+
+      const result = transformHierarchy('col', 'dim', rows);
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].reference).toBe('parent');
+      expect(result.values[0].children).toHaveLength(1);
+      expect(result.values[0].children![0].reference).toBe('child');
+    });
+  });
+
+  describe('with numeric (double) references at runtime', () => {
+    it('correctly links children to parents when reference and hierarchy are numbers', () => {
+      // Simulate what PostgreSQL returns for a DOUBLE column — numbers at runtime
+      // despite the TypeScript type being `string`.
+      const rows = [
+        baseRow({ reference: 1.0 as unknown as string, description: 'Parent', hierarchy: null as unknown as string }),
+        baseRow({ reference: 2.0 as unknown as string, description: 'Child', hierarchy: 1.0 as unknown as string })
+      ] as FilterRow[];
+
+      const result = transformHierarchy('col', 'dim', rows);
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].reference).toBe('1');
+      expect(result.values[0].children).toHaveLength(1);
+      expect(result.values[0].children![0].reference).toBe('2');
+    });
+
+    it('does not lose children from the output when references are doubles', () => {
+      const rows = [
+        baseRow({ reference: 1.0 as unknown as string, description: 'Root', hierarchy: null as unknown as string }),
+        baseRow({ reference: 2.0 as unknown as string, description: 'Child A', hierarchy: 1.0 as unknown as string }),
+        baseRow({ reference: 3.0 as unknown as string, description: 'Child B', hierarchy: 1.0 as unknown as string })
+      ] as FilterRow[];
+
+      const result = transformHierarchy('col', 'dim', rows);
+      const flat = flattenHierarchy(result.values);
+
+      expect(flat).toHaveLength(3);
+    });
+
+    it('builds a three-level hierarchy with double references', () => {
+      const rows = [
+        baseRow({ reference: 1.0 as unknown as string, description: 'Root', hierarchy: null as unknown as string }),
+        baseRow({ reference: 2.0 as unknown as string, description: 'Mid', hierarchy: 1.0 as unknown as string }),
+        baseRow({ reference: 3.0 as unknown as string, description: 'Leaf', hierarchy: 2.0 as unknown as string })
+      ] as FilterRow[];
+
+      const result = transformHierarchy('col', 'dim', rows);
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].children).toHaveLength(1);
+      expect(result.values[0].children![0].children).toHaveLength(1);
+      expect(result.values[0].children![0].children![0].reference).toBe('3');
+    });
+  });
+});
+
+describe('flattenHierarchy', () => {
+  it('returns a flat list of all nodes', () => {
+    const tree = [
+      {
+        reference: 'a',
+        description: 'A',
+        children: [
+          { reference: 'b', description: 'B' },
+          { reference: 'c', description: 'C' }
+        ]
+      }
+    ];
+
+    const result = flattenHierarchy(tree);
+
+    expect(result.map((n) => n.reference)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(flattenHierarchy([])).toEqual([]);
+  });
+});

--- a/test/unit/utils/consumer.test.ts
+++ b/test/unit/utils/consumer.test.ts
@@ -24,7 +24,7 @@ const baseRow = (overrides: Partial<FilterRow>): FilterRow => ({
   fact_table_column: 'col',
   dimension_name: 'dim',
   description: '',
-  hierarchy: null as unknown as string,
+  hierarchy: null,
   ...overrides
 });
 
@@ -32,7 +32,7 @@ describe('transformHierarchy', () => {
   describe('with string references', () => {
     it('builds a two-level hierarchy', () => {
       const rows: FilterRow[] = [
-        baseRow({ reference: 'parent', description: 'Parent', hierarchy: null as unknown as string }),
+        baseRow({ reference: 'parent', description: 'Parent', hierarchy: null }),
         baseRow({ reference: 'child', description: 'Child', hierarchy: 'parent' })
       ];
 
@@ -47,12 +47,11 @@ describe('transformHierarchy', () => {
 
   describe('with numeric (double) references at runtime', () => {
     it('correctly links children to parents when reference and hierarchy are numbers', () => {
-      // Simulate what PostgreSQL returns for a DOUBLE column — numbers at runtime
-      // despite the TypeScript type being `string`.
-      const rows = [
-        baseRow({ reference: 1.0 as unknown as string, description: 'Parent', hierarchy: null as unknown as string }),
-        baseRow({ reference: 2.0 as unknown as string, description: 'Child', hierarchy: 1.0 as unknown as string })
-      ] as FilterRow[];
+      // Simulate what PostgreSQL returns for a DOUBLE column — numbers at runtime.
+      const rows: FilterRow[] = [
+        baseRow({ reference: 1.0, description: 'Parent', hierarchy: null }),
+        baseRow({ reference: 2.0, description: 'Child', hierarchy: 1.0 })
+      ];
 
       const result = transformHierarchy('col', 'dim', rows);
 
@@ -63,11 +62,11 @@ describe('transformHierarchy', () => {
     });
 
     it('does not lose children from the output when references are doubles', () => {
-      const rows = [
-        baseRow({ reference: 1.0 as unknown as string, description: 'Root', hierarchy: null as unknown as string }),
-        baseRow({ reference: 2.0 as unknown as string, description: 'Child A', hierarchy: 1.0 as unknown as string }),
-        baseRow({ reference: 3.0 as unknown as string, description: 'Child B', hierarchy: 1.0 as unknown as string })
-      ] as FilterRow[];
+      const rows: FilterRow[] = [
+        baseRow({ reference: 1.0, description: 'Root', hierarchy: null }),
+        baseRow({ reference: 2.0, description: 'Child A', hierarchy: 1.0 }),
+        baseRow({ reference: 3.0, description: 'Child B', hierarchy: 1.0 })
+      ];
 
       const result = transformHierarchy('col', 'dim', rows);
       const flat = flattenHierarchy(result.values);
@@ -76,11 +75,11 @@ describe('transformHierarchy', () => {
     });
 
     it('builds a three-level hierarchy with double references', () => {
-      const rows = [
-        baseRow({ reference: 1.0 as unknown as string, description: 'Root', hierarchy: null as unknown as string }),
-        baseRow({ reference: 2.0 as unknown as string, description: 'Mid', hierarchy: 1.0 as unknown as string }),
-        baseRow({ reference: 3.0 as unknown as string, description: 'Leaf', hierarchy: 2.0 as unknown as string })
-      ] as FilterRow[];
+      const rows: FilterRow[] = [
+        baseRow({ reference: 1.0, description: 'Root', hierarchy: null }),
+        baseRow({ reference: 2.0, description: 'Mid', hierarchy: 1.0 }),
+        baseRow({ reference: 3.0, description: 'Leaf', hierarchy: 2.0 })
+      ];
 
       const result = transformHierarchy('col', 'dim', rows);
 


### PR DESCRIPTION
There was a small bug in the hierachy generation code which meant when the incoming value was a double it wasn't joining the values together properly.

Additionally when trying to handle lookups with doubles in the reference column it causes issues processing the lookup.  So correctly sets the column type to 'DOUBLE PRECISION' so when passed to Postgres it doesn't cause issues.