### PR TITLE
SW-1270: fix replacement dataset title showing wrong language on overview

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -81,7 +81,7 @@ export const listPublishedDatasets = async (req: Request, res: Response, next: N
 export const getPublishedDatasetById = async (req: Request, res: Response): Promise<void> => {
   const lang = req.language as Locale;
   const dataset = await PublishedDatasetRepository.getById(res.locals.datasetId, withPublishedRevision);
-  const datasetDTO = ConsumerDatasetDTO.fromDataset(dataset);
+  const datasetDTO = ConsumerDatasetDTO.fromDataset(dataset, lang);
 
   if (dataset.userGroupId) {
     const userGroup = await UserGroupRepository.getByIdWithOrganisation(dataset.userGroupId);

--- a/src/controllers/consumer.ts
+++ b/src/controllers/consumer.ts
@@ -47,7 +47,7 @@ export const listPublishedDatasets = async (req: Request, res: Response, next: N
 
 export const getPublishedDatasetById = async (req: Request, res: Response): Promise<void> => {
   const dataset = await PublishedDatasetRepository.getById(res.locals.datasetId, withAll);
-  const datasetDTO = ConsumerDatasetDTO.fromDataset(dataset);
+  const datasetDTO = ConsumerDatasetDTO.fromDataset(dataset, req.language as Locale);
 
   if (dataset.userGroupId) {
     const userGroup = await UserGroupRepository.getByIdWithOrganisation(dataset.userGroupId);

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -152,7 +152,7 @@ export const getDatasetById = async (req: Request, res: Response): Promise<void>
       break;
   }
 
-  const datasetDTO = DatasetDTO.fromDataset(dataset);
+  const datasetDTO = DatasetDTO.fromDataset(dataset, req.language as Locale);
 
   if (userGroup) {
     datasetDTO.publisher = PublisherDTO.fromUserGroup(userGroup, req.language as Locale);

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -7,6 +7,7 @@ import { Revision } from '../entities/dataset/revision';
 import { DimensionDTO } from './dimension-dto';
 import { ConsumerRevisionDTO } from './consumer-revision-dto';
 import { PublisherDTO } from './publisher-dto';
+import { Locale } from '../enums/locale';
 
 // WARNING: Make sure to filter any props the consumer side should not have access to
 export class ConsumerDatasetDTO {
@@ -21,16 +22,17 @@ export class ConsumerDatasetDTO {
   end_date?: string;
   publisher?: PublisherDTO;
 
-  static fromDataset(dataset: Dataset): ConsumerDatasetDTO {
+  static fromDataset(dataset: Dataset, lang: Locale = Locale.English): ConsumerDatasetDTO {
     const dto = new ConsumerDatasetDTO();
     dto.id = dataset.id;
     dto.first_published_at = dataset.firstPublishedAt?.toISOString();
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     if (dataset.replacementDatasetId) {
+      const metadata = dataset.replacementDataset?.publishedRevision?.metadata;
       dto.replaced_by = {
         dataset_id: dataset.replacementDatasetId,
-        dataset_title: dataset.replacementDataset?.publishedRevision?.metadata?.[0]?.title ?? undefined,
+        dataset_title: metadata?.find((m) => m.language.includes(lang))?.title ?? undefined,
         auto_redirect: dataset.replacementAutoRedirect ?? false
       };
     }

--- a/src/dtos/consumer-dataset-dto.ts
+++ b/src/dtos/consumer-dataset-dto.ts
@@ -30,9 +30,10 @@ export class ConsumerDatasetDTO {
 
     if (dataset.replacementDatasetId) {
       const metadata = dataset.replacementDataset?.publishedRevision?.metadata;
+      const langCode = lang.toLowerCase();
       dto.replaced_by = {
         dataset_id: dataset.replacementDatasetId,
-        dataset_title: metadata?.find((m) => m.language.includes(lang))?.title ?? undefined,
+        dataset_title: metadata?.find((m) => m.language.toLowerCase().includes(langCode))?.title ?? undefined,
         auto_redirect: dataset.replacementAutoRedirect ?? false
       };
     }

--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -47,9 +47,10 @@ export class DatasetDTO {
 
     if (dataset.replacementDatasetId) {
       const metadata = dataset.replacementDataset?.publishedRevision?.metadata;
+      const langCode = lang.toLowerCase();
       dto.replaced_by = {
         dataset_id: dataset.replacementDatasetId,
-        dataset_title: metadata?.find((m) => m.language.includes(lang))?.title ?? undefined,
+        dataset_title: metadata?.find((m) => m.language.toLowerCase().includes(langCode))?.title ?? undefined,
         auto_redirect: dataset.replacementAutoRedirect ?? false
       };
     }

--- a/src/dtos/dataset-dto.ts
+++ b/src/dtos/dataset-dto.ts
@@ -9,6 +9,7 @@ import { FactTableColumnDto } from './fact-table-column-dto';
 import { TaskDTO } from './task-dto';
 import { Task } from '../entities/task/task';
 import { PublisherDTO } from './publisher-dto';
+import { Locale } from '../enums/locale';
 
 export class DatasetDTO {
   id: string;
@@ -35,7 +36,7 @@ export class DatasetDTO {
   tasks?: TaskDTO[];
   publisher?: PublisherDTO;
 
-  static fromDataset(dataset: Dataset): DatasetDTO {
+  static fromDataset(dataset: Dataset, lang: Locale = Locale.English): DatasetDTO {
     const dto = new DatasetDTO();
     dto.id = dataset.id;
     dto.created_at = dataset.createdAt.toISOString();
@@ -45,9 +46,10 @@ export class DatasetDTO {
     dto.archived_at = dataset.archivedAt?.toISOString();
 
     if (dataset.replacementDatasetId) {
+      const metadata = dataset.replacementDataset?.publishedRevision?.metadata;
       dto.replaced_by = {
         dataset_id: dataset.replacementDatasetId,
-        dataset_title: dataset.replacementDataset?.publishedRevision?.metadata?.[0]?.title ?? undefined,
+        dataset_title: metadata?.find((m) => m.language.includes(lang))?.title ?? undefined,
         auto_redirect: dataset.replacementAutoRedirect ?? false
       };
     }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -111,7 +111,9 @@ export class TaskService {
         if (replacement.archivedAt) {
           throw new BadRequestException('errors.request_archive.replacement_archived');
         }
-        const title = replacement.publishedRevision?.metadata?.find((m) => m.language.includes(Locale.English))?.title;
+        const title = replacement.publishedRevision?.metadata?.find((m) =>
+          m.language.toLowerCase().includes(Locale.English)
+        )?.title;
         metadata.replacementDatasetId = replacementDatasetId;
         metadata.replacementDatasetTitle = title;
         metadata.autoRedirect = autoRedirect ?? false;

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -10,6 +10,7 @@ import { PublishedDatasetRepository } from '../repositories/published-dataset';
 import { getPublishingStatus } from '../utils/dataset-status';
 import { PublishingStatus } from '../enums/publishing-status';
 import { BadRequestException } from '../exceptions/bad-request.exception';
+import { Locale } from '../enums/locale';
 
 export class TaskService {
   async create(
@@ -110,7 +111,7 @@ export class TaskService {
         if (replacement.archivedAt) {
           throw new BadRequestException('errors.request_archive.replacement_archived');
         }
-        const title = replacement.publishedRevision?.metadata?.[0]?.title;
+        const title = replacement.publishedRevision?.metadata?.find((m) => m.language.includes(Locale.English))?.title;
         metadata.replacementDatasetId = replacementDatasetId;
         metadata.replacementDatasetTitle = title;
         metadata.autoRedirect = autoRedirect ?? false;

--- a/test/unit/dtos/consumer-dataset-dto.test.ts
+++ b/test/unit/dtos/consumer-dataset-dto.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../../src/dtos/publisher-dto', () => ({
 
 import { Dataset } from '../../../src/entities/dataset/dataset';
 import { ConsumerDatasetDTO } from '../../../src/dtos/consumer-dataset-dto';
+import { Locale } from '../../../src/enums/locale';
 import { ConsumerRevisionDTO } from '../../../src/dtos/consumer-revision-dto';
 import { DimensionDTO } from '../../../src/dtos/dimension-dto';
 
@@ -51,13 +52,20 @@ describe('ConsumerDatasetDTO', () => {
       expect(dto.replaced_by).toBeUndefined();
     });
 
-    it('should populate replaced_by when replacementDatasetId is set', () => {
+    it('should populate replaced_by with the English replacement title by default', () => {
+      // Welsh metadata is deliberately first in the array to guard against the previous
+      // metadata[0] bug that returned whichever language happened to be first.
       const dto = ConsumerDatasetDTO.fromDataset(
         makeDataset({
           replacementDatasetId: 'rep-ds-1',
           replacementAutoRedirect: true,
           replacementDataset: {
-            publishedRevision: { metadata: [{ title: 'Replacement Title' }] }
+            publishedRevision: {
+              metadata: [
+                { language: 'cy-GB', title: 'Teitl Cymraeg' },
+                { language: 'en-GB', title: 'Replacement Title' }
+              ]
+            }
           }
         })
       );
@@ -67,6 +75,26 @@ describe('ConsumerDatasetDTO', () => {
         dataset_title: 'Replacement Title',
         auto_redirect: true
       });
+    });
+
+    it('should resolve the replacement title in the requested language', () => {
+      const dataset = makeDataset({
+        replacementDatasetId: 'rep-ds-1',
+        replacementAutoRedirect: true,
+        replacementDataset: {
+          publishedRevision: {
+            metadata: [
+              { language: 'cy-GB', title: 'Teitl Cymraeg' },
+              { language: 'en-GB', title: 'Replacement Title' }
+            ]
+          }
+        }
+      });
+
+      expect(ConsumerDatasetDTO.fromDataset(dataset, Locale.English).replaced_by?.dataset_title).toBe(
+        'Replacement Title'
+      );
+      expect(ConsumerDatasetDTO.fromDataset(dataset, Locale.Welsh).replaced_by?.dataset_title).toBe('Teitl Cymraeg');
     });
 
     it('should default auto_redirect to false when replacementAutoRedirect is falsy', () => {

--- a/test/unit/dtos/consumer-dataset-dto.test.ts
+++ b/test/unit/dtos/consumer-dataset-dto.test.ts
@@ -97,6 +97,29 @@ describe('ConsumerDatasetDTO', () => {
       expect(ConsumerDatasetDTO.fromDataset(dataset, Locale.Welsh).replaced_by?.dataset_title).toBe('Teitl Cymraeg');
     });
 
+    it('should match the replacement language case-insensitively', () => {
+      const dataset = makeDataset({
+        replacementDatasetId: 'rep-ds-1',
+        replacementAutoRedirect: true,
+        replacementDataset: {
+          publishedRevision: {
+            metadata: [
+              { language: 'cy-GB', title: 'Teitl Cymraeg' },
+              { language: 'en-GB', title: 'Replacement Title' }
+            ]
+          }
+        }
+      });
+
+      // request language may arrive as a lower-case full locale (e.g. 'en-gb')
+      expect(ConsumerDatasetDTO.fromDataset(dataset, 'en-gb' as Locale).replaced_by?.dataset_title).toBe(
+        'Replacement Title'
+      );
+      expect(ConsumerDatasetDTO.fromDataset(dataset, 'cy-gb' as Locale).replaced_by?.dataset_title).toBe(
+        'Teitl Cymraeg'
+      );
+    });
+
     it('should default auto_redirect to false when replacementAutoRedirect is falsy', () => {
       const dto = ConsumerDatasetDTO.fromDataset(
         makeDataset({

--- a/test/unit/dtos/dataset-dto.test.ts
+++ b/test/unit/dtos/dataset-dto.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../../src/dtos/task-dto', () => ({
 
 import { Dataset } from '../../../src/entities/dataset/dataset';
 import { DatasetDTO } from '../../../src/dtos/dataset-dto';
+import { Locale } from '../../../src/enums/locale';
 import { DimensionDTO } from '../../../src/dtos/dimension-dto';
 import { RevisionDTO } from '../../../src/dtos/revision-dto';
 import { MeasureDTO } from '../../../src/dtos/measure-dto';
@@ -190,13 +191,20 @@ describe('DatasetDTO', () => {
       expect(dto.replaced_by).toBeUndefined();
     });
 
-    it('should populate replaced_by when replacementDatasetId is set', () => {
+    it('should populate replaced_by with the English replacement title by default', () => {
+      // Welsh metadata is deliberately first in the array to guard against the previous
+      // metadata[0] bug that returned whichever language happened to be first.
       const dto = DatasetDTO.fromDataset(
         makeDataset({
           replacementDatasetId: 'rep-ds-1',
           replacementAutoRedirect: true,
           replacementDataset: {
-            publishedRevision: { metadata: [{ title: 'Replacement Title' }] }
+            publishedRevision: {
+              metadata: [
+                { language: 'cy-GB', title: 'Teitl Cymraeg' },
+                { language: 'en-GB', title: 'Replacement Title' }
+              ]
+            }
           }
         })
       );
@@ -206,6 +214,24 @@ describe('DatasetDTO', () => {
         dataset_title: 'Replacement Title',
         auto_redirect: true
       });
+    });
+
+    it('should resolve the replacement title in the requested language', () => {
+      const dataset = makeDataset({
+        replacementDatasetId: 'rep-ds-1',
+        replacementAutoRedirect: true,
+        replacementDataset: {
+          publishedRevision: {
+            metadata: [
+              { language: 'cy-GB', title: 'Teitl Cymraeg' },
+              { language: 'en-GB', title: 'Replacement Title' }
+            ]
+          }
+        }
+      });
+
+      expect(DatasetDTO.fromDataset(dataset, Locale.English).replaced_by?.dataset_title).toBe('Replacement Title');
+      expect(DatasetDTO.fromDataset(dataset, Locale.Welsh).replaced_by?.dataset_title).toBe('Teitl Cymraeg');
     });
 
     it('should default auto_redirect to false when replacementAutoRedirect is falsy', () => {

--- a/test/unit/dtos/dataset-dto.test.ts
+++ b/test/unit/dtos/dataset-dto.test.ts
@@ -234,6 +234,25 @@ describe('DatasetDTO', () => {
       expect(DatasetDTO.fromDataset(dataset, Locale.Welsh).replaced_by?.dataset_title).toBe('Teitl Cymraeg');
     });
 
+    it('should match the replacement language case-insensitively', () => {
+      const dataset = makeDataset({
+        replacementDatasetId: 'rep-ds-1',
+        replacementAutoRedirect: true,
+        replacementDataset: {
+          publishedRevision: {
+            metadata: [
+              { language: 'cy-GB', title: 'Teitl Cymraeg' },
+              { language: 'en-GB', title: 'Replacement Title' }
+            ]
+          }
+        }
+      });
+
+      // request language may arrive as a lower-case full locale (e.g. 'en-gb')
+      expect(DatasetDTO.fromDataset(dataset, 'en-gb' as Locale).replaced_by?.dataset_title).toBe('Replacement Title');
+      expect(DatasetDTO.fromDataset(dataset, 'cy-gb' as Locale).replaced_by?.dataset_title).toBe('Teitl Cymraeg');
+    });
+
     it('should default auto_redirect to false when replacementAutoRedirect is falsy', () => {
       const dto = DatasetDTO.fromDataset(
         makeDataset({


### PR DESCRIPTION
## What

Fixes [SW-1270](https://marvell-consulting.atlassian.net/browse/SW-1270): on the publisher overview, the link to an archived dataset's replacement displayed its title in Welsh even in an English session. The link target was correct (it uses the dataset id) — only the displayed title was the wrong language.

## Why it happened

`DatasetDTO.fromDataset` and `ConsumerDatasetDTO.fromDataset` resolved the replacement title with `metadata?.[0]?.title` — the first metadata row in the array, regardless of language. Each revision stores one metadata row per locale (`en-GB` / `cy-GB`, built from `SUPPORTED_LOCALES` in `repositories/revision.ts`), and array order isn't guaranteed, so the Welsh row could win.

The frontend publisher overview (`overview.jsx`) renders `replaced_by.dataset_title` as the link text, which is why the wrong-language title showed while the link still worked.

## Fix

- Resolve the replacement title by the request language using the existing `PublisherDTO` pattern: `metadata?.find((m) => m.language.includes(lang))?.title`. (`.includes` because the request language is the short code `en`/`cy` while metadata is stored as `en-GB`/`cy-GB`.)
- Add an optional `lang: Locale = Locale.English` parameter to both DTOs' `fromDataset`, and pass `req.language` from the controllers that load the replacement metadata (`dataset.ts` overview, `consumer.ts`, `consumer-v2.ts`).
- `services/task.ts` now snapshots a deterministic English replacement title when an archive is requested, instead of `metadata[0]`.

Only loads that include the replacement relation can hit this (`getDatasetOverview`, `withAll`, `withPublishedRevision`); other call sites are unaffected, so the optional default keeps them untouched.

## Tests

Updated both DTO unit tests so the metadata array lists Welsh first (reproducing the old bug) and asserts English-by-default plus correct per-language resolution.

## Verification

- `tsc --noEmit`, prettier, eslint: clean
- Unit suite: 938 passed
- Affected integration routes (`consumer-v1`/`consumer-v2` dataset-metadata): 22 passed


[SW-1270]: https://marvellconsulting.atlassian.net/browse/SW-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ