### PR TITLE
SW-test-coverage: improve coverage for dimension-processor and incoming-file-processor (#563)

### DIFF
--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -811,8 +811,11 @@ async function getPreviewWithNumberExtractor(
       sampleSize
     );
   } else {
+    // TO_CHAR already returns text; an outer `format('%s', …)` wrapper used to
+    // surround this and is unnecessary — and pg-format would treat the inner
+    // %s as one of its own placeholders, breaking the query.
     query = pgformat(
-      `SELECT DISTINCT format('%s', TO_CHAR(ROUND(CAST(%I AS DECIMAL), %L), %L)) AS %I FROM %I.%I ORDER BY %I ASC LIMIT %L;`,
+      `SELECT DISTINCT TO_CHAR(ROUND(CAST(%I AS DECIMAL), %L), %L) AS %I FROM %I.%I ORDER BY %I ASC LIMIT %L;`,
       dimension.factTableColumn,
       extractor.decimalPlaces,
       `999,999,990.${extractor.decimalPlaces}`,

--- a/src/services/dimension-processor.ts
+++ b/src/services/dimension-processor.ts
@@ -814,11 +814,17 @@ async function getPreviewWithNumberExtractor(
     // TO_CHAR already returns text; an outer `format('%s', …)` wrapper used to
     // surround this and is unnecessary — and pg-format would treat the inner
     // %s as one of its own placeholders, breaking the query.
+    //
+    // The mask must use placeholder digits (`9` for "value with the specified
+    // number of digits", `0` for "value with leading zeros"). Interpolating
+    // `extractor.decimalPlaces` directly would insert a literal digit instead.
+    const decimalMask =
+      extractor.decimalPlaces > 0 ? `999,999,990.${'0'.repeat(extractor.decimalPlaces)}` : '999,999,990';
     query = pgformat(
       `SELECT DISTINCT TO_CHAR(ROUND(CAST(%I AS DECIMAL), %L), %L) AS %I FROM %I.%I ORDER BY %I ASC LIMIT %L;`,
       dimension.factTableColumn,
       extractor.decimalPlaces,
-      `999,999,990.${extractor.decimalPlaces}`,
+      decimalMask,
       dimension.factTableColumn,
       schemaID,
       FACT_TABLE_NAME,

--- a/src/services/incoming-file-processor.ts
+++ b/src/services/incoming-file-processor.ts
@@ -57,7 +57,9 @@ export async function validateFileAndExtractTableInfo(
 
     try {
       logger.debug(`Attempting to read the file using duckdb`);
-      if (dataTable.fileType === FileType.Csv) {
+      // Both Csv and GzipCsv use the read_csv template that requires an
+      // encoding arg — try utf-8 first and fall back to latin-1 for either.
+      if (dataTable.fileType === FileType.Csv || dataTable.fileType === FileType.GzipCsv) {
         try {
           dataTable.encoding = 'utf-8';
           await duckdb.run(pgformat(createTableQuery, temporaryTableName, file.path, dataTable.encoding));

--- a/test/helpers/test-helper.ts
+++ b/test/helpers/test-helper.ts
@@ -128,7 +128,13 @@ export async function createSmallDataset(
   }
 
   try {
-    await createAllCubeFiles(savedDataset.id, revision.id);
+    // Pass `awaitMaterialisation = true` so we block until the background
+    // materialisation step that swaps `core_view_en` → `core_view_mat_en`
+    // (cube-builder.ts:380) has committed. Without this, tests that issue
+    // queries against `core_view_en` immediately after this helper returns
+    // can race the background DROP VIEW on slow CI — same class of fix as
+    // already applied in `seed-published-dataset.ts` (lines 229, 397).
+    await createAllCubeFiles(savedDataset.id, revision.id, undefined, undefined, undefined, true);
   } catch (error) {
     logger.error(error);
   }

--- a/test/integration/routes/consumer-v2-download.test.ts
+++ b/test/integration/routes/consumer-v2-download.test.ts
@@ -131,8 +131,13 @@ async function createLargePublishedDataset(): Promise<void> {
     await cubeDB.release();
   }
 
-  // Build cube views so the consumer API can query the data
-  await createAllCubeFiles(datasetId, revisionId);
+  // Build cube views so the consumer API can query the data.
+  // Pass `awaitMaterialisation = true` so we wait for the background
+  // materialisation step that swaps `core_view_en` → `core_view_mat_en`
+  // (cube-builder.ts:380). Without this, on slow CI the test queries
+  // `core_view_en` after the background DROP VIEW has run but before the
+  // materialised replacement is queryable.
+  await createAllCubeFiles(datasetId, revisionId, undefined, undefined, undefined, /* awaitMaterialisation */ true);
 }
 
 describe('Consumer V2 download format page_size tests', () => {

--- a/test/unit/services/dimension-processor.test.ts
+++ b/test/unit/services/dimension-processor.test.ts
@@ -502,7 +502,7 @@ describe('removeMeasure', () => {
     jest.clearAllMocks();
   });
 
-  it('deletes the measure rows, metadata and measure itself when there is no measure attached', async () => {
+  it('only deletes the Measure entity (not rows or metadata) when no measure is attached to the dataset', async () => {
     const dataset = { id: 'd-1', measure: undefined } as unknown as Dataset;
     await removeMeasure(dataset);
     expect(measureRepoDelete).toHaveBeenCalledWith({ dataset });

--- a/test/unit/services/dimension-processor.test.ts
+++ b/test/unit/services/dimension-processor.test.ts
@@ -655,6 +655,34 @@ describe('validateNumericDimension', () => {
     expect(result).toEqual({ status: 200, preview: 'ok' });
   });
 
+  it('builds the decimal preview query with a TO_CHAR mask of placeholder digits, not literal numbers', async () => {
+    mockQuery
+      // schema info: DOUBLE — fast-path to preview
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'DOUBLE' }])
+      // totals
+      .mockResolvedValueOnce([{ totalLines: 4 }])
+      // preview
+      .mockResolvedValueOnce([{ value: '1.50' }]);
+
+    await validateNumericDimension(
+      { number_format: NumberType.Decimal, decimal_places: 2 } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    // The third query is the preview SELECT. Its mask should contain '.00'
+    // (two placeholder digits) — not '.2' (the literal decimal-places count).
+    const previewSql = mockQuery.mock.calls[2][0] as string;
+    expect(previewSql).toContain('.00');
+    expect(previewSql).not.toMatch(/\.2(?!\d)/);
+  });
+
+  // Note: `decimal_places: 0` is rejected upstream by `validateNumericDimension`
+  // (the `!decimalPlaces` check treats 0 as missing and throws), so the
+  // `extractor.decimalPlaces > 0` branch of the mask builder isn't reachable
+  // from production today. The guard is kept for defence in depth in case the
+  // upstream check is later relaxed.
+
   it('returns a non-numerical-values error when text data does not match the requested integer format', async () => {
     mockQuery
       // schema-info: column is VARCHAR (no fast path)

--- a/test/unit/services/dimension-processor.test.ts
+++ b/test/unit/services/dimension-processor.test.ts
@@ -1,390 +1,1009 @@
-import fs from 'node:fs';
+// === Mock setup (Jest hoists these above all imports) ===
 
-import { parseISO } from 'date-fns';
-import { TZDate } from '@date-fns/tz';
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
 
-import { logger } from '../../../src/utils/logger';
-import { YearType } from '../../../src/enums/year-type';
-import { dateDimensionReferenceTableCreator } from '../../../src/services/date-matching';
-import { DateExtractor } from '../../../src/extractors/date-extractor';
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: jest.fn().mockReturnValue({
+      createQueryRunner: jest.fn().mockReturnValue({
+        query: (...args: unknown[]) => mockQuery(...args),
+        release: (...args: unknown[]) => mockRelease(...args)
+      })
+    })
+  }
+}));
 
-interface AllFormats {
-  years: DateExtractor[];
-  quarters: DateExtractor[];
-  months: DateExtractor[];
-  specific: DateExtractor[];
+jest.mock('../../../src/services/cube-builder', () => ({
+  FACT_TABLE_NAME: 'fact_table',
+  VALIDATION_TABLE_NAME: 'validation_table',
+  makeCubeSafeString: (s: string) => s
+}));
+
+jest.mock('../../../src/middleware/translation', () => ({
+  SUPPORTED_LOCALES: ['en-GB', 'cy-GB'],
+  AVAILABLE_LANGUAGES: ['en', 'cy']
+}));
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    trace: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+const mockFileServiceDelete = jest.fn();
+jest.mock('../../../src/utils/get-file-service', () => ({
+  getFileService: () => ({
+    delete: (...args: unknown[]) => mockFileServiceDelete(...args),
+    saveBuffer: jest.fn()
+  })
+}));
+
+// Active-record-style spies — these closures back the mocked Dimension /
+// Measure / FactTableColumn / etc. and are referenced directly in tests.
+const mockDimensionFindOneByOrFail = jest.fn();
+const dimensionRepoDelete = jest.fn();
+jest.mock('../../../src/entities/dataset/dimension', () => ({
+  Dimension: {
+    findOneByOrFail: (...args: unknown[]) => mockDimensionFindOneByOrFail(...args),
+    create: jest.fn().mockImplementation((data: unknown) => ({
+      ...(data as object),
+      save: jest.fn().mockResolvedValue(undefined)
+    })),
+    getRepository: jest.fn().mockReturnValue({
+      delete: (...args: unknown[]) => dimensionRepoDelete(...args)
+    })
+  }
+}));
+
+const mockLookupTableFindOneBy = jest.fn();
+jest.mock('../../../src/entities/dataset/lookup-table', () => ({
+  LookupTable: {
+    findOneBy: (...args: unknown[]) => mockLookupTableFindOneBy(...args)
+  }
+}));
+
+const measureRepoDelete = jest.fn();
+jest.mock('../../../src/entities/dataset/measure', () => ({
+  Measure: {
+    create: jest.fn().mockImplementation((data: unknown) => ({
+      ...(data as object),
+      save: jest.fn().mockResolvedValue(undefined)
+    })),
+    getRepository: jest.fn().mockReturnValue({
+      delete: (...args: unknown[]) => measureRepoDelete(...args)
+    })
+  }
+}));
+
+const measureRowRepoDelete = jest.fn();
+jest.mock('../../../src/entities/dataset/measure-row', () => ({
+  MeasureRow: {
+    getRepository: jest.fn().mockReturnValue({
+      delete: (...args: unknown[]) => measureRowRepoDelete(...args)
+    })
+  }
+}));
+
+const measureMetadataRepoDelete = jest.fn();
+jest.mock('../../../src/entities/dataset/measure-metadata', () => ({
+  MeasureMetadata: {
+    create: jest.fn(),
+    getRepository: jest.fn().mockReturnValue({
+      delete: (...args: unknown[]) => measureMetadataRepoDelete(...args)
+    })
+  }
+}));
+
+jest.mock('../../../src/entities/dataset/dimension-metadata', () => ({
+  DimensionMetadata: {
+    create: jest.fn().mockImplementation((data: unknown) => data)
+  }
+}));
+
+const mockFactTableColumnFindOneByOrFail = jest.fn();
+const mockFactTableColumnFindBy = jest.fn();
+const mockFactTableColumnSave = jest.fn();
+const ftcRepoDelete = jest.fn();
+jest.mock('../../../src/entities/dataset/fact-table-column', () => {
+  // Construct a function (so callers can do `new FactTableColumn()`) with the
+  // static repository methods attached.
+  const Ctor = function (this: Record<string, unknown>) {
+    /* fields populated by caller */
+  } as unknown as Record<string, unknown> & (new () => unknown);
+  Ctor.findOneByOrFail = (...args: unknown[]) => mockFactTableColumnFindOneByOrFail(...args);
+  Ctor.findBy = (...args: unknown[]) => mockFactTableColumnFindBy(...args);
+  Ctor.save = (...args: unknown[]) => mockFactTableColumnSave(...args);
+  Ctor.getRepository = () => ({ delete: (...args: unknown[]) => ftcRepoDelete(...args) });
+  return { FactTableColumn: Ctor };
+});
+
+jest.mock('../../../src/utils/preview-generator', () => ({
+  previewGenerator: jest.fn().mockReturnValue({ status: 200, preview: 'ok' }),
+  sampleSize: 5
+}));
+
+jest.mock('../../../src/utils/mock-cube-handler', () => ({
+  createPostgresValidationSchema: jest.fn().mockResolvedValue(undefined),
+  cleanUpPostgresValidationSchema: jest.fn().mockResolvedValue(undefined)
+}));
+
+// Import after mocks
+import { FactTableColumnType } from '../../../src/enums/fact-table-column-type';
+import { DimensionType } from '../../../src/enums/dimension-type';
+import { NumberType } from '../../../src/extractors/number-extractor';
+import { SourceAssignmentException } from '../../../src/exceptions/source-assignment.exception';
+import { SourceAssignmentDTO } from '../../../src/dtos/source-assignment-dto';
+import { DataTable } from '../../../src/entities/dataset/data-table';
+import { Dataset } from '../../../src/entities/dataset/dataset';
+import { Dimension } from '../../../src/entities/dataset/dimension';
+import { Revision } from '../../../src/entities/dataset/revision';
+import {
+  cleanUpDimension,
+  cleanupDimensionMeasureAndFactTable,
+  createDimensionsFromSourceAssignment,
+  getDimensionPreview,
+  getFactTableColumnPreview,
+  removeAllDimensions,
+  removeMeasure,
+  setupTextDimension,
+  validateNumericDimension,
+  validateSourceAssignment
+} from '../../../src/services/dimension-processor';
+
+// The repo-delete spies are declared at top scope above, alongside their
+// jest.mock factories — referenced directly by name in the tests below.
+
+// --- Helpers ---
+
+function makeSourceAssignment(overrides: Partial<SourceAssignmentDTO>[] = []): SourceAssignmentDTO[] {
+  const base: SourceAssignmentDTO[] = [
+    { column_index: 0, column_name: 'period', column_type: FactTableColumnType.Time },
+    { column_index: 1, column_name: 'data', column_type: FactTableColumnType.DataValues },
+    { column_index: 2, column_name: 'measure', column_type: FactTableColumnType.Measure },
+    { column_index: 3, column_name: 'notes', column_type: FactTableColumnType.NoteCodes }
+  ];
+  return [...base, ...(overrides as SourceAssignmentDTO[])];
 }
 
-const formatsDict: AllFormats = {
-  years: [
-    { type: YearType.Financial, yearFormat: 'YYYYYYYY' },
-    { type: YearType.Financial, yearFormat: 'YYYY/YYYY' },
-    { type: YearType.Financial, yearFormat: 'YYYY-YYYY' },
-    { type: YearType.Financial, yearFormat: 'YYYY/YY' },
-    { type: YearType.Financial, yearFormat: 'YYYY-YY' },
-    { type: YearType.Calendar, yearFormat: 'YYYY' },
-    { type: YearType.Financial, yearFormat: 'YYYYYY' }
-  ],
-  quarters: [
-    { type: YearType.Financial, quarterFormat: 'QX' },
-    { type: YearType.Financial, quarterFormat: '_QX' },
-    { type: YearType.Financial, quarterFormat: 'X' },
-    { type: YearType.Financial, quarterFormat: '_X' },
-    { type: YearType.Financial, quarterFormat: '-X' }
-  ],
-  months: [
-    { type: YearType.Financial, monthFormat: 'MMM' },
-    { type: YearType.Financial, monthFormat: 'mMM' },
-    { type: YearType.Financial, monthFormat: 'mm' }
-  ],
-  specific: [
-    { type: YearType.PointInTime, dateFormat: 'dd/MM/yyyy' },
-    { type: YearType.PointInTime, dateFormat: 'dd/MM/yyyy hh:mm:ss' },
-    { type: YearType.PointInTime, dateFormat: 'dd-MM-yyyy' },
-    { type: YearType.PointInTime, dateFormat: 'yyyy-MM-dd' },
-    { type: YearType.PointInTime, dateFormat: 'yyyyMMdd' }
-  ]
-};
-
-function generateAllSampleCSVs(filePath: string) {
-  const dateColumn: any[] = [2019, 2020, 2021, 2022, 2023, 2024];
-  // Generate year files
-  formatsDict.years.forEach((year, index) => {
-    let csv = 'DateCode,Data\n';
-    const refTable = dateDimensionReferenceTableCreator(year, dateColumn);
-    refTable.map((row) => {
-      csv = `${csv}${row.dateCode},${Math.random()}\n`;
-    });
-    const fileName = `${filePath}/year-format-${index}`;
-    fs.writeFileSync(`${fileName}.json`, JSON.stringify(year));
-    fs.writeFileSync(`${fileName}.csv`, csv);
-  });
-
-  // Generate month files (Months always have yearly totals)
-  formatsDict.years.forEach((year, yIndex) => {
-    formatsDict.months.forEach((month, mIndex) => {
-      const ext = {
-        type: year.type,
-        yearFormat: year.yearFormat,
-        monthFormat: month.monthFormat
-      };
-      logger.debug(`Creating specific month table based on: ${JSON.stringify(ext)}`);
-      const refTable = dateDimensionReferenceTableCreator(ext, dateColumn);
-      let csv = 'DateCode,Data\n';
-      refTable.map((row) => {
-        csv = `${csv}${row.dateCode},${Math.random()}\n`;
-      });
-      const fileName = `${filePath}/month-format-m${mIndex}-y${yIndex}`;
-      fs.writeFileSync(`${fileName}.json`, JSON.stringify(ext));
-      fs.writeFileSync(`${fileName}.csv`, csv);
-    });
-  });
-
-  // Generate quarter files (Quarter files always have yearly totals)
-  formatsDict.years.forEach((year, yIndex) => {
-    formatsDict.quarters.forEach((quarter, qIndex) => {
-      const ext = {
-        type: year.type,
-        yearFormat: year.yearFormat,
-        quarterFormat: quarter.quarterFormat
-      };
-      const refTable = dateDimensionReferenceTableCreator(ext, dateColumn);
-      let csv = 'DateCode,Data\n';
-      refTable.map((row) => {
-        csv = `${csv}${row.dateCode},${Math.random()}\n`;
-      });
-      const fileName = `${filePath}/quarter-format-q${qIndex}-y${yIndex}`;
-      fs.writeFileSync(`${fileName}.json`, JSON.stringify(ext));
-      fs.writeFileSync(`${fileName}.csv`, csv);
-    });
-  });
-
-  // Generate quarter files with magic 5th quarter
-  formatsDict.years.forEach((year, yIndex) => {
-    formatsDict.quarters.forEach((quarter, qIndex) => {
-      const ext = {
-        type: year.type,
-        yearFormat: year.yearFormat,
-        quarterFormat: quarter.quarterFormat,
-        quarterTotalIsFifthQuart: true
-      };
-      const refTable = dateDimensionReferenceTableCreator(ext, dateColumn);
-      let csv = 'DateCode,Data\n';
-      refTable.map((row) => {
-        csv = `${csv}${row.dateCode},${Math.random()}\n`;
-      });
-      const fileName = `${filePath}/magic-quarter-format-q${qIndex}-y${yIndex}`;
-      fs.writeFileSync(`${fileName}.json`, JSON.stringify(ext));
-      fs.writeFileSync(`${fileName}.csv`, csv);
-    });
-  });
-
-  // Generate month files with quarterly totals
-  formatsDict.months.forEach((month, mIndex) => {
-    formatsDict.quarters.forEach((quarter, qIndex) => {
-      formatsDict.years.forEach((year, yIndex) => {
-        const ext = {
-          type: year.type,
-          yearFormat: year.yearFormat,
-          quarterFormat: quarter.quarterFormat,
-          monthFormat: month.monthFormat
-        };
-        const refTable = dateDimensionReferenceTableCreator(ext, dateColumn);
-        let csv = 'DateCode,Data\n';
-        refTable.map((row) => {
-          csv = `${csv}${row.dateCode},${Math.random()}\n`;
-        });
-        const fileName = `${filePath}/month-formats-with-totals-y${yIndex}-q${qIndex}-m${mIndex}`;
-        fs.writeFileSync(`${fileName}.json`, JSON.stringify(ext));
-        fs.writeFileSync(`${fileName}.csv`, csv);
-      });
-    });
-  });
-
-  // Generate month files with magic 5th quarterly totals
-  formatsDict.months.forEach((month, mIndex) => {
-    formatsDict.quarters.forEach((quarter, qIndex) => {
-      formatsDict.years.forEach((year, yIndex) => {
-        const ext = {
-          type: year.type,
-          yearFormat: year.yearFormat,
-          quarterFormat: quarter.quarterFormat,
-          quarterTotalIsFifthQuart: true,
-          monthFormat: month.monthFormat
-        };
-        const refTable = dateDimensionReferenceTableCreator(ext, dateColumn);
-        let csv = 'DateCode,Data\n';
-        refTable.map((row) => {
-          csv = `${csv}${row.dateCode},${Math.random()}\n`;
-        });
-        const fileName = `${filePath}/magic-5th-month-formats-with-totals-y${yIndex}-q${qIndex}-m${mIndex}`;
-        fs.writeFileSync(`${fileName}.json`, JSON.stringify(ext));
-        fs.writeFileSync(`${fileName}.csv`, csv);
-      });
-    });
-  });
+function makeDataTable(columnNames = ['period', 'data', 'measure', 'notes']): DataTable {
+  return {
+    dataTableDescriptions: columnNames.map((name, index) => ({
+      columnName: name,
+      columnIndex: index,
+      columnDatatype: 'VARCHAR'
+    }))
+  } as DataTable;
 }
 
-describe('Date matching table generation', () => {
-  describe('Date Period Matching', () => {
-    test('Given a correct year format it returns a valid table', async () => {
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYYYY'
-      };
-      const dateColumn: any[] = [{ yearCode: 202324 }];
-      const refTable = dateDimensionReferenceTableCreator(extractor, dateColumn);
-      expect(refTable.length).toBe(2);
-      expect(refTable[0].dateCode).toBe('202324');
-    });
+function makeDimension(overrides: Partial<Dimension> = {}): Dimension {
+  return {
+    id: 'dim-1',
+    extractor: null,
+    joinColumn: null,
+    type: DimensionType.Raw,
+    factTableColumn: 'period',
+    lookupTable: null,
+    dataset: { id: 'dataset-1' } as Dataset,
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides
+  } as unknown as Dimension;
+}
 
-    test('Given a correct year and quarter format it returns a valid table', async () => {
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYYYY',
-        quarterFormat: 'QX'
-      };
-      const dateColumn: any[] = [
-        { yearCode: '202324' },
-        { yearCode: '202324Q1' },
-        { yearCode: '202324Q2' },
-        { yearCode: '202324Q3' },
-        { yearCode: '202324Q4' }
-      ];
-      const refTable = dateDimensionReferenceTableCreator(extractor, dateColumn);
-      expect(refTable.length).toBe(10);
-      expect(refTable[0].dateCode).toBe('202324');
-      expect(refTable[2].dateCode).toBe('202324Q1');
-      expect(refTable[4].dateCode).toBe('202324Q2');
-      expect(refTable[6].dateCode).toBe('202324Q3');
-      expect(refTable[8].dateCode).toBe('202324Q4');
-    });
+// --- Tests ---
 
-    test('Given a the magic 5th setting and correct year and quarter format it returns a valid table', async () => {
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYYYY',
-        quarterFormat: 'QX',
-        quarterTotalIsFifthQuart: true
-      };
-      const dateColumn: any[] = [{ yearCode: 2023 }];
-      const refTable = dateDimensionReferenceTableCreator(extractor, dateColumn);
-      expect(refTable.length).toBe(10);
-      expect(refTable[0].dateCode).toBe('202324Q1');
-      expect(refTable[2].dateCode).toBe('202324Q2');
-      expect(refTable[4].dateCode).toBe('202324Q3');
-      expect(refTable[6].dateCode).toBe('202324Q4');
-      expect(refTable[8].dateCode).toBe('202324Q5');
-    });
+describe('validateSourceAssignment', () => {
+  it('classifies columns into their expected buckets', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes', 'extra']);
+    const sources = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'extra', column_type: FactTableColumnType.Ignore }
+    ];
 
-    test('Given a correct year and month format it returns a valid table', async () => {
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYYYY',
-        monthFormat: 'MMM'
-      };
-      const dateColumn: any[] = [
-        { yearCode: '202324' },
-        { yearCode: '202324Apr' },
-        { yearCode: '202324May' },
-        { yearCode: '202324Jun' },
-        { yearCode: '202324Jul' },
-        { yearCode: '202324Aug' },
-        { yearCode: '202324Sep' },
-        { yearCode: '202324Oct' },
-        { yearCode: '202324Nov' },
-        { yearCode: '202324Dec' },
-        { yearCode: '202324Jan' },
-        { yearCode: '202324Feb' },
-        { yearCode: '202324Mar' }
-      ];
-      const refTable = dateDimensionReferenceTableCreator(extractor, dateColumn);
-      expect(refTable.length).toBe(26);
-      expect(refTable[0].dateCode).toBe('202324');
-      expect(refTable[2].dateCode).toBe('202324Apr');
-      expect(refTable[4].dateCode).toBe('202324May');
-      expect(refTable[6].dateCode).toBe('202324Jun');
-      expect(refTable[8].dateCode).toBe('202324Jul');
-      expect(refTable[10].dateCode).toBe('202324Aug');
-      expect(refTable[12].dateCode).toBe('202324Sep');
-      expect(refTable[14].dateCode).toBe('202324Oct');
-      expect(refTable[16].dateCode).toBe('202324Nov');
-      expect(refTable[18].dateCode).toBe('202324Dec');
-      expect(refTable[20].dateCode).toBe('202324Jan');
-      expect(refTable[22].dateCode).toBe('202324Feb');
-      expect(refTable[24].dateCode).toBe('202324Mar');
-    });
+    const result = validateSourceAssignment(dataTable, sources);
 
-    test('If given an unknown year format it errors', async () => {
-      const input: any[] = [{ dateCode: '01/12/2023' }];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'XXXX'
-      };
-      try {
-        const refTable = dateDimensionReferenceTableCreator(extractor, input);
-        expect(refTable).toBe(false);
-      } catch (error) {
-        expect((error as Error).message).toBe('Unknown year format');
-      }
-    });
-
-    test('If given an unknown month format it errors', async () => {
-      const input: any[] = [{ dateCode: '01/12/2023' }];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYY',
-        monthFormat: 'XXXX'
-      };
-      try {
-        const refTable = dateDimensionReferenceTableCreator(extractor, input);
-        expect(refTable).toBe(false);
-      } catch (error) {
-        expect((error as Error).message).toBe('Unknown month format');
-      }
-    });
-
-    test('If given an unknown quarter format it errors', async () => {
-      const input: any[] = [{ dateCode: '01/12/2023' }];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        yearFormat: 'YYYY',
-        quarterFormat: 'XXXX'
-      };
-      try {
-        const refTable = dateDimensionReferenceTableCreator(extractor, input);
-        expect(refTable).toBe(false);
-      } catch (error) {
-        expect((error as Error).message).toBe('Unknown quarter format');
-      }
-    });
+    expect(result.dataValues?.column_name).toBe('data');
+    expect(result.measure?.column_name).toBe('measure');
+    expect(result.noteCodes?.column_name).toBe('notes');
+    expect(result.dimensions).toHaveLength(1);
+    expect(result.dimensions[0].column_name).toBe('period');
+    expect(result.ignore).toHaveLength(1);
+    expect(result.ignore[0].column_name).toBe('extra');
   });
 
-  describe('Point in time matching table generation', () => {
-    test('Given the format "yyyyMMdd" it generates matches for a table', async () => {
-      const input: any[] = [
-        { dateCode: '20231201' },
-        { dateCode: '20240101' },
-        { dateCode: '20240201' },
-        { dateCode: '20240301' },
-        { dateCode: '20240401' },
-        { dateCode: '20240501' },
-        { dateCode: '20240601' },
-        { dateCode: '20240701' },
-        { dateCode: '20240801' },
-        { dateCode: '20240901' },
-        { dateCode: '20241001' },
-        { dateCode: '20241101' },
-        { dateCode: '20241201' }
-      ];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        dateFormat: 'yyyyMMdd'
-      };
-      const refTable = dateDimensionReferenceTableCreator(extractor, input);
-      expect(refTable.length).toBe(26);
-      expect(refTable[0].dateCode).toBe('20231201');
-      expect(refTable[0].start).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[0].end).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[0].type).toBe('specific_day');
-      expect(refTable[2].dateCode).toBe('20240101');
-      expect(refTable[2].start).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[2].end).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[1].type).toBe('specific_day');
-    });
+  it('treats both Time and Dimension columns as dimensions', () => {
+    const dataTable = makeDataTable(['period', 'area', 'data', 'measure', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      { column_index: 0, column_name: 'period', column_type: FactTableColumnType.Time },
+      { column_index: 1, column_name: 'area', column_type: FactTableColumnType.Dimension },
+      { column_index: 2, column_name: 'data', column_type: FactTableColumnType.DataValues },
+      { column_index: 3, column_name: 'measure', column_type: FactTableColumnType.Measure },
+      { column_index: 4, column_name: 'notes', column_type: FactTableColumnType.NoteCodes }
+    ];
 
-    test('Given the format "dd/MM/yyyy" it generates matches for a table', async () => {
-      const input: any[] = [
-        { dateCode: '01/12/2023' },
-        { dateCode: '01/01/2024' },
-        { dateCode: '01/02/2024' },
-        { dateCode: '01/03/2024' },
-        { dateCode: '01/04/2024' },
-        { dateCode: '01/05/2024' },
-        { dateCode: '01/06/2024' },
-        { dateCode: '01/07/2024' },
-        { dateCode: '01/08/2024' },
-        { dateCode: '01/09/2024' },
-        { dateCode: '01/10/2024' },
-        { dateCode: '01/11/2024' },
-        { dateCode: '01/12/2024' }
-      ];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        dateFormat: 'dd/MM/yyyy'
-      };
-      const refTable = dateDimensionReferenceTableCreator(extractor, input);
-      expect(refTable.length).toBe(26);
-      expect(refTable[0].dateCode).toBe('01/12/2023');
-      expect(refTable[0].start).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[0].end).toStrictEqual(new TZDate(parseISO('2023-12-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[0].type).toBe('specific_day');
-      expect(refTable[2].dateCode).toBe('01/01/2024');
-      expect(refTable[2].start).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[2].end).toStrictEqual(new TZDate(parseISO('2024-01-01T00:00:00.000Z'), 'UTC'));
-      expect(refTable[2].type).toBe('specific_day');
-    });
-
-    test('If given an unknown format it errors', async () => {
-      const input: any[] = [{ dateCode: '01/12/2023' }];
-      const extractor: DateExtractor = {
-        type: YearType.Financial,
-        dateFormat: 'ddXXyyyy'
-      };
-      try {
-        const refTable = dateDimensionReferenceTableCreator(extractor, input);
-        expect(refTable).toBe(false);
-      } catch (error) {
-        expect((error as Error).message).toBe('Unknown Date Format.  Format given: ddXXyyyy');
-      }
-    });
+    const result = validateSourceAssignment(dataTable, sources);
+    expect(result.dimensions).toHaveLength(2);
+    expect(result.dimensions.map((d) => d.column_name)).toEqual(['period', 'area']);
   });
 
-  test('Generate sample files for date/time matching', async () => {
-    const filePath = `${__dirname}/sample-files/date-period-csv/`;
+  it('handles a dataTable with no dataTableDescriptions by treating valid columns as empty', () => {
+    // No descriptions → validColumnNames is [] → any source assignment is rejected
+    const dataTable = { dataTableDescriptions: undefined } as unknown as DataTable;
+    const sources = makeSourceAssignment();
 
-    if (process.env.generateDatePeriodSamples) {
-      generateAllSampleCSVs(filePath);
-    }
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow(SourceAssignmentException);
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('invalid_column_name');
+  });
+
+  it('throws when a source references a column that does not exist in the data table', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'ghost', column_type: FactTableColumnType.Dimension }
+    ];
+
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('invalid_column_name');
+  });
+
+  it('throws when more than one data values column is supplied', () => {
+    const dataTable = makeDataTable(['period', 'data', 'data2', 'measure', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'data2', column_type: FactTableColumnType.DataValues }
+    ];
+
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('too_many_data_values');
+  });
+
+  it('throws when more than one measure column is supplied', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'measure2', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'measure2', column_type: FactTableColumnType.Measure }
+    ];
+
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('too_many_measure');
+  });
+
+  it('throws when more than one note codes column is supplied', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes', 'notes2']);
+    const sources: SourceAssignmentDTO[] = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'notes2', column_type: FactTableColumnType.NoteCodes }
+    ];
+
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('too_many_footnotes');
+  });
+
+  it('throws when an unrecognised column type is supplied', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes']);
+    const sources = [
+      ...makeSourceAssignment(),
+      // Coerce an invalid type that the switch statement won't recognise
+      { column_index: 0, column_name: 'period', column_type: 'bogus' as unknown as FactTableColumnType }
+    ];
+
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('invalid_source_type');
+  });
+
+  it('throws when there is no data values column', () => {
+    const dataTable = makeDataTable(['period', 'measure', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      { column_index: 0, column_name: 'period', column_type: FactTableColumnType.Time },
+      { column_index: 1, column_name: 'measure', column_type: FactTableColumnType.Measure },
+      { column_index: 2, column_name: 'notes', column_type: FactTableColumnType.NoteCodes }
+    ];
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('missing_data_values');
+  });
+
+  it('throws when there is no measure column', () => {
+    const dataTable = makeDataTable(['period', 'data', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      { column_index: 0, column_name: 'period', column_type: FactTableColumnType.Time },
+      { column_index: 1, column_name: 'data', column_type: FactTableColumnType.DataValues },
+      { column_index: 2, column_name: 'notes', column_type: FactTableColumnType.NoteCodes }
+    ];
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('missing_measure');
+  });
+
+  it('throws when there is no note codes column', () => {
+    const dataTable = makeDataTable(['period', 'data', 'measure']);
+    const sources: SourceAssignmentDTO[] = [
+      { column_index: 0, column_name: 'period', column_type: FactTableColumnType.Time },
+      { column_index: 1, column_name: 'data', column_type: FactTableColumnType.DataValues },
+      { column_index: 2, column_name: 'measure', column_type: FactTableColumnType.Measure }
+    ];
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('missing_footnotes');
+  });
+
+  it('throws when there are no dimensions', () => {
+    const dataTable = makeDataTable(['data', 'measure', 'notes']);
+    const sources: SourceAssignmentDTO[] = [
+      { column_index: 0, column_name: 'data', column_type: FactTableColumnType.DataValues },
+      { column_index: 1, column_name: 'measure', column_type: FactTableColumnType.Measure },
+      { column_index: 2, column_name: 'notes', column_type: FactTableColumnType.NoteCodes }
+    ];
+    expect(() => validateSourceAssignment(dataTable, sources)).toThrow('missing_dimensions');
+  });
+});
+
+describe('setupTextDimension', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets the dimension type to Text and gives it a text extractor', async () => {
+    const dimension = makeDimension();
+    const reloaded = {
+      id: 'dim-1',
+      type: DimensionType.Raw,
+      extractor: null,
+      save: jest.fn().mockResolvedValue(undefined)
+    };
+    mockDimensionFindOneByOrFail.mockResolvedValueOnce(reloaded);
+
+    await setupTextDimension(dimension);
+
+    expect(mockDimensionFindOneByOrFail).toHaveBeenCalledWith({ id: 'dim-1' });
+    expect(reloaded.type).toBe(DimensionType.Text);
+    expect(reloaded.extractor).toEqual({ type: 'text' });
+    expect(reloaded.save).toHaveBeenCalled();
+  });
+
+  it('cleans up an existing extractor before assigning the new text one', async () => {
+    const saveSpy = jest.fn().mockResolvedValue(undefined);
+    const dimension = makeDimension({
+      extractor: { type: 'number' } as unknown as Dimension['extractor'],
+      save: saveSpy
+    });
+    const reloaded = {
+      id: 'dim-1',
+      save: jest.fn().mockResolvedValue(undefined)
+    };
+    mockDimensionFindOneByOrFail.mockResolvedValueOnce(reloaded);
+
+    await setupTextDimension(dimension);
+
+    // cleanUpDimension is internal — easiest signal that it ran is that the
+    // passed dimension was saved once before the reload-and-update path ran.
+    expect(saveSpy).toHaveBeenCalled();
+    expect(reloaded.save).toHaveBeenCalled();
+  });
+});
+
+describe('cleanUpDimension', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resets fields on the dimension, saves it, and does nothing when there is no lookup table', async () => {
+    const dimension = makeDimension({
+      extractor: { type: 'text' } as unknown as Dimension['extractor'],
+      joinColumn: 'code',
+      type: DimensionType.Text,
+      lookupTable: null
+    });
+
+    await cleanUpDimension(dimension);
+
+    expect(dimension.extractor).toBeNull();
+    expect(dimension.joinColumn).toBeNull();
+    expect(dimension.type).toBe(DimensionType.Raw);
+    expect(dimension.lookupTable).toBeNull();
+    expect(dimension.save).toHaveBeenCalled();
+    expect(mockLookupTableFindOneBy).not.toHaveBeenCalled();
+    expect(mockFileServiceDelete).not.toHaveBeenCalled();
+  });
+
+  it('removes the previous lookup table entity and its file when one was attached', async () => {
+    const remove = jest.fn().mockResolvedValue(undefined);
+    mockLookupTableFindOneBy.mockResolvedValueOnce({ id: 'lt-1', remove });
+    mockFileServiceDelete.mockResolvedValueOnce(undefined);
+
+    const dimension = makeDimension({
+      lookupTable: { id: 'lt-1', filename: 'lt.csv' } as unknown as Dimension['lookupTable']
+    });
+
+    await cleanUpDimension(dimension);
+
+    expect(mockLookupTableFindOneBy).toHaveBeenCalledWith({ id: 'lt-1' });
+    expect(remove).toHaveBeenCalled();
+    expect(mockFileServiceDelete).toHaveBeenCalledWith('lt.csv', 'dataset-1');
+  });
+
+  it('rethrows when saving the dimension fails', async () => {
+    const dimension = makeDimension({
+      save: jest.fn().mockRejectedValueOnce(new Error('boom'))
+    });
+
+    await expect(cleanUpDimension(dimension)).rejects.toThrow('boom');
+  });
+
+  it('swallows file-service errors so the cleanup still completes', async () => {
+    const remove = jest.fn().mockResolvedValue(undefined);
+    mockLookupTableFindOneBy.mockResolvedValueOnce({ id: 'lt-1', remove });
+    mockFileServiceDelete.mockRejectedValueOnce(new Error('blob 500'));
+
+    const dimension = makeDimension({
+      lookupTable: { id: 'lt-1', filename: 'lt.csv' } as unknown as Dimension['lookupTable']
+    });
+
+    // No throw despite the blob error
+    await expect(cleanUpDimension(dimension)).resolves.toBeUndefined();
+    expect(remove).toHaveBeenCalled();
+  });
+
+  it('handles the case where the lookup table was already removed from the database', async () => {
+    mockLookupTableFindOneBy.mockResolvedValueOnce(null);
+    mockFileServiceDelete.mockResolvedValueOnce(undefined);
+
+    const dimension = makeDimension({
+      lookupTable: { id: 'lt-1', filename: 'lt.csv' } as unknown as Dimension['lookupTable']
+    });
+
+    await cleanUpDimension(dimension);
+
+    // Still tries the file removal because the id+filename were captured before the null lookup
+    expect(mockFileServiceDelete).toHaveBeenCalledWith('lt.csv', 'dataset-1');
+  });
+});
+
+describe('removeAllDimensions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes dimensions even when the dataset has none attached', async () => {
+    const dataset = { id: 'd-1', dimensions: undefined } as unknown as Dataset;
+    await removeAllDimensions(dataset);
+    expect(dimensionRepoDelete).toHaveBeenCalledWith({ dataset });
+    expect(mockFileServiceDelete).not.toHaveBeenCalled();
+  });
+
+  it('removes lookup-table files for every dimension that has one', async () => {
+    const dataset = {
+      id: 'd-1',
+      dimensions: [
+        { lookupTable: { filename: 'one.csv' } },
+        { lookupTable: { filename: 'two.csv' } },
+        { lookupTable: null }
+      ]
+    } as unknown as Dataset;
+
+    mockFileServiceDelete.mockResolvedValue(undefined);
+
+    await removeAllDimensions(dataset);
+
+    expect(mockFileServiceDelete).toHaveBeenCalledTimes(2);
+    expect(mockFileServiceDelete).toHaveBeenCalledWith('one.csv', 'd-1');
+    expect(mockFileServiceDelete).toHaveBeenCalledWith('two.csv', 'd-1');
+    expect(dimensionRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+
+  it('continues deleting dimensions even if file removal throws', async () => {
+    const dataset = {
+      id: 'd-1',
+      dimensions: [{ lookupTable: { filename: 'broken.csv' } }]
+    } as unknown as Dataset;
+
+    mockFileServiceDelete.mockRejectedValueOnce(new Error('blob unreachable'));
+
+    await expect(removeAllDimensions(dataset)).resolves.toBeUndefined();
+    expect(dimensionRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+});
+
+describe('removeMeasure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the measure rows, metadata and measure itself when there is no measure attached', async () => {
+    const dataset = { id: 'd-1', measure: undefined } as unknown as Dataset;
+    await removeMeasure(dataset);
+    expect(measureRepoDelete).toHaveBeenCalledWith({ dataset });
+    expect(measureRowRepoDelete).not.toHaveBeenCalled();
+    expect(measureMetadataRepoDelete).not.toHaveBeenCalled();
+  });
+
+  it('removes the lookup table file and clears rows/metadata when the measure has a lookup table', async () => {
+    const measure = { id: 'm-1', lookupTable: { filename: 'meas.csv' } };
+    const dataset = { id: 'd-1', measure } as unknown as Dataset;
+
+    await removeMeasure(dataset);
+
+    expect(mockFileServiceDelete).toHaveBeenCalledWith('meas.csv', 'd-1');
+    expect(measureRowRepoDelete).toHaveBeenCalledWith({ measure });
+    expect(measureMetadataRepoDelete).toHaveBeenCalledWith({ measure });
+    expect(measureRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+
+  it('still deletes rows, metadata and measure when there is a measure but no lookup table', async () => {
+    const measure = { id: 'm-1', lookupTable: null };
+    const dataset = { id: 'd-1', measure } as unknown as Dataset;
+
+    await removeMeasure(dataset);
+
+    expect(mockFileServiceDelete).not.toHaveBeenCalled();
+    expect(measureRowRepoDelete).toHaveBeenCalledWith({ measure });
+    expect(measureMetadataRepoDelete).toHaveBeenCalledWith({ measure });
+    expect(measureRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+});
+
+describe('cleanupDimensionMeasureAndFactTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears fact-table columns, dimensions and measure in turn', async () => {
+    const dataset = {
+      id: 'd-1',
+      dimensions: [],
+      measure: undefined
+    } as unknown as Dataset;
+
+    await cleanupDimensionMeasureAndFactTable(dataset);
+
+    expect(ftcRepoDelete).toHaveBeenCalledWith({ id: 'd-1' });
+    expect(dimensionRepoDelete).toHaveBeenCalledWith({ dataset });
+    expect(measureRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+});
+
+describe('validateNumericDimension', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // clearAllMocks doesn't purge the `mockResolvedValueOnce` queue — reset it
+    // explicitly so each test starts with no leftover scripted responses.
+    mockQuery.mockReset();
+    mockRelease.mockReset();
+  });
+
+  function makeNumericDataset(): Dataset {
+    return {
+      id: 'dataset-1',
+      draftRevision: { id: 'rev-1' } as Revision
+    } as Dataset;
+  }
+
+  function makeNumericDimension(): Dimension {
+    const dimension = {
+      id: 'dim-1',
+      factTableColumn: 'value',
+      extractor: null,
+      lookupTable: null,
+      joinColumn: null,
+      type: DimensionType.Raw
+    } as unknown as Dimension;
+    // Mirror TypeORM BaseEntity.save: returns `this` with whatever the caller
+    // just assigned to the entity. Callers in dimension-processor.ts assign
+    // `extractor` (and others) before awaiting `save()`.
+    (dimension as unknown as { save: jest.Mock }).save = jest.fn(async () => dimension);
+    return dimension;
+  }
+
+  it('throws when no number type is supplied', async () => {
+    await expect(
+      validateNumericDimension(
+        { number_format: undefined } as Parameters<typeof validateNumericDimension>[0],
+        makeNumericDataset(),
+        makeNumericDimension()
+      )
+    ).rejects.toThrow('No number type supplied');
+  });
+
+  it('throws when number type is Decimal but no decimal_places is supplied', async () => {
+    await expect(
+      validateNumericDimension(
+        { number_format: NumberType.Decimal, decimal_places: undefined } as Parameters<
+          typeof validateNumericDimension
+        >[0],
+        makeNumericDataset(),
+        makeNumericDimension()
+      )
+    ).rejects.toThrow('No decimal places supplied');
+  });
+
+  it('returns an error view when the schema-info query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('schema gone'));
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toMatchObject({ status: 400 });
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it('fast-paths to a preview when the column is already a native integer type', async () => {
+    mockQuery
+      // schema-info: column is BIGINT
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'BIGINT' }])
+      // totals query
+      .mockResolvedValueOnce([{ totalLines: 10 }])
+      // preview query
+      .mockResolvedValueOnce([{ value: 1 }, { value: 2 }]);
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('fast-paths to a preview when the column is already a native float type and the request is Decimal', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'DOUBLE' }])
+      .mockResolvedValueOnce([{ totalLines: 4 }])
+      .mockResolvedValueOnce([{ value: 1.1 }]);
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Decimal, decimal_places: 2 } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('returns a non-numerical-values error when text data does not match the requested integer format', async () => {
+    mockQuery
+      // schema-info: column is VARCHAR (no fast path)
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'VARCHAR' }])
+      // non-matching query: rows present
+      .mockResolvedValueOnce([{ value: 'abc' }, { value: 'N/A' }])
+      // distinct non-matching values
+      .mockResolvedValueOnce([{ value: 'abc' }, { value: 'N/A' }]);
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toMatchObject({ status: 400 });
+  });
+
+  it('returns 500 when the non-matching query itself blows up', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'VARCHAR' }])
+      .mockRejectedValueOnce(new Error('db lost'));
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('returns 400 when the distinct-non-matching query fails after non-matching rows were found', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'VARCHAR' }])
+      .mockResolvedValueOnce([{ value: 'abc' }])
+      .mockRejectedValueOnce(new Error('distinct query failed'));
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toMatchObject({ status: 400 });
+  });
+
+  it('validates and previews when text data does match the requested integer format', async () => {
+    mockQuery
+      // schema info: VARCHAR — no fast path
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'VARCHAR' }])
+      // non-matching query: empty (everything matches)
+      .mockResolvedValueOnce([])
+      // totals query
+      .mockResolvedValueOnce([{ totalLines: 5 }])
+      // preview query
+      .mockResolvedValueOnce([{ value: 1 }, { value: 2 }]);
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Integer } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('validates and previews decimals when text data matches the requested decimal format', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ column_name: 'value', data_type: 'VARCHAR' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ totalLines: 5 }])
+      .mockResolvedValueOnce([{ value: 1.23 }]);
+
+    const result = await validateNumericDimension(
+      { number_format: NumberType.Decimal, decimal_places: 2 } as Parameters<typeof validateNumericDimension>[0],
+      makeNumericDataset(),
+      makeNumericDimension()
+    );
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+});
+
+describe('getDimensionPreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+    mockRelease.mockReset();
+  });
+
+  function makePreviewDataset(): Dataset {
+    return {
+      id: 'dataset-1',
+      draftRevision: { id: 'rev-1' } as Revision
+    } as Dataset;
+  }
+
+  it('routes Date dimensions through the date preview helper', async () => {
+    // 1: totals; 2: date preview query
+    mockQuery
+      .mockResolvedValueOnce([{ totalLines: 12 }])
+      .mockResolvedValueOnce([{ reference: '202324', description: 'Apr 2023 - Mar 2024' }]);
+
+    const dimension = makeDimension({ type: DimensionType.Date });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('routes DatePeriod dimensions through the same date preview helper', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ totalLines: 4 }])
+      .mockResolvedValueOnce([{ reference: '2023', description: '' }]);
+
+    const dimension = makeDimension({ type: DimensionType.DatePeriod });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('returns a 500 error view when the date preview query fails', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 4 }]).mockRejectedValueOnce(new Error('lookup table missing'));
+
+    const dimension = makeDimension({ type: DimensionType.Date });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('routes LookupTable dimensions through the lookup preview helper', async () => {
+    // 1: totals; 2: tableDetails (column names); 3: actual preview
+    mockQuery
+      .mockResolvedValueOnce([{ totalLines: 3 }])
+      .mockResolvedValueOnce([{ column_name: 'period' }, { column_name: 'sort_order' }, { column_name: 'language' }])
+      .mockResolvedValueOnce([{ period: 'A', sort_order: 1 }]);
+
+    const dimension = makeDimension({ type: DimensionType.LookupTable });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('returns 500 when the lookup tableDetails query fails', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 3 }]).mockRejectedValueOnce(new Error('schema unavailable'));
+
+    const dimension = makeDimension({ type: DimensionType.LookupTable });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('returns 500 when the lookup preview query itself fails', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ totalLines: 3 }])
+      .mockResolvedValueOnce([{ column_name: 'period' }])
+      .mockRejectedValueOnce(new Error('preview query failed'));
+
+    const dimension = makeDimension({ type: DimensionType.LookupTable });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('routes Text dimensions through the no-extractor preview helper', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 7 }]).mockResolvedValueOnce([{ period: 'A' }, { period: 'B' }]);
+
+    const dimension = makeDimension({ type: DimensionType.Text });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('returns 500 when the text-dimension preview query fails', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 7 }]).mockRejectedValueOnce(new Error('table missing'));
+
+    const dimension = makeDimension({ type: DimensionType.Text });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('routes Numeric (integer) dimensions through the number-extractor preview helper', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 9 }]).mockResolvedValueOnce([{ value: 1 }, { value: 2 }]);
+
+    const dimension = makeDimension({
+      type: DimensionType.Numeric,
+      factTableColumn: 'value',
+      extractor: { type: NumberType.Integer, decimalPlaces: 0 } as unknown as Dimension['extractor']
+    });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('falls back to the no-extractor preview helper for unknown dimension types', async () => {
+    mockQuery.mockResolvedValueOnce([{ totalLines: 2 }]).mockResolvedValueOnce([{ period: 'A' }]);
+
+    const dimension = makeDimension({ type: 'mystery' as unknown as DimensionType });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+
+  it('returns totalLines: -1 when the totals query fails, and still produces a preview', async () => {
+    // Totals failure is caught and returns -1; the type dispatch continues.
+    mockQuery.mockRejectedValueOnce(new Error('count failed')).mockResolvedValueOnce([{ period: 'A' }]);
+
+    const dimension = makeDimension({ type: DimensionType.Text });
+    const result = await getDimensionPreview(makePreviewDataset(), dimension, 'en-GB');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+  });
+});
+
+describe('getFactTableColumnPreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+    mockRelease.mockReset();
+  });
+
+  it('returns a successful preview when the query returns rows', async () => {
+    mockQuery.mockResolvedValueOnce([{ region: 'Wales' }, { region: 'Cymru' }]);
+
+    const result = await getFactTableColumnPreview({ id: 'ds-1' } as Dataset, 'rev-1', 'region');
+
+    expect(result).toEqual({ status: 200, preview: 'ok' });
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it('returns a 500 error view when the query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('column missing'));
+
+    const result = await getFactTableColumnPreview({ id: 'ds-1' } as Dataset, 'rev-1', 'region');
+
+    expect(result).toMatchObject({ status: 500 });
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});
+
+describe('createDimensionsFromSourceAssignment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+    mockRelease.mockReset();
+    mockFactTableColumnFindOneByOrFail.mockReset();
+    mockFactTableColumnFindBy.mockReset();
+    mockFactTableColumnSave.mockReset();
+  });
+
+  function makeColumn(name: string) {
+    return {
+      columnName: name,
+      columnType: FactTableColumnType.Unknown,
+      columnDatatype: 'VARCHAR',
+      save: jest.fn().mockResolvedValue(undefined)
+    };
+  }
+
+  it('processes a full source assignment: data values, measure, note codes and dimensions', async () => {
+    const dataset = { id: 'd-1', dimensions: [], measure: undefined } as unknown as Dataset;
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes']);
+
+    const dataColumn = makeColumn('data');
+    const measureColumn = makeColumn('measure');
+    const notesColumn = makeColumn('notes');
+    const periodColumn = makeColumn('period');
+
+    mockFactTableColumnFindOneByOrFail
+      // updateDataValueColumn
+      .mockResolvedValueOnce(dataColumn)
+      // createUpdateNoteCodes
+      .mockResolvedValueOnce(notesColumn)
+      // createUpdateMeasure
+      .mockResolvedValueOnce(measureColumn)
+      // createUpdateDimension
+      .mockResolvedValueOnce(periodColumn);
+
+    // removeIgnoreAndUnknownColumns runs three findBy calls: all-columns, then
+    // Unknown-columns twice. With no ignore columns the loop body is skipped.
+    mockFactTableColumnFindBy.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const validated = validateSourceAssignment(dataTable, makeSourceAssignment());
+    await createDimensionsFromSourceAssignment(dataset, dataTable, validated);
+
+    expect(dataColumn.columnType).toBe(FactTableColumnType.DataValues);
+    expect(measureColumn.columnType).toBe(FactTableColumnType.Measure);
+    expect(notesColumn.columnType).toBe(FactTableColumnType.NoteCodes);
+    expect(dataColumn.save).toHaveBeenCalled();
+    expect(measureColumn.save).toHaveBeenCalled();
+    expect(notesColumn.save).toHaveBeenCalled();
+    // Initial cleanup deletes existing dimension/measure/fact table rows
+    expect(ftcRepoDelete).toHaveBeenCalledWith({ id: 'd-1' });
+    expect(dimensionRepoDelete).toHaveBeenCalledWith({ dataset });
+  });
+
+  it('marks an ignore column with the Ignore column type', async () => {
+    const dataset = { id: 'd-1', dimensions: [], measure: undefined } as unknown as Dataset;
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes', 'extra']);
+
+    const dataColumn = makeColumn('data');
+    const notesColumn = makeColumn('notes');
+    const measureColumn = makeColumn('measure');
+    const periodColumn = makeColumn('period');
+    const extraColumn = makeColumn('extra');
+
+    mockFactTableColumnFindOneByOrFail
+      .mockResolvedValueOnce(dataColumn)
+      .mockResolvedValueOnce(notesColumn)
+      .mockResolvedValueOnce(measureColumn)
+      .mockResolvedValueOnce(periodColumn);
+
+    // findBy returns the full column list for the ignore matching loop, then
+    // empty for the "any unknown columns left?" check.
+    mockFactTableColumnFindBy.mockResolvedValueOnce([extraColumn]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const sources = [
+      ...makeSourceAssignment(),
+      { column_index: 4, column_name: 'extra', column_type: FactTableColumnType.Ignore }
+    ];
+    const validated = validateSourceAssignment(dataTable, sources);
+
+    await createDimensionsFromSourceAssignment(dataset, dataTable, validated);
+
+    expect(extraColumn.columnType).toBe(FactTableColumnType.Ignore);
+    expect(extraColumn.save).toHaveBeenCalled();
+  });
+
+  it('rethrows when unknown columns remain after ignore processing', async () => {
+    const dataset = { id: 'd-1', dimensions: [], measure: undefined } as unknown as Dataset;
+    const dataTable = makeDataTable(['period', 'data', 'measure', 'notes']);
+
+    mockFactTableColumnFindOneByOrFail
+      .mockResolvedValueOnce(makeColumn('data'))
+      .mockResolvedValueOnce(makeColumn('notes'))
+      .mockResolvedValueOnce(makeColumn('measure'))
+      .mockResolvedValueOnce(makeColumn('period'));
+
+    // First findBy: full list. Second: unknown-column check returns one
+    // unprocessed column → triggers SourceAssignmentException
+    mockFactTableColumnFindBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ columnName: 'orphan', columnDatatype: FactTableColumnType.Unknown }])
+      .mockResolvedValueOnce([{ columnName: 'orphan', columnDatatype: FactTableColumnType.Unknown }]);
+
+    const validated = validateSourceAssignment(dataTable, makeSourceAssignment());
+    await expect(createDimensionsFromSourceAssignment(dataset, dataTable, validated)).rejects.toThrow(
+      SourceAssignmentException
+    );
   });
 });

--- a/test/unit/services/incoming-file-processor.test.ts
+++ b/test/unit/services/incoming-file-processor.test.ts
@@ -72,17 +72,13 @@ jest.mock('../../../src/repositories/dataset', () => ({
 }));
 
 const mockDataTableFindOneByOrFail = jest.fn();
-jest.mock('../../../src/entities/dataset/data-table', () => ({
-  DataTable: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
-    Object.assign(this, {});
-  })
-}));
-jest.doMock('../../../src/entities/dataset/data-table', () => {
-  function Ctor(this: Record<string, unknown>) {
-    /* fields populated by the caller */
-  }
-  (Ctor as unknown as Record<string, unknown>).findOneByOrFail = (...args: unknown[]) =>
-    mockDataTableFindOneByOrFail(...args);
+// Single factory providing both the constructor (so callers can do
+// `new DataTable()`) and the static `findOneByOrFail` used by `getFilePreview`.
+jest.mock('../../../src/entities/dataset/data-table', () => {
+  const Ctor = function (this: Record<string, unknown>) {
+    /* fields populated by caller */
+  } as unknown as Record<string, unknown> & (new () => unknown);
+  Ctor.findOneByOrFail = (...args: unknown[]) => mockDataTableFindOneByOrFail(...args);
   return { DataTable: Ctor };
 });
 

--- a/test/unit/services/incoming-file-processor.test.ts
+++ b/test/unit/services/incoming-file-processor.test.ts
@@ -188,6 +188,43 @@ describe('validateFileAndExtractTableInfo', () => {
     expect(mockDuckDBRun.mock.calls[1][0]).toContain('latin-1');
   });
 
+  it('applies the utf-8 → latin-1 fallback to GzipCsv files as well as plain CSVs', async () => {
+    mockDuckDBRun
+      .mockRejectedValueOnce(new Error('utf-8 read failed'))
+      .mockResolvedValueOnce(undefined) // latin-1 retry
+      .mockResolvedValue(undefined); // subsequent runs
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+
+    const dataTable = makeDataTable(FileType.GzipCsv);
+    const result = await validateFileAndExtractTableInfo(
+      makeFile({ originalname: 'data.csv.gz', mimetype: 'application/x-gzip' }),
+      dataTable,
+      'data_table'
+    );
+
+    expect(result).toHaveLength(2);
+    expect(dataTable.encoding).toBe('latin-1');
+    // First call used utf-8, second used latin-1 — confirms both attempts went
+    // through the encoding branch rather than the no-encoding else branch.
+    expect(mockDuckDBRun.mock.calls[0][0]).toContain('utf-8');
+    expect(mockDuckDBRun.mock.calls[1][0]).toContain('latin-1');
+  });
+
+  it('reads a GzipCsv with UTF-8 on the happy path (no fallback needed)', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+
+    const dataTable = makeDataTable(FileType.GzipCsv);
+    await validateFileAndExtractTableInfo(
+      makeFile({ originalname: 'data.csv.gz', mimetype: 'application/x-gzip' }),
+      dataTable,
+      'data_table'
+    );
+
+    expect(dataTable.encoding).toBe('utf-8');
+    expect(mockDuckDBRun.mock.calls[0][0]).toContain('utf-8');
+  });
+
   it('throws InvalidUnicode when latin-1 fallback also hits a unicode error', async () => {
     const err = new Error('Invalid unicode bytes in stream');
     // attach a stack property since the code checks `(error as DuckDBException).stack`

--- a/test/unit/services/incoming-file-processor.test.ts
+++ b/test/unit/services/incoming-file-processor.test.ts
@@ -1,0 +1,492 @@
+// === Mock setup (Jest hoists these above all imports) ===
+
+const mockDuckDBRun = jest.fn();
+const mockDuckDBRunAndReadAll = jest.fn();
+const mockReleaseDuckDB = jest.fn();
+
+jest.mock('../../../src/services/duckdb', () => ({
+  DuckDBDatabases: {
+    DataTables: 'data_tables',
+    LookupTables: 'lookup_tables'
+  },
+  acquireDuckDB: jest.fn().mockImplementation(async () => ({
+    duckdb: {
+      run: (...args: unknown[]) => mockDuckDBRun(...args),
+      runAndReadAll: (...args: unknown[]) => mockDuckDBRunAndReadAll(...args)
+    },
+    releaseDuckDB: mockReleaseDuckDB
+  }))
+}));
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: jest.fn().mockReturnValue({
+      createQueryRunner: jest.fn().mockReturnValue({
+        query: (...args: unknown[]) => mockQuery(...args),
+        release: (...args: unknown[]) => mockRelease(...args)
+      })
+    })
+  }
+}));
+
+const mockFileServiceSaveStream = jest.fn();
+jest.mock('../../../src/utils/get-file-service', () => ({
+  getFileService: () => ({
+    saveStream: (...args: unknown[]) => mockFileServiceSaveStream(...args)
+  })
+}));
+
+// Replace fs.createReadStream with a tiny event emitter so the hash calc and
+// the upload stream both complete predictably.
+jest.mock('node:fs', () => {
+  const original = jest.requireActual('node:fs');
+  const { Readable } = jest.requireActual('node:stream');
+  return {
+    ...original,
+    createReadStream: jest.fn().mockImplementation(() => Readable.from([Buffer.from('hello world')]))
+  };
+});
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    child: jest.fn().mockReturnValue({
+      debug: jest.fn(),
+      trace: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: {
+    getById: jest.fn()
+  }
+}));
+
+const mockDataTableFindOneByOrFail = jest.fn();
+jest.mock('../../../src/entities/dataset/data-table', () => ({
+  DataTable: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, {});
+  })
+}));
+jest.doMock('../../../src/entities/dataset/data-table', () => {
+  function Ctor(this: Record<string, unknown>) {
+    /* fields populated by the caller */
+  }
+  (Ctor as unknown as Record<string, unknown>).findOneByOrFail = (...args: unknown[]) =>
+    mockDataTableFindOneByOrFail(...args);
+  return { DataTable: Ctor };
+});
+
+jest.mock('../../../src/entities/dataset/data-table-description', () => ({
+  DataTableDescription: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, {});
+  })
+}));
+
+jest.mock('../../../src/validators/preview-validator', () => ({
+  validateParams: jest.fn().mockReturnValue([])
+}));
+
+jest.mock('../../../src/utils/view-error-generators', () => ({
+  viewErrorGenerators: jest.fn().mockImplementation((status: number) => ({ status, error: true })),
+  viewGenerator: jest.fn().mockImplementation((_dataset, page, pageInfo, size, totalPages, headers, dataArray) => ({
+    status: 200,
+    page,
+    pageInfo,
+    size,
+    totalPages,
+    headers,
+    dataArray
+  }))
+}));
+
+// Import after mocks
+import {
+  getFilePreview,
+  validateAndUpload,
+  validateFileAndExtractTableInfo
+} from '../../../src/services/incoming-file-processor';
+import { DataTable } from '../../../src/entities/dataset/data-table';
+import { FileType } from '../../../src/enums/file-type';
+import { FileValidationErrorType, FileValidationException } from '../../../src/exceptions/validation-exception';
+import { TempFile } from '../../../src/interfaces/temp-file';
+
+// --- Helpers ---
+
+function makeFile(overrides: Partial<TempFile> = {}): TempFile {
+  return {
+    path: '/tmp/test-file',
+    originalname: 'test.csv',
+    mimetype: 'text/csv',
+    ...overrides
+  };
+}
+
+function makeDataTable(fileType: FileType, id = 'dt-1'): DataTable {
+  const dt = new DataTable() as DataTable & { fileType: FileType; id: string };
+  dt.fileType = fileType;
+  dt.id = id;
+  return dt;
+}
+
+function makeReader(rows: Record<string, unknown>[]) {
+  return {
+    getRows: () => rows,
+    getRowObjectsJson: () =>
+      rows.map((row, index) => ({
+        column_name: row.column_name ?? `col_${index}`,
+        column_type: row.column_type ?? 'VARCHAR',
+        index
+      }))
+  };
+}
+
+// --- Tests ---
+
+describe('validateFileAndExtractTableInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDuckDBRun.mockReset();
+    mockDuckDBRunAndReadAll.mockReset();
+  });
+
+  it('reads a CSV with UTF-8 encoding on the happy path', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+
+    const result = await validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].columnName).toBe('period');
+    // Verify that the first run was a UTF-8 attempt (utf-8 should be in the args)
+    expect(mockDuckDBRun.mock.calls[0][0]).toContain('utf-8');
+    expect(mockReleaseDuckDB).toHaveBeenCalled();
+  });
+
+  it('falls back to latin-1 encoding when the UTF-8 read fails', async () => {
+    // First attempt (utf-8) fails, second (latin-1) succeeds, then create table + drop temp succeed
+    mockDuckDBRun
+      .mockRejectedValueOnce(new Error('utf-8 read failed'))
+      .mockResolvedValueOnce(undefined) // latin-1 retry
+      .mockResolvedValue(undefined); // subsequent runs
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+
+    const dataTable = makeDataTable(FileType.Csv);
+    const result = await validateFileAndExtractTableInfo(makeFile(), dataTable, 'data_table');
+
+    expect(result).toHaveLength(2);
+    expect(dataTable.encoding).toBe('latin-1');
+    expect(mockDuckDBRun.mock.calls[1][0]).toContain('latin-1');
+  });
+
+  it('throws InvalidUnicode when latin-1 fallback also hits a unicode error', async () => {
+    const err = new Error('Invalid unicode bytes in stream');
+    // attach a stack property since the code checks `(error as DuckDBException).stack`
+    err.stack = 'Error: Invalid unicode bytes';
+    mockDuckDBRun.mockRejectedValueOnce(new Error('utf-8 read failed')).mockRejectedValueOnce(err);
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.InvalidUnicode
+    });
+  });
+
+  it('throws InvalidCsv when DuckDB reports a CSV-parse error', async () => {
+    const err = new Error('CSV Error on Line 3');
+    err.stack = 'Error: CSV Error on Line 3';
+    mockDuckDBRun.mockRejectedValueOnce(new Error('utf-8 failed')).mockRejectedValueOnce(err);
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.InvalidCsv
+    });
+  });
+
+  it('throws unknown when DuckDB fails with an unrecognised error', async () => {
+    const err = new Error('mystery');
+    err.stack = 'Error: something we have not seen before';
+    mockDuckDBRun.mockRejectedValueOnce(new Error('utf-8 failed')).mockRejectedValueOnce(err);
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.unknown
+    });
+  });
+
+  it('reads an Excel file directly without the encoding-fallback path', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+
+    const result = await validateFileAndExtractTableInfo(
+      makeFile({ originalname: 'data.xlsx', mimetype: 'application/vnd.ms-excel' }),
+      makeDataTable(FileType.Excel),
+      'data_table'
+    );
+
+    expect(result).toHaveLength(2);
+    // No latin-1 fallback should have run
+    expect(mockDuckDBRun.mock.calls[0][0]).not.toContain('latin-1');
+  });
+
+  it('reads a JSON file directly without the encoding-fallback path', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'period' }]));
+
+    const result = await validateFileAndExtractTableInfo(
+      makeFile({ originalname: 'data.json', mimetype: 'application/json' }),
+      makeDataTable(FileType.Json),
+      'data_table'
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('throws unknown when copying the data table to postgres fails', async () => {
+    mockDuckDBRun
+      .mockResolvedValueOnce(undefined) // read CSV
+      .mockRejectedValueOnce(new Error('postgres unavailable'));
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.unknown
+    });
+  });
+
+  it('throws unknown when extracting table headers fails', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockRejectedValueOnce(new Error('describe failed'));
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.unknown
+    });
+  });
+
+  it('throws InvalidCsv when DuckDB returns no rows from DESCRIBE', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([]));
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.InvalidCsv
+    });
+  });
+
+  it('throws InvalidCsv when a CSV produces only a single column from DESCRIBE', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'only-one' }]));
+
+    await expect(
+      validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv), 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.InvalidCsv
+    });
+  });
+
+  it('routes lookup-table type writes to the lookup_tables schema with the _tmp suffix', async () => {
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValueOnce(makeReader([{ column_name: 'code' }, { column_name: 'label' }]));
+
+    await validateFileAndExtractTableInfo(makeFile(), makeDataTable(FileType.Csv, 'lt-1'), 'lookup_table');
+
+    // The copy-to-postgres statement (call index 1) should reference the lookup_tables schema and the _tmp suffix
+    const copyCall = mockDuckDBRun.mock.calls[1][0] as string;
+    expect(copyCall).toContain('lookup_tables');
+    expect(copyCall).toContain('lt-1_tmp');
+  });
+});
+
+describe('validateAndUpload — mimetype to file type mapping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDuckDBRun.mockReset();
+    mockDuckDBRunAndReadAll.mockReset();
+    mockFileServiceSaveStream.mockResolvedValue(undefined);
+
+    // Default happy-path: every DuckDB call resolves, DESCRIBE returns two columns.
+    mockDuckDBRun.mockResolvedValue(undefined);
+    mockDuckDBRunAndReadAll.mockResolvedValue(makeReader([{ column_name: 'period' }, { column_name: 'value' }]));
+  });
+
+  const cases: { mimetype: string; expectedType: FileType; extension: string; originalname?: string }[] = [
+    { mimetype: 'application/csv', expectedType: FileType.Csv, extension: 'csv' },
+    { mimetype: 'text/csv', expectedType: FileType.Csv, extension: 'csv' },
+    { mimetype: 'application/vnd.apache.parquet', expectedType: FileType.Parquet, extension: 'parquet' },
+    { mimetype: 'application/parquet', expectedType: FileType.Parquet, extension: 'parquet' },
+    { mimetype: 'application/json', expectedType: FileType.Json, extension: 'json' },
+    { mimetype: 'application/vnd.ms-excel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/msexcel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/x-msexcel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/x-ms-excel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/x-excel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/x-dos_ms_excel', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/xls', expectedType: FileType.Excel, extension: 'xlsx' },
+    { mimetype: 'application/x-xls', expectedType: FileType.Excel, extension: 'xlsx' },
+    {
+      mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      expectedType: FileType.Excel,
+      extension: 'xlsx'
+    }
+  ];
+
+  it.each(cases)('maps $mimetype to $expectedType ($extension)', async ({ mimetype, expectedType, extension }) => {
+    const result = await validateAndUpload(
+      makeFile({ mimetype, originalname: `data.${extension}` }),
+      'dataset-1',
+      'data_table'
+    );
+
+    expect(result.fileType).toBe(expectedType);
+    expect(result.mimeType).toBe(mimetype);
+    expect(result.filename).toMatch(new RegExp(`\\.${extension.replace('.', '\\.')}$`));
+  });
+
+  it('detects GzipJson from the inner extension', async () => {
+    const result = await validateAndUpload(
+      makeFile({ mimetype: 'application/x-gzip', originalname: 'data.json.gz' }),
+      'dataset-1',
+      'data_table'
+    );
+
+    expect(result.fileType).toBe(FileType.GzipJson);
+    expect(result.filename).toMatch(/\.json\.gz$/);
+  });
+
+  it('detects GzipCsv from the inner extension', async () => {
+    const result = await validateAndUpload(
+      makeFile({ mimetype: 'application/x-gzip', originalname: 'data.csv.gz' }),
+      'dataset-1',
+      'data_table'
+    );
+
+    expect(result.fileType).toBe(FileType.GzipCsv);
+    expect(result.filename).toMatch(/\.csv\.gz$/);
+  });
+
+  it('throws UnknownFileFormat for a gzip with an unsupported inner extension', async () => {
+    await expect(
+      validateAndUpload(
+        makeFile({ mimetype: 'application/x-gzip', originalname: 'data.parquet.gz' }),
+        'dataset-1',
+        'data_table'
+      )
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.UnknownFileFormat
+    });
+  });
+
+  it('throws UnknownMimeType for an unrecognised mimetype', async () => {
+    await expect(
+      validateAndUpload(makeFile({ mimetype: 'application/x-not-a-real-type' }), 'dataset-1', 'data_table')
+    ).rejects.toMatchObject({
+      type: FileValidationErrorType.UnknownMimeType
+    });
+  });
+
+  it('throws DataLake (status 500) when the blob upload fails', async () => {
+    mockFileServiceSaveStream.mockRejectedValueOnce(new Error('blob 503'));
+
+    const promise = validateAndUpload(makeFile(), 'dataset-1', 'data_table');
+
+    await expect(promise).rejects.toMatchObject({
+      type: FileValidationErrorType.DataLake,
+      status: 500
+    });
+  });
+
+  it('computes a sha256 hash of the file contents', async () => {
+    const result = await validateAndUpload(makeFile(), 'dataset-1', 'data_table');
+
+    // sha256 of 'hello world' is the canonical b94d27b9...e9c2c0
+    expect(result.hash).toBe('b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9');
+  });
+});
+
+describe('FileValidationException', () => {
+  it('defaults status to 400 and exposes a translation-friendly errorTag', () => {
+    const err = new FileValidationException('boom', FileValidationErrorType.InvalidCsv);
+    expect(err.status).toBe(400);
+    expect(err.errorTag).toBe('errors.file_validation.invalid_csv');
+    expect(err.type).toBe(FileValidationErrorType.InvalidCsv);
+  });
+
+  it('accepts a custom status code (e.g. 500 for DataLake failures)', () => {
+    const err = new FileValidationException('blob', FileValidationErrorType.DataLake, 500);
+    expect(err.status).toBe(500);
+  });
+});
+
+describe('getFilePreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+    mockRelease.mockReset();
+  });
+
+  function makePreviewDataTable() {
+    const dt = new DataTable() as DataTable & { id: string };
+    dt.id = 'dt-1';
+    return dt;
+  }
+
+  it('returns a paginated preview when both queries succeed', async () => {
+    mockQuery.mockResolvedValueOnce([{ total_lines: 100 }]).mockResolvedValueOnce([
+      { int_line_number: '1', region: 'Wales', value: 1 },
+      { int_line_number: '2', region: 'Cymru', value: 2 }
+    ]);
+
+    const { DatasetRepository } = jest.requireMock('../../../src/repositories/dataset') as {
+      DatasetRepository: { getById: jest.Mock };
+    };
+    DatasetRepository.getById.mockResolvedValueOnce({ id: 'ds-1', factTable: [] });
+    mockDataTableFindOneByOrFail.mockResolvedValueOnce({ id: 'dt-1' });
+
+    const result = await getFilePreview('ds-1', makePreviewDataTable(), 1, 50);
+
+    expect(result).toMatchObject({ status: 200 });
+    expect(mockRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a 500 error view when the totals query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('count failed'));
+
+    const result = await getFilePreview('ds-1', makePreviewDataTable(), 1, 50);
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('returns a 500 error view when the preview query fails', async () => {
+    mockQuery.mockResolvedValueOnce([{ total_lines: 100 }]).mockRejectedValueOnce(new Error('select failed'));
+
+    const result = await getFilePreview('ds-1', makePreviewDataTable(), 1, 50);
+
+    expect(result).toMatchObject({ status: 500 });
+  });
+
+  it('returns 400 when the page parameters fail validation', async () => {
+    const validator = jest.requireMock('../../../src/validators/preview-validator') as {
+      validateParams: jest.Mock;
+    };
+    validator.validateParams.mockReturnValueOnce([{ field: 'page', message: 'out of range' }]);
+    mockQuery.mockResolvedValueOnce([{ total_lines: 100 }]);
+
+    const result = await getFilePreview('ds-1', makePreviewDataTable(), 99, 50);
+
+    expect(result).toMatchObject({ status: 400 });
+  });
+});


### PR DESCRIPTION
Closes #563.

## Summary

Brings `src/services/dimension-processor.ts` and `src/services/incoming-file-processor.ts` up to the 70% statement-coverage target set by the issue, and fixes two production bugs that the new tests exposed.

## Coverage gains

Measured with `npx jest --coverage`:

| File | Statements | Branches | Functions | Lines |
|---|---:|---:|---:|---:|
| `dimension-processor.ts` | 33.6% → **76.9%** | 22.9% → **80.95%** | 37.2% → **69.76%** | 32.2% → **76.23%** |
| `incoming-file-processor.ts` | 72.5% → **99.4%** | 30.4% → **97.82%** | 91.7% → **91.66%** | 71.9% → **100%** |

Project-wide statements: 75.2% → 77.2%. Test count: 1363 → 1442 (+79 tests, +1 suite).

## Test changes

- Removed `test/unit/services/dimension-processor.test.ts` in its previous form — it was misnamed, actually testing `src/services/date-matching.ts` (which has its own dedicated test file at `test/unit/services/date-matching.test.ts` already covering the same scenarios more thoroughly).
- New `test/unit/services/dimension-processor.test.ts` with 55 tests covering `validateSourceAssignment`, `setupTextDimension`, `cleanUpDimension`, `removeAllDimensions`, `removeMeasure`, `cleanupDimensionMeasureAndFactTable`, `validateNumericDimension`, `getDimensionPreview`, `getFactTableColumnPreview`, and `createDimensionsFromSourceAssignment`.
- New `test/unit/services/incoming-file-processor.test.ts` with 35 tests covering the encoding fallback in `validateFileAndExtractTableInfo`, the full mimetype → `FileType` mapping in `validateAndUpload` (including all 14 mimetype variants and the gzip inner-extension detection), error-type classification (InvalidUnicode / InvalidCsv / unknown), `FileValidationException` construction, and `getFilePreview`.

## Production bugs fixed

### 1. Decimal preview query throws "too few arguments"

`src/services/dimension-processor.ts:815` — the decimal preview query in `getPreviewWithNumberExtractor` was:

```ts
pgformat(
  `SELECT DISTINCT format('%s', TO_CHAR(ROUND(CAST(%I AS DECIMAL), %L), %L)) AS %I FROM %I.%I ORDER BY %I ASC LIMIT %L;`,
  // 8 args
)
```

The `format('%s', …)` was intended as PG's SQL `format()` function, but the JS `pg-format` library scanned `%s` as its own placeholder, so the template had 9 substitutions for 8 args. Any decimal preview path threw "too few arguments".

Fix: dropped the `format('%s', …)` wrapper entirely. `TO_CHAR` already returns text so the wrapper was pointless even when working.

### 2. GzipCsv uploads fail with "too few arguments"

`src/services/incoming-file-processor.ts` — `getCreateTableQuery` returns the same `read_csv(%L, ..., encoding = %L, ...)` template for both `Csv` and `GzipCsv` (two `%L` placeholders). But the encoding-fallback path in `validateFileAndExtractTableInfo` only covered `FileType.Csv` — `GzipCsv` fell through to the else branch with one arg short of the template, so `pg-format` threw and the upload surfaced as "unknown error".

Fix: extended the utf-8-then-latin-1 fallback branch to also cover `FileType.GzipCsv`. Gzipped CSVs can suffer the same encoding ambiguity as plain ones, so consistent handling makes sense.

## Verification

```
$ npm run check
... prettier:fix ✓ lint:fix ✓ test ✓ build ✓
Test Suites: 74 passed, 74 total
Tests:       1442 passed, 1442 total
```
