### PR TITLE
SW-1278: fix translation export reverting to Incomplete on dimension/metadata key collision

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ const config = defineConfig([
   {
     // global ignores need to be in their own block otherwise they don't seem to work
     ignores: [
+      '.claude/**',
       '.docker/**',
       '.github/**',
       '.vscode/**',

--- a/src/dtos/tasklist-state-dto.ts
+++ b/src/dtos/tasklist-state-dto.ts
@@ -208,7 +208,12 @@ export class TasklistStateDTO {
     const importedTranslations = lastImport?.data || [];
 
     const changesSinceImport = currentTranslations.some((t: TranslationDTO) => {
-      const imported = importedTranslations.find((i: TranslationDTO) => i.key === t.key);
+      // Match on both type and key: keys are only unique within a type, not across
+      // them. A dimension whose factTableColumn is e.g. "reason" collides with the
+      // metadata "reason" field, and matching on key alone cross-matches the two,
+      // reporting a spurious change on every import (SW-1278). validateImport pairs
+      // rows the same way.
+      const imported = importedTranslations.find((i: TranslationDTO) => i.type === t.type && i.key === t.key);
 
       if (!imported) {
         logger.debug(`"${t.key}" is a new translation since last import`);

--- a/test/integration/routes/translation.test.ts
+++ b/test/integration/routes/translation.test.ts
@@ -1,0 +1,292 @@
+// SW-1278 — a publisher reports that the "Export text fields for translation"
+// tasklist item flips back to Incomplete after they import their completed
+// translation CSV. The unit-level tests in test/unit/dtos/tasklist-state-dto.test.ts
+// cover the status-calculation logic in isolation with `collectTranslations` mocked.
+// This file exercises the real round trip — datasetService.updateTranslations()
+// persists values to the DB, getTasklistState() reads them back via the real
+// collectTranslations() utility — which is where the bug would most plausibly hide.
+
+import { dbManager } from '../../../src/db/database-manager';
+import { initPassport } from '../../../src/middleware/passport-auth';
+import { Dataset } from '../../../src/entities/dataset/dataset';
+import { Revision } from '../../../src/entities/dataset/revision';
+import { DimensionMetadata } from '../../../src/entities/dataset/dimension-metadata';
+import { RevisionMetadata } from '../../../src/entities/dataset/revision-metadata';
+import { EventLog } from '../../../src/entities/event-log';
+import { User } from '../../../src/entities/user/user';
+import { UserGroup } from '../../../src/entities/user/user-group';
+import { UserGroupRole } from '../../../src/entities/user/user-group-role';
+import { GroupRole } from '../../../src/enums/group-role';
+import { Locale } from '../../../src/enums/locale';
+import { TaskListStatus } from '../../../src/enums/task-list-status';
+import { DatasetService } from '../../../src/services/dataset';
+import { DatasetRepository, withMetadataForTranslation } from '../../../src/repositories/dataset';
+import { TranslationDTO } from '../../../src/dtos/translations-dto';
+import { collectTranslations } from '../../../src/utils/collect-translations';
+import { getFileService } from '../../../src/utils/get-file-service';
+import BlobStorage from '../../../src/services/blob-storage';
+import { ensureWorkerDataSources, resetDatabase } from '../../helpers/reset-database';
+import { getTestUser, getTestUserGroup } from '../../helpers/get-test-user';
+import { createFullDataset } from '../../helpers/test-helper';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+jest.mock('../../../src/services/blob-storage');
+BlobStorage.prototype.listFiles = jest
+  .fn()
+  .mockReturnValue([{ name: 'test-data-1.csv', path: 'test/test-data-1.csv', isDirectory: false }]);
+BlobStorage.prototype.saveBuffer = jest.fn();
+
+const user: User = getTestUser('translation-test-user');
+let userGroup = getTestUserGroup('Translation Test Group');
+let datasetService: DatasetService;
+
+interface SeededDataset {
+  dataset: Dataset;
+  revision: Revision;
+}
+
+// Creates a dataset with both English and Welsh metadata seeded for the dimensions
+// and revision, and (optionally) a related link. updateTranslations() asserts that
+// each dimension already has a `cy` metadata row, so we have to put one there.
+async function seedDataset(opts: {
+  title?: string;
+  summary?: string;
+  collection?: string;
+  quality?: string;
+  withRelatedLink?: boolean;
+  dimensionColumnNames?: string[];
+}): Promise<SeededDataset> {
+  const datasetId = uuidV4();
+  const revisionId = uuidV4();
+  const dataTableId = uuidV4();
+
+  await createFullDataset(datasetId, revisionId, dataTableId, user);
+
+  const revision = await Revision.findOne({
+    where: { id: revisionId },
+    relations: { metadata: true }
+  });
+  if (!revision) throw new Error('seed: revision not found');
+
+  // Fill every translatable metadata field with a realistic English value, so
+  // exports won't contain null cells (which would get rejected by validation in
+  // production anyway). The Welsh side starts blank — the round-trip simulates a
+  // publisher who exports, fills in Welsh, and re-imports.
+  const metaEn = revision.metadata.find((m) => m.language === Locale.EnglishGb)!;
+  const metaCy = revision.metadata.find((m) => m.language === Locale.WelshGb)!;
+  metaEn.title = opts.title ?? 'Healthy Child Wales Programme';
+  metaCy.title = '';
+  metaEn.summary = opts.summary ?? 'Annual percentage of incomplete contacts.';
+  metaCy.summary = '';
+  metaEn.collection = opts.collection ?? 'Data collection notes.';
+  metaCy.collection = '';
+  metaEn.quality = opts.quality ?? 'Quality statement.';
+  metaCy.quality = '';
+  await RevisionMetadata.getRepository().save([metaEn, metaCy]);
+
+  if (opts.withRelatedLink) {
+    revision.relatedLinks = [
+      {
+        id: uuidV4(),
+        url: 'https://example.gov.wales/related',
+        labelEN: "Publisher's notes",
+        labelCY: '',
+        created_at: new Date().toISOString()
+      }
+    ];
+    await revision.save();
+  }
+
+  // createFullDataset only attaches English metadata to dimensions. updateTranslations
+  // requires a Welsh row to exist for each dimension — create blank Welsh rows here.
+  const dataset = await DatasetRepository.getById(datasetId, withMetadataForTranslation);
+  for (const dimension of dataset.dimensions) {
+    const hasCy = dimension.metadata.some((m) => m.language.includes('cy'));
+    if (!hasCy) {
+      const cyMeta = DimensionMetadata.create({
+        id: dimension.id,
+        language: 'cy-GB',
+        name: ''
+      } as DimensionMetadata);
+      await DimensionMetadata.getRepository().save(cyMeta);
+    }
+  }
+
+  // Reload to get the full state for the caller.
+  const reloaded = await DatasetRepository.getById(datasetId, withMetadataForTranslation);
+  return { dataset: reloaded, revision: reloaded.draftRevision! };
+}
+
+// Simulates the controller flow without going through HTTP file streaming / AV scan:
+//   1. Save an `export` EventLog (as translationExport() does after streaming CSV).
+//   2. Call datasetService.updateTranslations() with the filled-in translations
+//      (as applyImport() does once the user has confirmed the validated upload).
+//   3. Save an `import` EventLog (as applyImport() does after updateTranslations()).
+async function simulateExportThenImport(
+  revisionId: string,
+  exportedTranslations: TranslationDTO[],
+  importedTranslations: TranslationDTO[],
+  exportTime: Date
+): Promise<void> {
+  await EventLog.getRepository().save({
+    action: 'export',
+    entity: 'translations',
+    entityId: revisionId,
+    data: exportedTranslations,
+    userId: user.id,
+    client: 'translation-integration-test',
+    createdAt: exportTime
+  });
+
+  // Drive applyImport's key call.
+  const dataset = await DatasetRepository.getById(
+    (await Revision.findOneByOrFail({ id: revisionId })).datasetId,
+    withMetadataForTranslation
+  );
+  await datasetService.updateTranslations(dataset.id, importedTranslations);
+
+  await EventLog.getRepository().save({
+    action: 'import',
+    entity: 'translations',
+    entityId: revisionId,
+    data: importedTranslations,
+    userId: user.id,
+    client: 'translation-integration-test'
+  });
+}
+
+function fillWelsh(translations: TranslationDTO[]): TranslationDTO[] {
+  return translations.map((t) => ({
+    ...t,
+    cymraeg: t.cymraeg && t.cymraeg.length > 0 ? t.cymraeg : `${t.english ?? ''} (cy)`
+  }));
+}
+
+describe('Translation round trip (SW-1278)', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+    await resetDatabase();
+    await initPassport(dbManager.getAppDataSource());
+    userGroup = await dbManager.getAppDataSource().getRepository(UserGroup).save(userGroup);
+    user.groupRoles = [UserGroupRole.create({ group: userGroup, roles: [GroupRole.Editor] })];
+    await user.save();
+    const fileService = getFileService();
+    datasetService = new DatasetService(Locale.EnglishGb, fileService);
+  });
+
+  it('marks both export and import Completed after a clean round trip', async () => {
+    const { dataset, revision } = await seedDataset({ title: 'My dataset' });
+    const exported = collectTranslations(dataset);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+
+  it('marks both Completed after a round trip with whitespace-padded metadata values', async () => {
+    // If `stringify` writes the padded value verbatim and the CSV parser's
+    // `trim: true` strips it, the imported event payload will not match the
+    // stored values. The unit suite proves this would surface as Incomplete —
+    // here we check whether the real round trip suffers from it.
+    const { dataset, revision } = await seedDataset({ title: ' Healthy Child Wales Programme ' });
+    const exported = collectTranslations(dataset);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+
+  it('marks both Completed when metadata contains an apostrophe', async () => {
+    const { dataset, revision } = await seedDataset({ title: "Children's wellbeing" });
+    const exported = collectTranslations(dataset);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+
+  it('marks both Completed when revision has a related link', async () => {
+    const { dataset, revision } = await seedDataset({ title: 'With related links', withRelatedLink: true });
+    const exported = collectTranslations(dataset);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+
+  it('flips export Incomplete after the user edits metadata following a successful import', async () => {
+    // This is the legitimate stale case. Pinned down to make sure a future fix
+    // to SW-1278 does not over-correct and break it.
+    const { dataset, revision } = await seedDataset({ title: 'Before edit' });
+    const exported = collectTranslations(dataset);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    // User edits English title afterwards. RevisionMetadata's primary key column is
+    // `revision_id` mapped to the property `id`.
+    const metaEn = await RevisionMetadata.findOneByOrFail({
+      id: revision.id,
+      language: Locale.EnglishGb
+    });
+    metaEn.title = 'After edit';
+    await metaEn.save();
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Incomplete);
+    expect(state.translation.export).toBe(TaskListStatus.Incomplete);
+  });
+
+  it('marks both Completed for an update revision where the `reason` metadata key is in scope', async () => {
+    // The reported dataset is an update (Healthy Child Wales Programme has a published
+    // first revision and was being updated). On update revisions, `reason` joins the
+    // translatable keys, and updateTranslations() persists it via a dynamic assignment
+    // that the TS cast at services/dataset.ts:236 doesn't list — useful to confirm
+    // the runtime behaviour is correct.
+    const { dataset, revision } = await seedDataset({ title: 'Update revision title' });
+
+    // Promote the seeded revision to look like an update: bump revisionIndex past 1.
+    // collectTranslations() only checks revisionIndex to decide whether `reason` is in
+    // scope; the previousRevisionId branch (the Unchanged short-circuit) only fires
+    // when previousRevision is also loaded, which it isn't here.
+    revision.revisionIndex = 2;
+    await revision.save();
+
+    // Reload through the same accessor the service uses.
+    const reloadedDataset = await DatasetRepository.getById(dataset.id, withMetadataForTranslation);
+    const metaEn = reloadedDataset.draftRevision!.metadata.find((m) => m.language === Locale.EnglishGb)!;
+    metaEn.reason = 'Annual refresh';
+    await metaEn.save();
+    const metaCy = reloadedDataset.draftRevision!.metadata.find((m) => m.language === Locale.WelshGb)!;
+    metaCy.reason = '';
+    await metaCy.save();
+
+    const refreshed = await DatasetRepository.getById(dataset.id, withMetadataForTranslation);
+    const exported = collectTranslations(refreshed);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+});

--- a/test/integration/services/translation.test.ts
+++ b/test/integration/services/translation.test.ts
@@ -10,6 +10,7 @@ import { dbManager } from '../../../src/db/database-manager';
 import { initPassport } from '../../../src/middleware/passport-auth';
 import { Dataset } from '../../../src/entities/dataset/dataset';
 import { Revision } from '../../../src/entities/dataset/revision';
+import { Dimension } from '../../../src/entities/dataset/dimension';
 import { DimensionMetadata } from '../../../src/entities/dataset/dimension-metadata';
 import { RevisionMetadata } from '../../../src/entities/dataset/revision-metadata';
 import { EventLog } from '../../../src/entities/event-log';
@@ -274,6 +275,49 @@ describe('Translation round trip (SW-1278)', () => {
     metaEn.reason = 'Annual refresh';
     await metaEn.save();
     const metaCy = reloadedDataset.draftRevision!.metadata.find((m) => m.language === Locale.WelshGb)!;
+    metaCy.reason = '';
+    await metaCy.save();
+
+    const refreshed = await DatasetRepository.getById(dataset.id, withMetadataForTranslation);
+    const exported = collectTranslations(refreshed);
+    const imported = fillWelsh(exported);
+
+    await simulateExportThenImport(revision.id, exported, imported, new Date(Date.now() - 60_000));
+
+    const state = await datasetService.getTasklistState(dataset.id, Locale.EnglishGb);
+
+    expect(state.translation.import).toBe(TaskListStatus.Completed);
+    expect(state.translation.export).toBe(TaskListStatus.Completed);
+  });
+
+  it('marks both Completed after a normal import (Welsh filled in) when a dimension key collides with the metadata reason key', async () => {
+    // The exact production repro for SW-1278. The reported dataset has a dimension whose
+    // factTableColumn is "reason", which shares the translation key "reason" with the
+    // metadata reason field on an update revision. collectTranslations emits two rows
+    // keyed "reason" (one dimension, one metadata) and the tasklist diff used to match
+    // on key alone, cross-matching them and flipping export to Incomplete on a no-op
+    // re-import. This drives the real round trip end to end.
+    const { dataset, revision } = await seedDataset({ title: 'Collision dataset' });
+
+    // Update revision → the metadata `reason` key is in scope.
+    revision.revisionIndex = 2;
+    await revision.save();
+
+    // Rename a dimension's column to "reason" so its key collides with metadata reason.
+    const collidingDim = dataset.dimensions[0];
+    collidingDim.factTableColumn = 'reason';
+    await Dimension.getRepository().save(collidingDim);
+    const dimMetaEn = collidingDim.metadata.find((m) => m.language.includes('en'))!;
+    dimMetaEn.name = 'Reason for non-contact';
+    await DimensionMetadata.getRepository().save(dimMetaEn);
+
+    // Give the metadata reason a value distinct from the dimension name — the cross-match
+    // only produces a spurious diff when the two "reason" rows hold different text.
+    const reloaded = await DatasetRepository.getById(dataset.id, withMetadataForTranslation);
+    const metaEn = reloaded.draftRevision!.metadata.find((m) => m.language === Locale.EnglishGb)!;
+    metaEn.reason = 'This update includes the latest annual data.';
+    await metaEn.save();
+    const metaCy = reloaded.draftRevision!.metadata.find((m) => m.language === Locale.WelshGb)!;
     metaCy.reason = '';
     await metaCy.save();
 

--- a/test/integration/services/translation.test.ts
+++ b/test/integration/services/translation.test.ts
@@ -54,7 +54,6 @@ async function seedDataset(opts: {
   collection?: string;
   quality?: string;
   withRelatedLink?: boolean;
-  dimensionColumnNames?: string[];
 }): Promise<SeededDataset> {
   const datasetId = uuidV4();
   const revisionId = uuidV4();

--- a/test/unit/dtos/tasklist-state-dto.test.ts
+++ b/test/unit/dtos/tasklist-state-dto.test.ts
@@ -695,6 +695,203 @@ describe('TasklistStateDTO', () => {
 
       expect(result.import).toBe(TaskListStatus.Incomplete);
     });
+
+    // A publisher reports that after importing
+    // their completed translation CSV, the "Export text fields for translation" tasklist
+    // item flips back to Incomplete, blocking publication. updateTranslations() in
+    // services/dataset.ts sets metaEN/CY.updatedAt = NOW on every successful import, so
+    // post-import the condition `lastExport.createdAt < lastMetaUpdateAt` is always true.
+    // That means exportStale reduces entirely to importStale (changesSinceImport), and
+    // the only way export can revert to Incomplete after import is if collectTranslations()
+    // produces values that do not exactly match the imported CSV data.
+    describe('post-import state (SW-1278)', () => {
+      it('keeps export Completed after a realistic import where updatedAt > lastExport.createdAt', () => {
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: importTime },
+            { language: 'cy', updatedAt: importTime }
+          ]
+        } as unknown as Revision;
+
+        const translationEvents = [
+          {
+            action: 'import',
+            createdAt: importTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]
+          },
+          {
+            action: 'export',
+            createdAt: exportTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: '' }]
+          }
+        ] as unknown as EventLog[];
+
+        mockCollectTranslations.collectTranslations.mockReturnValue([{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]);
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result).toEqual({
+          import: TaskListStatus.Completed,
+          export: TaskListStatus.Completed
+        });
+      });
+
+      it('flips both items to Incomplete when current translations diverge from the last import payload', () => {
+        // The mechanism that invalidates the export item after an import is the
+        // content diff between current state and the import event payload — not
+        // anything timestamp-related on its own. Any divergence (a metadata edit,
+        // a related-link rename, a CSV trim mismatch) flips both items. The
+        // specific divergence used here (trailing whitespace) is incidental.
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: importTime },
+            { language: 'cy', updatedAt: importTime }
+          ]
+        } as unknown as Revision;
+
+        const translationEvents = [
+          {
+            action: 'import',
+            createdAt: importTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]
+          },
+          {
+            action: 'export',
+            createdAt: exportTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: '' }]
+          }
+        ] as unknown as EventLog[];
+
+        mockCollectTranslations.collectTranslations.mockReturnValue([
+          { key: 'title', english: 'Foo ', cymraeg: 'Ffw' }
+        ]);
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result.import).toBe(TaskListStatus.Incomplete);
+        expect(result.export).toBe(TaskListStatus.Incomplete);
+      });
+
+      it('flips export to Incomplete when current value is null but imported value is a string', () => {
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: importTime },
+            { language: 'cy', updatedAt: importTime }
+          ]
+        } as unknown as Revision;
+
+        const translationEvents = [
+          {
+            action: 'import',
+            createdAt: importTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]
+          },
+          {
+            action: 'export',
+            createdAt: exportTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: '' }]
+          }
+        ] as unknown as EventLog[];
+
+        mockCollectTranslations.collectTranslations.mockReturnValue([{ key: 'title', english: null, cymraeg: 'Ffw' }]);
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result.import).toBe(TaskListStatus.Incomplete);
+        expect(result.export).toBe(TaskListStatus.Incomplete);
+      });
+
+      it('flips export to Incomplete when current translations contain a key that was not in the import payload', () => {
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+        const metaEditTime = new Date('2026-05-20T12:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: metaEditTime },
+            { language: 'cy', updatedAt: metaEditTime }
+          ]
+        } as unknown as Revision;
+
+        const translationEvents = [
+          {
+            action: 'import',
+            createdAt: importTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]
+          },
+          {
+            action: 'export',
+            createdAt: exportTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: '' }]
+          }
+        ] as unknown as EventLog[];
+
+        // A new translatable field appeared after the import (e.g. roundingDescription
+        // became visible because roundingApplied was toggled on).
+        mockCollectTranslations.collectTranslations.mockReturnValue([
+          { key: 'title', english: 'Foo', cymraeg: 'Ffw' },
+          { key: 'roundingDescription', english: 'rounded', cymraeg: 'crwn' }
+        ]);
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result.import).toBe(TaskListStatus.Incomplete);
+        expect(result.export).toBe(TaskListStatus.Incomplete);
+      });
+
+      it('correctly flips export to Incomplete when metadata is edited after a successful import', () => {
+        // Legitimate stale case — pin this down so a future fix to SW-1278 doesn't
+        // over-correct and break the case where the user really did change metadata
+        // after importing.
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+        const metaEditTime = new Date('2026-05-20T12:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: metaEditTime },
+            { language: 'cy', updatedAt: metaEditTime }
+          ]
+        } as unknown as Revision;
+
+        const translationEvents = [
+          {
+            action: 'import',
+            createdAt: importTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: 'Ffw' }]
+          },
+          {
+            action: 'export',
+            createdAt: exportTime,
+            data: [{ key: 'title', english: 'Foo', cymraeg: '' }]
+          }
+        ] as unknown as EventLog[];
+
+        // User edited the English title after importing.
+        mockCollectTranslations.collectTranslations.mockReturnValue([
+          { key: 'title', english: 'Foo v2', cymraeg: 'Ffw' }
+        ]);
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result.import).toBe(TaskListStatus.Incomplete);
+        expect(result.export).toBe(TaskListStatus.Incomplete);
+      });
+    });
   });
 
   describe('fromDataset', () => {

--- a/test/unit/dtos/tasklist-state-dto.test.ts
+++ b/test/unit/dtos/tasklist-state-dto.test.ts
@@ -891,6 +891,91 @@ describe('TasklistStateDTO', () => {
         expect(result.import).toBe(TaskListStatus.Incomplete);
         expect(result.export).toBe(TaskListStatus.Incomplete);
       });
+
+      // The actual SW-1278 repro. The affected dataset has a dimension whose
+      // factTableColumn is literally "reason", which shares the key "reason" with
+      // the metadata reason field (the update reason). collectTranslations and the
+      // import payload both contain two rows keyed "reason" that differ only by
+      // `type`. The diff matched on `key` alone, so the metadata "reason" row
+      // cross-matched the dimension "reason" row and reported a spurious change —
+      // flipping export to Incomplete on every import. The collision is structural,
+      // so it fires whether or not the import actually changed anything: covered both
+      // ways below — a no-op re-import of the unchanged file, and the normal flow
+      // where the publisher fills in the Welsh before re-importing.
+      const collidingRows = (cy: { dimension: string; title: string; reason: string }) => [
+        { type: 'dimension', key: 'reason', english: 'Reason for non-contact', cymraeg: cy.dimension },
+        { type: 'metadata', key: 'title', english: 'HCWP', cymraeg: cy.title },
+        {
+          type: 'metadata',
+          key: 'reason',
+          english: 'This update includes the latest annual data.',
+          cymraeg: cy.reason
+        }
+      ];
+
+      const welsh = { dimension: 'Y rheswm am y diffyg cysylltu', title: 'RPIC', reason: 'Diweddariad' };
+
+      it('keeps both items Completed on a no-op re-import of the unchanged file when a dimension key collides with a metadata key', () => {
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: importTime },
+            { language: 'cy', updatedAt: importTime }
+          ]
+        } as unknown as Revision;
+
+        // Welsh already present; the user re-imports the exported file untouched, so
+        // the export, import and current state are all identical.
+        const roundTripped = collidingRows(welsh);
+
+        const translationEvents = [
+          { action: 'import', createdAt: importTime, data: roundTripped },
+          { action: 'export', createdAt: exportTime, data: roundTripped }
+        ] as unknown as EventLog[];
+
+        mockCollectTranslations.collectTranslations.mockReturnValue(collidingRows(welsh));
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result).toEqual({
+          import: TaskListStatus.Completed,
+          export: TaskListStatus.Completed
+        });
+      });
+
+      it('keeps both items Completed after a normal import that fills in the Welsh when a dimension key collides with a metadata key', () => {
+        const dataset = {} as Dataset;
+        const exportTime = new Date('2026-05-20T10:00:00');
+        const importTime = new Date('2026-05-20T11:00:00');
+
+        const revision = {
+          metadata: [
+            { language: 'en', updatedAt: importTime },
+            { language: 'cy', updatedAt: importTime }
+          ]
+        } as unknown as Revision;
+
+        const blank = { dimension: '', title: '', reason: '' };
+
+        // Exported with blank Welsh; the publisher fills it in and re-imports. Current
+        // state matches the imported (now-translated) payload.
+        const translationEvents = [
+          { action: 'import', createdAt: importTime, data: collidingRows(welsh) },
+          { action: 'export', createdAt: exportTime, data: collidingRows(blank) }
+        ] as unknown as EventLog[];
+
+        mockCollectTranslations.collectTranslations.mockReturnValue(collidingRows(welsh));
+
+        const result = TasklistStateDTO.translationStatus(dataset, revision, translationEvents);
+
+        expect(result).toEqual({
+          import: TaskListStatus.Completed,
+          export: TaskListStatus.Completed
+        });
+      });
     });
   });
 

--- a/test/unit/dtos/tasklist-state-dto.test.ts
+++ b/test/unit/dtos/tasklist-state-dto.test.ts
@@ -780,7 +780,7 @@ describe('TasklistStateDTO', () => {
         expect(result.export).toBe(TaskListStatus.Incomplete);
       });
 
-      it('flips export to Incomplete when current value is null but imported value is a string', () => {
+      it('flips both items to Incomplete when current value is null but imported value is a string', () => {
         const dataset = {} as Dataset;
         const exportTime = new Date('2026-05-20T10:00:00');
         const importTime = new Date('2026-05-20T11:00:00');
@@ -813,7 +813,7 @@ describe('TasklistStateDTO', () => {
         expect(result.export).toBe(TaskListStatus.Incomplete);
       });
 
-      it('flips export to Incomplete when current translations contain a key that was not in the import payload', () => {
+      it('flips both items to Incomplete when current translations contain a key that was not in the import payload', () => {
         const dataset = {} as Dataset;
         const exportTime = new Date('2026-05-20T10:00:00');
         const importTime = new Date('2026-05-20T11:00:00');
@@ -852,7 +852,7 @@ describe('TasklistStateDTO', () => {
         expect(result.export).toBe(TaskListStatus.Incomplete);
       });
 
-      it('correctly flips export to Incomplete when metadata is edited after a successful import', () => {
+      it('correctly flips both items to Incomplete when metadata is edited after a successful import', () => {
         // Legitimate stale case — pin this down so a future fix to SW-1278 doesn't
         // over-correct and break the case where the user really did change metadata
         // after importing.


### PR DESCRIPTION
## Summary

Fixes [SW-1278](https://marvellconsulting.atlassian.net/browse/SW-1278): a publisher reported that immediately after importing their completed translation CSV, the **Export text fields for translation** tasklist item flips back to **Incomplete**, blocking publication. Re-importing the exported file *unchanged* reproduces it.

## Root cause

`TasklistStateDTO.translationStatus()` decides whether translations have changed since the last import by diffing the current translations against the import event payload. It matched rows on `key` alone:

```ts
const imported = importedTranslations.find((i) => i.key === t.key);
```

Translation keys are only unique *within a type*, not across types. The affected dataset has a **dimension whose `factTableColumn` is `reason`** ("Reason for non-contact") and a **metadata `reason` field** ("This update includes the latest annual data.") — both rows carry `key: "reason"`. With key-only matching, the metadata `reason` row matches against the dimension `reason` row, the English values differ, and `changesSinceImport` becomes `true` on every import.

Because `updateTranslations()` bumps `updatedAt` to now on import, the `exportStale` condition (`lastExport.createdAt < lastMetaUpdateAt`) is always true post-import, so `exportStale` reduces to `changesSinceImport`. The spurious diff therefore flips export to Incomplete on every import — including a no-op re-import of the exported file.

The collision is structural: it affects any dataset with a dimension column named `title`, `summary`, `collection`, `quality`, or `reason`. This is why the round-trip tests added earlier in this PR passed — none of them had a colliding dimension.

## Fix

Match on both `type` and `key`, which is exactly how `validateImport` already pairs rows (`controllers/translation.ts:110`):

```ts
const imported = importedTranslations.find((i) => i.type === t.type && i.key === t.key);
```

## Tests

Both new tests fail against the unfixed code and pass with the fix.

**Unit (`test/unit/dtos/tasklist-state-dto.test.ts`)** — under `post-import state (SW-1278)`:
- no-op re-import of the unchanged file with a colliding dimension/metadata key
- normal import where the publisher fills in the Welsh before re-importing

**Integration (`test/integration/services/translation.test.ts`)** — the real round trip via `datasetService.updateTranslations()` → `collectTranslations()` → `getTasklistState()`, with an actual dimension renamed to `reason` colliding with the metadata `reason` on an update revision.

The earlier round-trip coverage from this branch (clean round trip, whitespace-padded metadata, apostrophes, related links, metadata-edited-after-import, `reason` in scope) is retained.

## Test plan

- [x] `npm test` passes (1359 tests)
- [x] `npm run check` passes

[SW-1278]: https://marvellconsulting.atlassian.net/browse/SW-1278
