### PR TITLE
Fix flaky CI cube-build integration tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -41,6 +41,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    # Cache the DuckDB extension dir so the postgres extension installed in global-setup is
+    # restored offline on subsequent runs. Keyed on the lockfile so a DuckDB version bump busts it.
+    - name: Cache DuckDB extensions
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.duckdb
+        key: duckdb-ext-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          duckdb-ext-${{ runner.os }}-
     - run: npm ci
     - run: npm run prettier:ci
     - run: npm run lint:ci

--- a/test/helpers/global-setup.ts
+++ b/test/helpers/global-setup.ts
@@ -1,11 +1,38 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { Client } from 'pg';
+import { DuckDBInstance } from '@duckdb/node-api';
 
 interface GlobalConfig {
   maxWorkers: number;
 }
 
 const BASE_DB = 'statswales-backend-test';
+
+// Pre-install the DuckDB `postgres` extension once, in this single setup process, before any
+// Jest workers spawn. The app only ever calls `LOAD 'postgres'` (src/services/duckdb.ts), which
+// otherwise triggers a per-worker autoinstall: every worker races to download the extension into
+// the shared ~/.duckdb cache, and a network blip or concurrent partial write surfaces as
+// `IO Error: Extension "...postgres_scanner.duckdb_extension" not found`. Installing once here
+// populates that cache so each worker's LOAD is a local, offline operation.
+async function installPostgresExtension(): Promise<void> {
+  const attempts = 3;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const instance = await DuckDBInstance.create(':memory:');
+    const conn = await instance.connect();
+    try {
+      await conn.run(`INSTALL postgres;`);
+      return;
+    } catch (err) {
+      if (attempt === attempts) {
+        throw new Error(`Failed to install DuckDB postgres extension after ${attempts} attempts: ${err}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    } finally {
+      conn.disconnectSync();
+      instance.closeSync();
+    }
+  }
+}
 
 // Read connection params with the same defaults as jest-setup.ts
 const host = process.env.TEST_DB_HOST ?? 'localhost';
@@ -18,6 +45,8 @@ export default async function globalSetup(globalConfig: GlobalConfig): Promise<v
 
   mkdirSync('coverage', { recursive: true });
   writeFileSync('coverage/.jest-workers', String(workerCount));
+
+  await installPostgresExtension();
 
   const client = new Client({ host, port, user, password, database: 'postgres' });
   await client.connect();

--- a/test/helpers/global-setup.ts
+++ b/test/helpers/global-setup.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { Client } from 'pg';
-import { DuckDBInstance } from '@duckdb/node-api';
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
 
 interface GlobalConfig {
   maxWorkers: number;
@@ -17,9 +17,11 @@ const BASE_DB = 'statswales-backend-test';
 async function installPostgresExtension(): Promise<void> {
   const attempts = 3;
   for (let attempt = 1; attempt <= attempts; attempt++) {
-    const instance = await DuckDBInstance.create(':memory:');
-    const conn = await instance.connect();
+    let instance: DuckDBInstance | undefined;
+    let conn: DuckDBConnection | undefined;
     try {
+      instance = await DuckDBInstance.create(':memory:');
+      conn = await instance.connect();
       await conn.run(`INSTALL postgres;`);
       return;
     } catch (err) {
@@ -28,8 +30,8 @@ async function installPostgresExtension(): Promise<void> {
       }
       await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
     } finally {
-      conn.disconnectSync();
-      instance.closeSync();
+      conn?.disconnectSync();
+      instance?.closeSync();
     }
   }
 }

--- a/test/helpers/reset-database.ts
+++ b/test/helpers/reset-database.ts
@@ -3,8 +3,44 @@ import { dbManager } from '../../src/db/database-manager';
 // Registered at import time (synchronous, before any test runs) so jest-circus allows it.
 // Each test file gets its own module instance, so each file gets its own afterAll registration.
 afterAll(async () => {
+  // Drain any in-flight queries before tearing down the pools. The cube-builder fires its
+  // validation-cube cleanup as an unawaited `void cleanUpValidationCube(...)` (DROP SCHEMA CASCADE)
+  // in src/services/revision.ts, so it can still be running when a test ends. Destroying the data
+  // source mid-query surfaces as "Connection terminated"; letting it race resetDatabase's own
+  // DROP SCHEMA surfaces as `relation "<id>.core_view_en" does not exist`.
+  await waitForIdleConnections();
   await dbManager.destroyDataSources();
 });
+
+/**
+ * Waits until this worker's database has no active queries other than our own, so that fire-and-forget
+ * background work (e.g. the cube-builder's unawaited validation-cube cleanup) has settled before we
+ * reset schemas or destroy the connection pools. Best-effort: returns on timeout or query error rather
+ * than failing the suite. Both data sources point at the same per-worker DB, so polling pg_stat_activity
+ * on the app pool also covers in-flight work on the cube pool.
+ */
+async function waitForIdleConnections(timeoutMs = 10000, intervalMs = 50): Promise<void> {
+  if (!dbManager.getAppDataSource().isInitialized) return;
+  const deadline = Date.now() + timeoutMs;
+  const qr = dbManager.getAppDataSource().createQueryRunner();
+  try {
+    while (Date.now() < deadline) {
+      const rows: { active: number }[] = await qr.query(`
+        SELECT count(*)::int AS active
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND pid <> pg_backend_pid()
+          AND state = 'active'
+      `);
+      if ((rows[0]?.active ?? 0) === 0) return;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  } catch {
+    // best-effort drain — fall through to teardown/reset
+  } finally {
+    await qr.release();
+  }
+}
 
 /**
  * Initialises the dbManager and runs pending migrations for this test file's module instance.
@@ -22,6 +58,9 @@ export async function ensureWorkerDataSources(): Promise<void> {
  * drops/recreates the dynamic cube schemas so the next suite starts with a clean slate.
  */
 export async function resetDatabase(): Promise<void> {
+  // Let any unawaited cube-builder cleanup finish before we drop the dynamic schemas, otherwise the
+  // two DROP SCHEMA CASCADE statements race on the same UUID schema.
+  await waitForIdleConnections();
   const qr = dbManager.getAppDataSource().createQueryRunner();
   try {
     const tables: { tablename: string }[] = await qr.query(`

--- a/test/helpers/reset-database.ts
+++ b/test/helpers/reset-database.ts
@@ -30,6 +30,7 @@ async function waitForIdleConnections(timeoutMs = 10000, intervalMs = 50): Promi
         FROM pg_stat_activity
         WHERE datname = current_database()
           AND pid <> pg_backend_pid()
+          AND backend_type = 'client backend'
           AND state = 'active'
       `);
       if ((rows[0]?.active ?? 0) === 0) return;
@@ -38,7 +39,13 @@ async function waitForIdleConnections(timeoutMs = 10000, intervalMs = 50): Promi
   } catch {
     // best-effort drain — fall through to teardown/reset
   } finally {
-    await qr.release();
+    // release() can itself reject (e.g. the connection already dropped); swallow it so the
+    // best-effort drain never fails the suite.
+    try {
+      await qr.release();
+    } catch {
+      // ignore
+    }
   }
 }
 


### PR DESCRIPTION
## What

Fixes the intermittent failures in the `Node.js CI` integration tests (the cube-build pipeline). Two distinct symptoms, both test-infrastructure races rather than test-logic bugs — each failure hit a different cube-building test and a plain re-run went green.

## Symptom 1 — `IO Error: Extension "...postgres_scanner.duckdb_extension" not found`

The app only ever calls `LOAD 'postgres'` (`src/services/duckdb.ts`); there is no `INSTALL postgres` anywhere. `LOAD` therefore falls through to DuckDB's autoload → autoinstall, a network download into the shared `~/.duckdb` cache. Each Jest worker creates its own `DuckDBInstance` and races to download into that cache; CI doesn't cache `~/.duckdb`. A network blip or concurrent partial write surfaces as "not found".

Fix:
- `test/helpers/global-setup.ts` pre-installs the extension once, in the single setup process before any worker spawns (with a few retries). Workers' `LOAD` then hits the local cache.
- `.github/workflows/node-test.yml` caches `~/.duckdb`, keyed on the lockfile hash so a DuckDB version bump invalidates it.

## Symptom 2 — `Connection terminated` / `relation "<id>.core_view_en" does not exist`

The cube-builder fires its validation-cube cleanup as `void cleanUpValidationCube(...)` (a `DROP SCHEMA CASCADE`) in `src/services/revision.ts`. This is intentional in production — it lets the HTTP response return without blocking on cleanup, and a cleanup failure is non-fatal. But in tests that unawaited query can still be running when the per-file `afterAll` destroys the connection pool ("Connection terminated"), or it can race `resetDatabase`'s own `DROP SCHEMA CASCADE` on the same UUID schema (`relation ... does not exist`, then a consumer-download test 500s).

Fix (test-only — production behaviour unchanged):
- `test/helpers/reset-database.ts` adds `waitForIdleConnections()`, which polls `pg_stat_activity` for active queries on the worker DB (best-effort, up to 10s) and is called at the start of `resetDatabase()` and in the `afterAll` before destroying the data sources. This drains the intentional background cleanup before reset/teardown.

## Testing

- Verified `INSTALL`-then-`LOAD 'postgres'` succeeds offline on a fresh instance.
- Integration suite run 3× at the CI-equivalent `--maxWorkers=2`: 30/30 suites and 416/416 tests green each time, with zero `Connection terminated` and zero `core_view ... does not exist`.
- prettier / eslint / tsc clean on the changed files. (`prettier:ci` only globs `{src,test}/**/*.ts`, so the workflow YAML is intentionally left hand-formatted.)

## Notes

- `actions/cache` is pinned to `0057852bfaa89a56745cba8c7296529d2fc39830` (v4.3.0), verified against the upstream tag list.
- No production code changed.
