### PR TITLE
SW-1247: log client IP and rate-limit-bypass validity on backend HTTP requests

### DIFF
--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -9,5 +9,6 @@ declare module 'express-serve-static-core' {
     files?: Internal.Files;
     fileService: StorageService;
     datasetService: DatasetService;
+    rateLimitBypass?: boolean;
   }
 }

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -36,6 +36,7 @@ export const rateLimiter = (req: Request, res: Response, next: NextFunction): vo
     timingSafeEqual(Buffer.from(bypassToken), Buffer.from(headerToken))
   ) {
     logger.debug('Rate limit bypass token matched, skipping rate limiting for this request.');
+    req.rateLimitBypass = true;
     next();
     return;
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -20,6 +20,36 @@ function createLogger(): pino.Logger {
 
 export const logger = createLogger();
 
+// Exported for unit testing. The `req` passed in is the pino-http-wrapped Express
+// request, so all Express extensions (query, params, augmented fields) are present.
+export interface SerializedRequest {
+  method?: unknown;
+  url?: unknown;
+  query?: unknown;
+  params?: unknown;
+  ip?: unknown;
+  rateLimitBypass: boolean;
+}
+
+export function serializeRequest(
+  req: { rateLimitBypass?: boolean; ip?: string } & Record<string, unknown>
+): SerializedRequest {
+  return {
+    ...pick(req, ['method', 'url', 'query', 'params', 'ip']),
+    // Set by the rateLimiter middleware when a valid x-rate-limit-bypass token
+    // was presented — i.e. the request came from one of our own frontend pods.
+    // The token value itself is never logged; only its validity as a boolean.
+    rateLimitBypass: Boolean(req.rateLimitBypass)
+    // `ip` is Express's resolved client IP, derived from X-Forwarded-For via
+    // `app.set('trust proxy', 1)`. Correct so long as the deployment topology
+    // stays as Front Door → Container Apps ingress → Express (the only XFF-appending
+    // hop is Front Door; the ACA ingress is transparent and locked to Front Door
+    // egress IPs). If another L7 layer is ever added in front (e.g. App Gateway),
+    // bump `trust proxy` to match the new hop count or this field will log the
+    // intermediate proxy's address instead of the real client.
+  };
+}
+
 export const httpLogger = pinoHttp({
   logger,
   autoLogging: {
@@ -37,9 +67,7 @@ export const httpLogger = pinoHttp({
     return 'info';
   },
   serializers: {
-    req(req) {
-      return pick(req, ['method', 'url', 'query', 'params']);
-    },
+    req: serializeRequest,
     res(res) {
       return pick(res, ['statusCode']);
     }

--- a/test/unit/middleware/rate-limiter.test.ts
+++ b/test/unit/middleware/rate-limiter.test.ts
@@ -33,8 +33,8 @@ function createApp() {
 
   const app = express();
   app.use(rateLimiter!);
-  app.get('/test', (_req: Request, res: Response) => {
-    res.status(200).json({ message: 'ok' });
+  app.get('/test', (req: Request, res: Response) => {
+    res.status(200).json({ message: 'ok', rateLimitBypass: req.rateLimitBypass ?? false });
   });
   return app;
 }
@@ -45,21 +45,23 @@ describe('rateLimiter middleware', () => {
       mockConfig.rateLimit.bypassToken = 'test-secret-token';
     });
 
-    test('bypasses rate limit when valid token header is present', async () => {
+    test('bypasses rate limit and flags req.rateLimitBypass=true when valid token header is present', async () => {
       const app = createApp();
 
       for (let i = 0; i < 5; i++) {
         const res = await request(app).get('/test').set('x-rate-limit-bypass', 'test-secret-token');
         expect(res.status).toBe(200);
+        expect(res.body.rateLimitBypass).toBe(true);
       }
     });
 
-    test('applies rate limit when no bypass header is present', async () => {
+    test('applies rate limit and leaves req.rateLimitBypass=false when no bypass header is present', async () => {
       const app = createApp();
 
       for (let i = 0; i < 2; i++) {
         const res = await request(app).get('/test');
         expect(res.status).toBe(200);
+        expect(res.body.rateLimitBypass).toBe(false);
       }
 
       const res = await request(app).get('/test');
@@ -67,12 +69,13 @@ describe('rateLimiter middleware', () => {
       expect(res.body).toEqual({ message: 'Too many requests, please try again later.' });
     });
 
-    test('applies rate limit when bypass header has wrong token', async () => {
+    test('applies rate limit and leaves req.rateLimitBypass=false when bypass header has wrong token', async () => {
       const app = createApp();
 
       for (let i = 0; i < 2; i++) {
         const res = await request(app).get('/test').set('x-rate-limit-bypass', 'wrong-token');
         expect(res.status).toBe(200);
+        expect(res.body.rateLimitBypass).toBe(false);
       }
 
       const res = await request(app).get('/test').set('x-rate-limit-bypass', 'wrong-token');
@@ -85,12 +88,13 @@ describe('rateLimiter middleware', () => {
       mockConfig.rateLimit.bypassToken = undefined;
     });
 
-    test('applies rate limit even when bypass header is present', async () => {
+    test('applies rate limit and leaves req.rateLimitBypass=false even when bypass header is present', async () => {
       const app = createApp();
 
       for (let i = 0; i < 2; i++) {
         const res = await request(app).get('/test').set('x-rate-limit-bypass', 'some-token');
         expect(res.status).toBe(200);
+        expect(res.body.rateLimitBypass).toBe(false);
       }
 
       const res = await request(app).get('/test').set('x-rate-limit-bypass', 'some-token');

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -1,0 +1,63 @@
+jest.mock('../../../src/config', () => ({
+  config: {
+    logger: { level: 'silent' }
+  }
+}));
+
+import { serializeRequest } from '../../../src/utils/logger';
+
+describe('serializeRequest (pino-http req serializer)', () => {
+  const baseReq = {
+    method: 'GET',
+    url: '/v1/datasets?page=1',
+    query: { page: '1' },
+    params: { id: 'abc' },
+    ip: '203.0.113.47'
+  };
+
+  test('emits only the picked fields plus the rateLimitBypass boolean', () => {
+    expect(serializeRequest({ ...baseReq, rateLimitBypass: true })).toEqual({
+      method: 'GET',
+      url: '/v1/datasets?page=1',
+      query: { page: '1' },
+      params: { id: 'abc' },
+      ip: '203.0.113.47',
+      rateLimitBypass: true
+    });
+  });
+
+  test('defaults rateLimitBypass to false when the flag is absent', () => {
+    const out = serializeRequest({ ...baseReq });
+    expect(out.rateLimitBypass).toBe(false);
+  });
+
+  test('includes the Express-resolved client IP', () => {
+    const out = serializeRequest({ ...baseReq });
+    expect(out.ip).toBe('203.0.113.47');
+  });
+
+  test('omits ip when the request has none (e.g. socket-less mock contexts)', () => {
+    const { ip: _ip, ...reqWithoutIp } = baseReq;
+    const out = serializeRequest(reqWithoutIp);
+    expect(out).not.toHaveProperty('ip');
+  });
+
+  test('does not include sensitive headers or body even if present on the request', () => {
+    const headers: Record<string, string> = { authorization: 'Bearer abc' };
+    headers['x-rate-limit-bypass'] = 'super-secret-token';
+
+    const out = serializeRequest({
+      ...baseReq,
+      headers,
+      body: { password: 'hunter2' },
+      rateLimitBypass: true
+    });
+
+    const serialised = JSON.stringify(out);
+    expect(serialised).not.toContain('super-secret-token');
+    expect(serialised).not.toContain('Bearer');
+    expect(serialised).not.toContain('hunter2');
+    expect(out).not.toHaveProperty('headers');
+    expect(out).not.toHaveProperty('body');
+  });
+});


### PR DESCRIPTION
## What

Adds two fields to backend HTTP access logs so future incident investigations can be served from app logs alone, without round-tripping to Azure Front Door's access log:

- `ip` — the Express-resolved client IP, derived from `X-Forwarded-For` via the existing `app.set('trust proxy', 1)`.
- `rateLimitBypass` — boolean indicating whether the request presented a **valid** `x-rate-limit-bypass` token. Reflects validity rather than mere presence so an external caller cannot spoof "ours" in the logs by sending an arbitrary value in that header.

The bypass token value itself is never logged.

Closes [SW-1247](https://marvellconsulting.atlassian.net/browse/SW-1247).

## How

- `src/middleware/rate-limiter.ts` — after the existing `timingSafeEqual` check succeeds, set `req.rateLimitBypass = true` before calling `next()`. The non-matching branch is left untouched and the serializer defaults a missing flag to `false`, so the secret comparison stays in one place.
- `src/utils/logger.ts` — extracted the pino-http `req` serializer into an exported `serializeRequest` function (with a `SerializedRequest` interface) and added `ip` and `rateLimitBypass` to its output. Comment block on the function records the trust-proxy assumption (see "Topology assumption" below).
- `src/@types/express/index.d.ts` — extended the existing `express-serve-static-core` `Request` augmentation with the optional `rateLimitBypass?: boolean` field.

## Tests

- `test/unit/middleware/rate-limiter.test.ts` — all four existing cases now also assert `req.rateLimitBypass` is `true` only when a valid token is presented and `false` (defaulted) for absent / wrong / not-configured token paths.
- `test/unit/utils/logger.test.ts` — new file. Covers serializer output shape, IP propagation, default-false for the bypass flag, IP omission when absent, and that header / body content never leaks into the serialised output even if those fields are present on the request object.

`npm run check` passes (1,450 tests, lint, build).

## Topology assumption

The `ip` field's correctness depends on `app.set('trust proxy', 1)` matching the actual hop count in front of Express.

Verified against `statswales-terraform`: the inbound chain is Client → Azure Front Door → Container Apps ingress → Express, and only Front Door appends to `X-Forwarded-For` (the ACA ingress is transparent internal routing and is IP-locked to Front Door egress ranges in `modules/container_apps/main.tf`). `trust proxy: 1` is therefore correct today.

If a future change introduces another L7 layer in front of the container — e.g. the Application Gateway flagged as "Planned" in `SolutionDesignDocument.md` — `trust proxy` must be bumped to the new hop count or the `ip` field will log the intermediate proxy's address rather than the real client's.

## Privacy note

This adds a second copy of client IPs (already present in Front Door access logs) into the Container Apps console log table. No new processing activity, lawful basis, or DPIA scope — same controller, same data, same purpose, just a second storage location in the same Log Analytics workspace. Worth confirming separately that retention on the app-log table is not longer than retention on the Front Door access-log table.

## Out of scope

- `src/middleware/rate-limiter.ts:18` already logs `req.ip` on 429s ("Rate limit exceeded for IP: …"). Pre-existing; left as-is.
- Production verification that the new fields appear in `ContainerAppConsoleLogs_CL` unmasked — needs to be checked post-deploy in the staging environment.


[SW-1247]: https://marvellconsulting.atlassian.net/browse/SW-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ