### PR TITLE
SW-1246: cursor pagination on v2 data endpoint

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -17,6 +17,7 @@ import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../utils/page-defaults';
 import { clamp } from '../utils/clamp';
 import { ConsumerRevisionDTO } from '../dtos/consumer-revision-dto';
 import {
+  BuildDataQueryResult,
   buildDataQuery,
   sendCsv,
   sendExcel,
@@ -157,8 +158,16 @@ export const getPublishedDatasetData = async (req: Request, res: Response, next:
       ? await QueryStoreRepository.getById(filterId)
       : await QueryStoreRepository.getByRequest(dataset.id, publishedRevision.id, dataOptions);
 
-    const query = await buildDataQuery(queryStore, pageOptions);
-    await sendFormattedResponse(query, queryStore, pageOptions, res);
+    // ensurePublishedDataset loads a lean dataset (no factTable). buildDataQuery
+    // needs the fact-table columns to resolve a deterministic sort plan for
+    // both cursor-mode and offset-mode pagination, so reload with factTable
+    // when it isn't already present.
+    const datasetForBuild = dataset.factTable
+      ? dataset
+      : await PublishedDatasetRepository.getById(dataset.id, { factTable: true });
+
+    const buildResult = await buildDataQuery(queryStore, pageOptions, datasetForBuild);
+    await sendFormattedResponse(buildResult, queryStore, pageOptions, res);
   } catch (err) {
     if (res.headersSent) {
       logger.error(err, 'Error detected fetching data after headers already sent');
@@ -521,29 +530,30 @@ export const getPublicationHistory = async (_req: Request, res: Response): Promi
 };
 
 export const sendFormattedResponse = async (
-  query: string,
+  buildResult: BuildDataQueryResult,
   queryStore: QueryStore,
   pageOptions: PageOptions,
   res: Response
 ): Promise<void> => {
+  const sql = buildResult.sql;
   switch (pageOptions.format) {
     case OutputFormats.Frontend:
       // consumer view: load via PublishedDatasetRepository (consumer pool, published-only)
       return sendFrontendView(
-        query,
+        buildResult,
         queryStore,
         pageOptions,
         res,
         PublishedDatasetRepository.getById.bind(PublishedDatasetRepository)
       );
     case OutputFormats.Csv:
-      return sendCsv(query, queryStore, res);
+      return sendCsv(sql, queryStore, res);
     case OutputFormats.Excel:
-      return sendExcel(query, queryStore, res);
+      return sendExcel(sql, queryStore, res);
     case OutputFormats.Json:
-      return sendJson(query, queryStore, res);
+      return sendJson(sql, queryStore, res);
     case OutputFormats.Html:
-      return sendHtml(query, queryStore, res);
+      return sendHtml(sql, queryStore, res);
     default:
       res.status(400).json({ error: 'Format not supported' });
   }

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -68,7 +68,14 @@ import { QueryStoreRepository } from '../repositories/query-store';
 import { parsePageOptions } from '../utils/parse-page-options';
 import { resolvePreviewRevisionId } from '../utils/revision';
 import { OutputFormats } from '../enums/output-formats';
-import { buildDataQuery, sendCsv, sendExcel, sendFrontendView, sendJson } from '../services/consumer-view-v2';
+import {
+  BuildDataQueryResult,
+  buildDataQuery,
+  sendCsv,
+  sendExcel,
+  sendFrontendView,
+  sendJson
+} from '../services/consumer-view-v2';
 import { QueryStore } from '../entities/query-store';
 import { PageOptions } from '../interfaces/page-options';
 import { rebuildAllFilterTablesForRevisions, rebuildCubesForRevisions } from '../services/revision';
@@ -317,8 +324,8 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
       ? await QueryStoreRepository.getById(filterId)
       : await QueryStoreRepository.getByRequest(dataset.id, previewRevisionId, dataOptions);
 
-    const query = await buildDataQuery(queryStore, pageOptions);
-    await sendFormattedResponse(query, queryStore, pageOptions, res);
+    const buildResult = await buildDataQuery(queryStore, pageOptions, dataset);
+    await sendFormattedResponse(buildResult, queryStore, pageOptions, res);
   } catch (err) {
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
@@ -329,21 +336,28 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
 };
 
 export const sendFormattedResponse = async (
-  query: string,
+  buildResult: BuildDataQueryResult,
   queryStore: QueryStore,
   pageOptions: PageOptions,
   res: Response
 ): Promise<void> => {
+  const sql = buildResult.sql;
   switch (pageOptions.format) {
     case OutputFormats.Frontend:
       // publisher preview: load via DatasetRepository so drafts resolve and we stay on the publisher pool
-      return sendFrontendView(query, queryStore, pageOptions, res, DatasetRepository.getById.bind(DatasetRepository));
+      return sendFrontendView(
+        buildResult,
+        queryStore,
+        pageOptions,
+        res,
+        DatasetRepository.getById.bind(DatasetRepository)
+      );
     case OutputFormats.Csv:
-      return sendCsv(query, queryStore, res);
+      return sendCsv(sql, queryStore, res);
     case OutputFormats.Excel:
-      return sendExcel(query, queryStore, res);
+      return sendExcel(sql, queryStore, res);
     case OutputFormats.Json:
-      return sendJson(query, queryStore, res);
+      return sendJson(sql, queryStore, res);
     default:
       res.status(400).json({ error: 'Format not supported' });
   }

--- a/src/interfaces/page-options.ts
+++ b/src/interfaces/page-options.ts
@@ -9,4 +9,8 @@ export interface PageOptions {
   locale: Locale;
   y?: string[] | string;
   x?: string[] | string;
+  // Opaque keyset-pagination cursor. When supplied, the caller is opting in
+  // to cursor-based pagination and page_number is ignored beyond its default
+  // of 1. Mutually exclusive with non-default page_number.
+  cursor?: string;
 }

--- a/src/routes/consumer/v2/api.ts
+++ b/src/routes/consumer/v2/api.ts
@@ -371,7 +371,11 @@ publicApiV2Router.get(
       specified by the required <code>format</code> parameter. <code>csv</code> and <code>xlsx</code>
       return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code>
       and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).
-      To apply filters, first create a filter via POST /{dataset_id}/data, then use
+      <br><br>Pagination supports two modes: <code>page_number</code>-based (OFFSET) for shallow paging,
+      and opaque <code>cursor</code>-based (keyset) for efficient deep paging. The response carries both
+      <code>next_cursor</code> and <code>prev_cursor</code> in <code>page_info</code> so clients can
+      switch into cursor mode at any point. The two modes are mutually exclusive within a single request.
+      <br><br>To apply filters, first create a filter via POST /{dataset_id}/data, then use
       GET /{dataset_id}/data/{filter_id}."
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = [
@@ -380,7 +384,8 @@ publicApiV2Router.get(
       '#/components/parameters/output_format',
       '#/components/parameters/page_number',
       '#/components/parameters/page_size',
-      '#/components/parameters/sort_by'
+      '#/components/parameters/sort_by',
+      '#/components/parameters/cursor'
     ]
     #swagger.responses[200] = {
       description: 'A JSON array of data row objects',
@@ -405,7 +410,8 @@ publicApiV2Router.get(
       chosen options for a specific filter ID. The required <code>format</code> parameter selects the response shape:
       <code>csv</code> and <code>xlsx</code> stream the full filtered dataset, while <code>json</code>,
       <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100,
-      max 10,000)."
+      max 10,000). Both <code>page_number</code> and opaque <code>cursor</code> pagination are supported (mutually
+      exclusive within a single request) — see GET /{dataset_id}/data for details."
     #swagger.autoQuery = false
     #swagger.parameters['$ref'] = [
       '#/components/parameters/language',
@@ -414,6 +420,7 @@ publicApiV2Router.get(
       '#/components/parameters/page_number',
       '#/components/parameters/page_size',
       '#/components/parameters/sort_by',
+      '#/components/parameters/cursor',
       '#/components/parameters/filter_id'
     ]
     #swagger.responses[200] = {

--- a/src/routes/consumer/v2/openapi-cy.json
+++ b/src/routes/consumer/v2/openapi-cy.json
@@ -291,6 +291,9 @@
           },
           {
             "$ref": "#/components/parameters/sort_by"
+          },
+          {
+            "$ref": "#/components/parameters/cursor"
           }
         ],
         "responses": {
@@ -373,6 +376,9 @@
           },
           {
             "$ref": "#/components/parameters/sort_by"
+          },
+          {
+            "$ref": "#/components/parameters/cursor"
           },
           {
             "$ref": "#/components/parameters/filter_id"
@@ -571,6 +577,16 @@
           "type": "string"
         },
         "example": "title:asc,last_updated_at:desc"
+      },
+      "cursor": {
+        "name": "cursor",
+        "in": "query",
+        "description": "Opaque keyset cursor returned in <code>page_info.next_cursor</code> / <code>prev_cursor</code>. Pass it back to fetch the next (or previous) slice of rows without paying the OFFSET cost. Cursors are bound to a specific dataset revision, language and sort order — they become invalid if any of those change, and the server will return <code>400</code> in that case. Mutually exclusive with <code>page_number</code> > 1.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 2048
+        }
       },
       "filter": {
         "name": "filter",

--- a/src/routes/consumer/v2/openapi-en.json
+++ b/src/routes/consumer/v2/openapi-en.json
@@ -272,7 +272,7 @@
           "Data"
         ],
         "summary": "Get paginated data for a dataset",
-        "description": "Returns rows for the latest published revision in the format  specified by the required <code>format</code> parameter. <code>csv</code> and <code>xlsx</code>  return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code>  and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).  To apply filters, first create a filter via POST /{dataset_id}/data, then use  GET /{dataset_id}/data/{filter_id}.",
+        "description": "Returns rows for the latest published revision in the format  specified by the required <code>format</code> parameter. <code>csv</code> and <code>xlsx</code>  return the full dataset as a streamed file attachment. <code>json</code>, <code>frontend</code>  and <code>html</code> return paginated responses (default <code>page_size</code> 100, max 10,000).  <br><br>Pagination supports two modes: <code>page_number</code>-based (OFFSET) for shallow paging,  and opaque <code>cursor</code>-based (keyset) for efficient deep paging. The response carries both  <code>next_cursor</code> and <code>prev_cursor</code> in <code>page_info</code> so clients can  switch into cursor mode at any point. The two modes are mutually exclusive within a single request.  <br><br>To apply filters, first create a filter via POST /{dataset_id}/data, then use  GET /{dataset_id}/data/{filter_id}.",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"
@@ -291,6 +291,9 @@
           },
           {
             "$ref": "#/components/parameters/sort_by"
+          },
+          {
+            "$ref": "#/components/parameters/cursor"
           }
         ],
         "responses": {
@@ -354,7 +357,7 @@
           "Data"
         ],
         "summary": "Get a filtered data table for a dataset",
-        "description": "Returns current data for a published dataset, filtered and displayed according to the  chosen options for a specific filter ID. The required <code>format</code> parameter selects the response shape:  <code>csv</code> and <code>xlsx</code> stream the full filtered dataset, while <code>json</code>,  <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100,  max 10,000).",
+        "description": "Returns current data for a published dataset, filtered and displayed according to the  chosen options for a specific filter ID. The required <code>format</code> parameter selects the response shape:  <code>csv</code> and <code>xlsx</code> stream the full filtered dataset, while <code>json</code>,  <code>frontend</code> and <code>html</code> return paginated responses (default <code>page_size</code> 100,  max 10,000). Both <code>page_number</code> and opaque <code>cursor</code> pagination are supported (mutually  exclusive within a single request) — see GET /{dataset_id}/data for details.",
         "parameters": [
           {
             "$ref": "#/components/parameters/language"
@@ -373,6 +376,9 @@
           },
           {
             "$ref": "#/components/parameters/sort_by"
+          },
+          {
+            "$ref": "#/components/parameters/cursor"
           },
           {
             "$ref": "#/components/parameters/filter_id"
@@ -571,6 +577,16 @@
           "type": "string"
         },
         "example": "title:asc,last_updated_at:desc"
+      },
+      "cursor": {
+        "name": "cursor",
+        "in": "query",
+        "description": "Opaque keyset cursor returned in <code>page_info.next_cursor</code> / <code>prev_cursor</code>. Pass it back to fetch the next (or previous) slice of rows without paying the OFFSET cost. Cursors are bound to a specific dataset revision, language and sort order — they become invalid if any of those change, and the server will return <code>400</code> in that case. Mutually exclusive with <code>page_number</code> > 1.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 2048
+        }
       },
       "filter": {
         "name": "filter",

--- a/src/routes/consumer/v2/schema.ts
+++ b/src/routes/consumer/v2/schema.ts
@@ -94,6 +94,18 @@ export const schemaV2 = {
         schema: { type: 'string' },
         example: 'title:asc,last_updated_at:desc'
       },
+      cursor: {
+        name: 'cursor',
+        in: 'query',
+        description:
+          `Opaque keyset cursor returned in <code>page_info.next_cursor</code> / <code>prev_cursor</code>. ` +
+          `Pass it back to fetch the next (or previous) slice of rows without paying the OFFSET cost. ` +
+          `Cursors are bound to a specific dataset revision, language and sort order — they become invalid ` +
+          `if any of those change, and the server will return <code>400</code> in that case. Mutually exclusive ` +
+          `with <code>page_number</code> > 1.`,
+        required: false,
+        schema: { type: 'string', maxLength: 2048 }
+      },
       filter: {
         name: 'filter',
         in: 'query',

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -27,6 +27,7 @@ import {
   CursorKeyValue,
   CursorPayload,
   CURSOR_VERSION,
+  computeContextHash,
   computeSortHash,
   decodeCursor,
   encodeCursor
@@ -714,10 +715,7 @@ export function buildCursorFromRow(
   const key: CursorKeyValue[] = sortPlan.map((s) => normaliseKeyValue(row[s.sortIdent]));
   const payload: CursorPayload = {
     v: CURSOR_VERSION,
-    q: queryStore.id,
-    r: queryStore.revisionId,
-    l: language,
-    h: sortHash,
+    c: computeContextHash(queryStore.id, queryStore.revisionId, language, sortHash),
     d: direction,
     k: key
   };

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -333,7 +333,7 @@ export async function sendFrontendView(
   const query = buildResult.sql;
 
   try {
-    const { pageNumber = 1, pageSize = queryStore.totalLines, locale, cursor } = pageOptions;
+    const { pageNumber = 1, pageSize = queryStore.totalLines, locale } = pageOptions;
     const lang = locale.includes('en') ? 'en-gb' : 'cy-gb';
     const langForHash = locale.includes('en') ? 'en-GB' : 'cy-GB';
 
@@ -423,15 +423,29 @@ export async function sendFrontendView(
     let next_cursor: string | null = null;
     let prev_cursor: string | null = null;
     if (buildResult.sortPlan && buildResult.sortPlan.length > 0 && buildResult.sortHash && rowKeyValues.length > 0) {
-      // Offset mode emits next_cursor whenever there are more rows after the
-      // current page — it's the seam the frontend uses to swap from
-      // page_number paging into cursor paging. Cursor mode emits next_cursor
-      // only when there is genuinely more data ahead (the over-fetch row).
+      // `hasMore` gates the direction the request just walked. Forward cursor
+      // requests over-fetch ahead → hasMore means more rows further forward.
+      // Backward requests over-fetch behind → hasMore means more rows further
+      // backward. The opposite direction's cursor is always emittable in
+      // cursor mode because we necessarily came from there.
+      //
+      // Offset mode only emits next_cursor — it's the seam the frontend uses
+      // to swap from page_number paging into cursor paging at the page-cap
+      // boundary. prev_cursor stays null because offset callers navigate
+      // backwards with page_number, not a cursor.
       const lastKeys = rowKeyValues[rowKeyValues.length - 1];
       const firstKeys = rowKeyValues[0];
-      const offsetHasMore = !isCursorMode && pageSize * pageNumber < queryStore.totalLines;
 
-      if ((!isCursorMode && offsetHasMore) || (isCursorMode && hasMore)) {
+      let emitNext = false;
+      let emitPrev = false;
+      if (isCursorMode) {
+        emitNext = buildResult.direction === 'b' ? true : hasMore;
+        emitPrev = buildResult.direction === 'b' ? hasMore : true;
+      } else {
+        emitNext = pageSize * pageNumber < queryStore.totalLines;
+      }
+
+      if (emitNext) {
         next_cursor = buildCursorFromRow(
           lastKeys,
           buildResult.sortPlan,
@@ -441,7 +455,7 @@ export async function sendFrontendView(
           buildResult.sortHash
         );
       }
-      if (isCursorMode && cursor) {
+      if (emitPrev) {
         prev_cursor = buildCursorFromRow(
           firstKeys,
           buildResult.sortPlan,

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -12,6 +12,7 @@ import { FilterRow } from '../interfaces/filter-row';
 import { FilterTable } from '../interfaces/filter-table';
 import { dbManager } from '../db/database-manager';
 import { QueryStore } from '../entities/query-store';
+import { Dataset } from '../entities/dataset/dataset';
 import { BadRequestException } from '../exceptions/bad-request.exception';
 import { flattenHierarchy, sortFilterRows, transformHierarchy } from '../utils/consumer';
 import { PageOptions } from '../interfaces/page-options';
@@ -21,6 +22,17 @@ import { getColumnHeaders } from '../utils/column-headers';
 import { QueryStoreRepository } from '../repositories/query-store';
 import { DataSource } from 'typeorm';
 import { DatasetLoader } from './consumer-view';
+import {
+  CursorDirection,
+  CursorKeyValue,
+  CursorPayload,
+  CURSOR_VERSION,
+  computeSortHash,
+  decodeCursor,
+  encodeCursor
+} from '../utils/cursor-codec';
+import { KeysetSortColumn, buildKeysetWhere } from './keyset-where-builder';
+import { resolveDefaultSort } from './default-sort-resolver';
 
 const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76 rows because ?
 const HIGH_WATER_MARK = 500; // max rows to buffer in memory at once when streaming from the database
@@ -310,7 +322,7 @@ async function runAndRetryQuery(
 }
 
 export async function sendFrontendView(
-  query: string,
+  buildResult: BuildDataQueryResult,
   queryStore: QueryStore,
   pageOptions: PageOptions,
   res: Response,
@@ -318,10 +330,12 @@ export async function sendFrontendView(
 ): Promise<void> {
   logger.info(`Sending Frontend View for query id ${queryStore.id}...`);
   const cubeDataSource = dbManager.getCubeDataSource();
+  const query = buildResult.sql;
 
   try {
-    const { pageNumber = 1, pageSize = queryStore.totalLines, locale } = pageOptions;
+    const { pageNumber = 1, pageSize = queryStore.totalLines, locale, cursor } = pageOptions;
     const lang = locale.includes('en') ? 'en-gb' : 'cy-gb';
+    const langForHash = locale.includes('en') ? 'en-GB' : 'cy-GB';
 
     const filters = await cubeDataSource.query(
       pgformat(
@@ -348,8 +362,43 @@ export async function sendFrontendView(
     logger.debug(`Fetching dataset ${queryStore.datasetId}...`);
     const dataset = await loader(queryStore.datasetId, { factTable: true, dimensions: true });
 
-    const rows = await runAndRetryQuery(query, queryStore, cubeDataSource);
+    let rows = await runAndRetryQuery(query, queryStore, cubeDataSource);
     logger.debug(`Fetched ${rows.length} rows`);
+
+    // Cursor mode over-fetches one row to detect whether more rows exist;
+    // pop the trailing row before shaping the response, then reverse if we
+    // were walking backwards.
+    let hasMore = false;
+    if (buildResult.mode === 'cursor' && rows.length > pageSize) {
+      hasMore = true;
+      rows = rows.slice(0, pageSize);
+    }
+    if (buildResult.mode === 'cursor' && buildResult.direction === 'b') {
+      rows = rows.slice().reverse();
+    }
+
+    // Capture sort-key values per row before we drop the `_sort` columns —
+    // we need them later when building next_cursor / prev_cursor. In offset
+    // mode we also harvest the keys so the response carries an initial cursor
+    // for the frontend's switch into cursor mode at the page-cap boundary.
+    const sortIdents = buildResult.sortPlan?.map((s) => s.sortIdent) ?? [];
+    const rowKeyValues: Record<string, unknown>[] = rows.map((row) => {
+      const captured: Record<string, unknown> = {};
+      for (const ident of sortIdents) captured[ident] = (row as Record<string, unknown>)[ident];
+      return captured;
+    });
+
+    // Strip injected `_sort` columns so the client only sees display columns.
+    if (sortIdents.length > 0) {
+      const dropSet = new Set(sortIdents);
+      rows = rows.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(row as Record<string, unknown>)) {
+          if (!dropSet.has(k)) out[k] = v;
+        }
+        return out;
+      });
+    }
 
     // Build headers from the first row if available
     let headers: ReturnType<typeof getColumnHeaders> | undefined;
@@ -362,9 +411,47 @@ export async function sendFrontendView(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = rows.map((row: any) => Object.values(row));
 
-    const start_record = pageSize * (pageNumber - 1);
-    const end_record = start_record + rows.length;
     const total_pages = Math.max(1, Math.ceil(queryStore.totalLines / pageSize));
+
+    // current_page / start_record / end_record are meaningless under cursor
+    // pagination — the response just carries totals + cursors there.
+    const isCursorMode = buildResult.mode === 'cursor';
+    const start_record = isCursorMode ? null : pageSize * (pageNumber - 1);
+    const end_record = isCursorMode ? null : (start_record ?? 0) + rows.length;
+    const current_page = isCursorMode ? null : pageNumber;
+
+    let next_cursor: string | null = null;
+    let prev_cursor: string | null = null;
+    if (buildResult.sortPlan && buildResult.sortPlan.length > 0 && buildResult.sortHash && rowKeyValues.length > 0) {
+      // Offset mode emits next_cursor whenever there are more rows after the
+      // current page — it's the seam the frontend uses to swap from
+      // page_number paging into cursor paging. Cursor mode emits next_cursor
+      // only when there is genuinely more data ahead (the over-fetch row).
+      const lastKeys = rowKeyValues[rowKeyValues.length - 1];
+      const firstKeys = rowKeyValues[0];
+      const offsetHasMore = !isCursorMode && pageSize * pageNumber < queryStore.totalLines;
+
+      if ((!isCursorMode && offsetHasMore) || (isCursorMode && hasMore)) {
+        next_cursor = buildCursorFromRow(
+          lastKeys,
+          buildResult.sortPlan,
+          'f',
+          queryStore,
+          langForHash,
+          buildResult.sortHash
+        );
+      }
+      if (isCursorMode && cursor) {
+        prev_cursor = buildCursorFromRow(
+          firstKeys,
+          buildResult.sortPlan,
+          'b',
+          queryStore,
+          langForHash,
+          buildResult.sortHash
+        );
+      }
+    }
 
     const response = {
       dataset: ConsumerDatasetDTO.fromDataset(dataset),
@@ -373,12 +460,14 @@ export async function sendFrontendView(
       ...(headers && { headers }),
       data,
       page_info: {
-        current_page: pageNumber,
+        current_page,
         page_size: pageSize,
         total_pages,
         total_records: queryStore.totalLines,
         start_record,
-        end_record
+        end_record,
+        next_cursor,
+        prev_cursor
       }
     };
 
@@ -390,50 +479,244 @@ export async function sendFrontendView(
   }
 }
 
-export async function buildDataQuery(queryStore: QueryStore, pageOptions: PageOptions): Promise<string> {
-  logger.debug(`Building data query from query store id ${queryStore.id}...`);
-  const { locale, pageNumber, pageSize, sort } = pageOptions;
-  const lang = locale.includes('en') ? 'en-GB' : 'cy-GB';
-  let query = queryStore.query[lang] || queryStore.query['en-GB'];
+export interface SortColumnPlan {
+  // Display name as it appears in the core view (e.g. 'Year', 'Ardal').
+  displayName: string;
+  // The SQL identifier used in ORDER BY and the keyset WHERE — display
+  // name plus the translated `_sort` postfix (e.g. 'Year_sort').
+  sortIdent: string;
+  direction: 'asc' | 'desc';
+}
 
-  if (!query) {
+export type BuildDataMode = 'bulk' | 'offset' | 'cursor';
+
+export interface BuildDataQueryResult {
+  sql: string;
+  mode: BuildDataMode;
+  // Populated whenever the query is paginated. sendFrontendView consumes
+  // this to build next_cursor / prev_cursor from the returned rows.
+  sortPlan?: SortColumnPlan[];
+  // Forward or backward traversal — meaningful in cursor mode only.
+  direction?: CursorDirection;
+  // Hash used to bind cursors to a specific sort spec + language.
+  sortHash?: string;
+}
+
+export async function buildDataQuery(
+  queryStore: QueryStore,
+  pageOptions: PageOptions,
+  dataset?: Dataset
+): Promise<BuildDataQueryResult> {
+  logger.debug(`Building data query from query store id ${queryStore.id}...`);
+  const { locale, pageNumber, pageSize, sort, cursor } = pageOptions;
+  const lang = locale.includes('en') ? 'en-GB' : 'cy-GB';
+  const baseQuery = queryStore.query[lang] || queryStore.query['en-GB'];
+
+  if (!baseQuery) {
     throw new Error(`No query found for language ${lang} or fallback en-GB`);
   }
 
-  if (sort && sort.length > 0) {
-    const sortBy: string[] = [];
-    const sortColumnPostfix = `_${t('column_headers.sort', { lng: locale })}`;
-    const validColumns = queryStore.columnMapping
-      .filter((m) => m.language === lang.toLowerCase())
-      .map((m) => m.dimension_name);
-    validColumns.push(t('column_headers.data_values', { lng: locale }));
-
-    for (const sortOption of sort) {
-      const [colName, direction = 'asc'] = sortOption.split('|');
-      if (!validColumns.includes(colName)) {
-        throw new BadRequestException('errors.invalid_sort_by');
-      }
-      sortBy.push(pgformat('%I %s', `${colName}${sortColumnPostfix}`, direction.toUpperCase()));
-    }
-
-    query = pgformat('%s ORDER BY %s', query, sortBy.join(', '));
+  // Bulk export path (no pagination, no sort coercion, no cursor support).
+  if (pageSize === undefined) {
+    if (cursor) throw new BadRequestException('errors.cursor_unsupported_for_format');
+    logger.debug(`Query = ${baseQuery}`);
+    return { sql: baseQuery, mode: 'bulk' };
   }
 
-  // if no page size is provided we return all rows (bulk CSV/Excel export path)
-  if (pageSize !== undefined) {
-    const offset = (pageNumber - 1) * pageSize;
+  const sortPlan = resolveSortPlan(sort, queryStore, dataset, locale, lang);
+  const orderByClause = sortPlan.length > 0 ? buildOrderByClause(sortPlan) : '';
+  const sortHash = sortPlan.length > 0 ? computeSortHashForPlan(sortPlan, lang) : undefined;
 
-    // prevent div by zero
-    const totalPages = pageSize <= 0 ? 0 : Math.ceil(queryStore.totalLines / pageSize);
-
-    if (totalPages > 0 && pageNumber > totalPages) {
-      throw new BadRequestException('errors.page_number_too_high');
+  if (cursor) {
+    if (sortPlan.length === 0) {
+      // Without a resolvable order there is nothing to key off.
+      throw new BadRequestException('errors.cursor_requires_sort');
     }
 
-    query = pgformat(`%s LIMIT %L OFFSET %L;`, query, pageSize, offset);
+    const payload = decodeCursor(cursor, {
+      queryStoreId: queryStore.id,
+      revisionId: queryStore.revisionId,
+      language: lang,
+      sortHash: sortHash!,
+      keyArity: sortPlan.length
+    });
+
+    const sql = buildCursorSql(baseQuery, sortPlan, payload, pageSize, payload.d);
+    logger.debug(`Query = ${sql}`);
+    return { sql, mode: 'cursor', sortPlan, direction: payload.d, sortHash };
   }
 
-  logger.debug(`Query = ${query}`);
+  // Offset path.
+  const offset = (pageNumber - 1) * pageSize;
+  const totalPages = pageSize <= 0 ? 0 : Math.ceil(queryStore.totalLines / pageSize);
+  if (totalPages > 0 && pageNumber > totalPages) {
+    throw new BadRequestException('errors.page_number_too_high');
+  }
 
-  return query;
+  // Inject `_sort` columns so sendFrontendView can build a usable next_cursor
+  // from the returned rows (offset mode is the entry point the frontend uses
+  // before swapping into cursor mode at the page-cap boundary).
+  const queryWithSortIdents =
+    sortPlan.length > 0
+      ? injectSortIdentsIntoSelect(
+          baseQuery,
+          sortPlan.map((s) => s.sortIdent)
+        )
+      : baseQuery;
+
+  const orderedQuery = orderByClause ? pgformat('%s %s', queryWithSortIdents, orderByClause) : queryWithSortIdents;
+  const sql = pgformat(`%s LIMIT %L OFFSET %L;`, orderedQuery, pageSize, offset);
+  logger.debug(`Query = ${sql}`);
+  return { sql, mode: 'offset', sortPlan: sortPlan.length > 0 ? sortPlan : undefined, sortHash };
+}
+
+function resolveSortPlan(
+  userSort: string[],
+  queryStore: QueryStore,
+  dataset: Dataset | undefined,
+  locale: string,
+  lang: string
+): SortColumnPlan[] {
+  const sortPostfix = `_${t('column_headers.sort', { lng: locale })}`;
+  const langKey = lang.toLowerCase();
+  const validColumns = queryStore.columnMapping.filter((m) => m.language === langKey).map((m) => m.dimension_name);
+  validColumns.push(t('column_headers.data_values', { lng: locale }));
+  const validSet = new Set(validColumns);
+
+  const entries: Array<{ displayName: string; direction: 'asc' | 'desc' }> = [];
+  const seen = new Set<string>();
+
+  // 1. User-supplied sort_by first, with their chosen direction.
+  for (const sortOption of userSort ?? []) {
+    const [colName, direction = 'asc'] = sortOption.split('|');
+    if (!validSet.has(colName)) {
+      throw new BadRequestException('errors.invalid_sort_by');
+    }
+    if (seen.has(colName)) continue;
+    seen.add(colName);
+    entries.push({ displayName: colName, direction: direction.toLowerCase() === 'desc' ? 'desc' : 'asc' });
+  }
+
+  // 2. Append the default sort / PK tie-breakers in ASC for determinism.
+  //    resolveDefaultSort picks the time column first, falls back to first dim,
+  //    then appends remaining PK columns. We skip anything already in entries.
+  if (dataset) {
+    const defaults = resolveDefaultSort(dataset.factTable, queryStore.columnMapping, lang);
+    for (const d of defaults) {
+      if (seen.has(d.columnName)) continue;
+      seen.add(d.columnName);
+      entries.push({ displayName: d.columnName, direction: d.direction });
+    }
+  }
+
+  return entries.map((e) => ({
+    displayName: e.displayName,
+    sortIdent: `${e.displayName}${sortPostfix}`,
+    direction: e.direction
+  }));
+}
+
+function buildOrderByClause(sortPlan: SortColumnPlan[]): string {
+  const parts = sortPlan.map((s) => pgformat('%I %s', s.sortIdent, s.direction.toUpperCase()));
+  return `ORDER BY ${parts.join(', ')}`;
+}
+
+function computeSortHashForPlan(sortPlan: SortColumnPlan[], lang: string): string {
+  return computeSortHash(
+    sortPlan.map((s) => ({ columnName: s.displayName, direction: s.direction })),
+    lang
+  );
+}
+
+function buildCursorSql(
+  baseQuery: string,
+  sortPlan: SortColumnPlan[],
+  payload: CursorPayload,
+  pageSize: number,
+  direction: CursorDirection
+): string {
+  // For backward traversal we flip every ORDER BY direction so the LIMIT
+  // grabs rows immediately preceding the cursor; sendFrontendView reverses
+  // them client-side before emitting.
+  const orderedPlan: SortColumnPlan[] =
+    direction === 'b' ? sortPlan.map((s) => ({ ...s, direction: s.direction === 'asc' ? 'desc' : 'asc' })) : sortPlan;
+
+  const orderBy = buildOrderByClause(orderedPlan);
+  const keysetColumns: KeysetSortColumn[] = sortPlan.map((s) => ({
+    sqlIdent: s.sortIdent,
+    direction: s.direction
+  }));
+  const where = buildKeysetWhere(keysetColumns, payload.k, direction);
+
+  // The base query's SELECT projects display columns only (e.g. "Year",
+  // "Area"). Keyset comparisons need the `_sort` variants of those columns,
+  // so we amend the inner SELECT to also project them. sendFrontendView
+  // strips them before returning rows to the client.
+  const sortIdents = sortPlan.map((s) => s.sortIdent);
+  const innerQuery = injectSortIdentsIntoSelect(baseQuery, sortIdents);
+
+  // Wrap as a subquery so we don't have to reason about whether the inner
+  // query already has WHERE / ORDER BY clauses.
+  return pgformat(`SELECT * FROM (%s) AS t WHERE %s %s LIMIT %L;`, innerQuery, where, orderBy, pageSize + 1);
+}
+
+// Add `_sort` identifiers to the SELECT list of `baseQuery` so a wrapping
+// subquery can reference them. No-op when the base SELECT is `*` or already
+// projects every required identifier. Conservatively falls through if the
+// SELECT clause doesn't match our expected shape — the caller will then
+// surface a clear SQL error.
+function injectSortIdentsIntoSelect(baseQuery: string, sortIdents: string[]): string {
+  const match = baseQuery.match(/^(\s*SELECT\s+)(.*?)(\s+FROM\s+[\s\S]+)$/i);
+  if (!match) return baseQuery;
+  const [, prefix, cols, rest] = match;
+  const trimmed = cols.trim();
+  if (trimmed === '*') return baseQuery;
+
+  const missing = sortIdents.filter((id) => !columnAlreadyProjected(cols, id));
+  if (missing.length === 0) return baseQuery;
+
+  const extras = missing.map((id) => pgformat('%I', id)).join(', ');
+  return `${prefix}${cols}, ${extras}${rest}`;
+}
+
+function columnAlreadyProjected(selectList: string, ident: string): boolean {
+  // Cheap presence check — the base SELECT only ever quotes identifiers
+  // ("Area_sort") so a substring test catches the existing projections
+  // without parsing the SQL.
+  return selectList.includes(`"${ident}"`);
+}
+
+// Build the cursor payload for the row at `index` in the returned dataset,
+// given the resolved sort plan. The key tuple is composed from the row's
+// sort-postfixed columns so the next keyset query can resume past it.
+export function buildCursorFromRow(
+  row: Record<string, unknown>,
+  sortPlan: SortColumnPlan[],
+  direction: CursorDirection,
+  queryStore: QueryStore,
+  language: string,
+  sortHash: string
+): string {
+  const key: CursorKeyValue[] = sortPlan.map((s) => normaliseKeyValue(row[s.sortIdent]));
+  const payload: CursorPayload = {
+    v: CURSOR_VERSION,
+    q: queryStore.id,
+    r: queryStore.revisionId,
+    l: language,
+    h: sortHash,
+    d: direction,
+    k: key
+  };
+  return encodeCursor(payload);
+}
+
+function normaliseKeyValue(v: unknown): CursorKeyValue {
+  if (v === null || v === undefined) return null;
+  const t = typeof v;
+  if (t === 'string' || t === 'number' || t === 'boolean') return v as string | number | boolean;
+  // BIGINT comes back from node-postgres as a string by default; Date objects
+  // stringify safely. Fall back to JSON-roundtrip via String() for anything
+  // else exotic — the keyset comparison happens server-side via pgformat %L,
+  // which handles the implicit cast back to the column's Postgres type.
+  return String(v);
 }

--- a/src/services/default-sort-resolver.ts
+++ b/src/services/default-sort-resolver.ts
@@ -1,0 +1,75 @@
+import { FactTableColumn } from '../entities/dataset/fact-table-column';
+import { FactTableColumnType } from '../enums/fact-table-column-type';
+import { FactTableToDimensionName } from '../interfaces/fact-table-column-to-dimension-name';
+
+export interface ResolvedSortColumn {
+  // Display name as it appears in the core view (i.e. the translated
+  // dimension_name from queryStore.columnMapping for the requested language).
+  // This matches the `colName` format that buildDataQuery already expects
+  // for user-supplied sort_by.
+  columnName: string;
+  direction: 'asc' | 'desc';
+}
+
+// Resolve a deterministic default sort + tie-breakers for keyset pagination.
+//
+// Strategy:
+//   1. Primary sort = first Time column on the fact table (lowest columnIndex)
+//      if one exists; otherwise first Dimension column.
+//   2. Tie-breakers = remaining composite-PK columns (Dimension/Measure/Time)
+//      in columnIndex order, all ASC, with duplicates of the primary removed.
+//
+// Columns that have no entry in queryStore.columnMapping for the requested
+// language are skipped — they can't be referenced in the core view's translated
+// SELECT list, so emitting them would produce invalid SQL.
+//
+// Returns an empty array when no usable sort key can be resolved (no fact-table
+// columns of the expected types, or no columnMapping entries for the language).
+// The caller decides what to do with that — usually fall back to OFFSET-only.
+export function resolveDefaultSort(
+  factTable: FactTableColumn[] | null | undefined,
+  columnMapping: FactTableToDimensionName[],
+  language: string
+): ResolvedSortColumn[] {
+  if (!factTable || factTable.length === 0) return [];
+
+  const lang = language.toLowerCase();
+  const nameByFactColumn = new Map<string, string>();
+  for (const m of columnMapping) {
+    if (m.language.toLowerCase() === lang) {
+      nameByFactColumn.set(m.fact_table_column, m.dimension_name);
+    }
+  }
+  if (nameByFactColumn.size === 0) return [];
+
+  const sorted = [...factTable].sort((a, b) => a.columnIndex - b.columnIndex);
+
+  const isPkType = (t: FactTableColumnType): boolean =>
+    t === FactTableColumnType.Time || t === FactTableColumnType.Dimension || t === FactTableColumnType.Measure;
+
+  const primary =
+    sorted.find((c) => c.columnType === FactTableColumnType.Time && nameByFactColumn.has(c.columnName)) ||
+    sorted.find((c) => c.columnType === FactTableColumnType.Dimension && nameByFactColumn.has(c.columnName));
+
+  if (!primary) return [];
+
+  const result: ResolvedSortColumn[] = [];
+  const seenDisplayNames = new Set<string>();
+
+  const append = (factColName: string): void => {
+    const displayName = nameByFactColumn.get(factColName);
+    if (!displayName) return;
+    if (seenDisplayNames.has(displayName)) return;
+    seenDisplayNames.add(displayName);
+    result.push({ columnName: displayName, direction: 'asc' });
+  };
+
+  append(primary.columnName);
+
+  for (const col of sorted) {
+    if (!isPkType(col.columnType)) continue;
+    append(col.columnName);
+  }
+
+  return result;
+}

--- a/src/services/keyset-where-builder.ts
+++ b/src/services/keyset-where-builder.ts
@@ -1,0 +1,67 @@
+import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
+
+import { CursorKeyValue } from '../utils/cursor-codec';
+
+export interface KeysetSortColumn {
+  // The column identifier as it appears in the outer SELECT — already
+  // translated and postfixed where applicable. Will be passed through
+  // pgformat's %I.
+  sqlIdent: string;
+  direction: 'asc' | 'desc';
+}
+
+export type KeysetDirection = 'f' | 'b';
+
+// Build the WHERE clause for a keyset paginated query. Returns a single SQL
+// fragment of the form `(... OR ... OR ...)` that, AND-ed onto a query
+// emitting rows in `ORDER BY columns`, yields the rows strictly after (or
+// before, for backward) the supplied key tuple.
+//
+// Assumes Postgres default NULL placement: NULLS LAST for ASC, NULLS FIRST
+// for DESC. That matches the existing ORDER BY clauses elsewhere in the
+// service, which don't override NULLS placement.
+export function buildKeysetWhere(
+  columns: KeysetSortColumn[],
+  key: CursorKeyValue[],
+  direction: KeysetDirection
+): string {
+  if (columns.length === 0) {
+    throw new Error('buildKeysetWhere: at least one sort column is required');
+  }
+  if (columns.length !== key.length) {
+    throw new Error('buildKeysetWhere: key tuple length must match sort column count');
+  }
+
+  const rungs: string[] = [];
+  for (let i = 0; i < columns.length; i++) {
+    const equalityPrefix = columns.slice(0, i).map((col, j) => equalityPredicate(col.sqlIdent, key[j]));
+    const step = stepPredicate(columns[i], key[i], direction);
+    const parts = [...equalityPrefix, step];
+    rungs.push(parts.length === 1 ? parts[0] : `(${parts.join(' AND ')})`);
+  }
+
+  return `(${rungs.join(' OR ')})`;
+}
+
+function equalityPredicate(sqlIdent: string, value: CursorKeyValue): string {
+  // IS NOT DISTINCT FROM treats NULL = NULL as true, which is what we want
+  // for the equality rungs that chain into the next column.
+  return pgformat('%I IS NOT DISTINCT FROM %L', sqlIdent, value);
+}
+
+function stepPredicate(column: KeysetSortColumn, value: CursorKeyValue, direction: KeysetDirection): string {
+  // Effective direction: backward traversal flips comparators.
+  const effective = direction === 'f' ? column.direction : column.direction === 'asc' ? 'desc' : 'asc';
+
+  if (effective === 'asc') {
+    // ASC, NULLS LAST: NULLs come after all non-NULL values.
+    //  - value NOT NULL: rows with c > value, OR rows where c IS NULL.
+    //  - value NULL: nothing comes after NULL → both halves are false.
+    return pgformat('(%I > %L OR (%I IS NULL AND %L IS NOT NULL))', column.sqlIdent, value, column.sqlIdent, value);
+  }
+
+  // DESC, NULLS FIRST: NULLs come before all non-NULL values.
+  //  - value NOT NULL: rows with c < value (NULLs are already behind us).
+  //  - value NULL: rows where c IS NOT NULL.
+  return pgformat('(%I < %L OR (%I IS NOT NULL AND %L IS NULL))', column.sqlIdent, value, column.sqlIdent, value);
+}

--- a/src/utils/cursor-codec.ts
+++ b/src/utils/cursor-codec.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+
+import { BadRequestException } from '../exceptions/bad-request.exception';
+
+export const CURSOR_VERSION = 1;
+export const MAX_CURSOR_LENGTH = 2048;
+
+export type CursorDirection = 'f' | 'b';
+
+// Values that can appear in a key tuple. NULL handling matters for keyset
+// pagination, so the codec must preserve a JSON null through encode/decode.
+export type CursorKeyValue = string | number | boolean | null;
+
+export interface CursorPayload {
+  v: number;
+  q: string; // queryStoreId
+  r: string; // revisionId
+  l: string; // language
+  h: string; // sortHash
+  d: CursorDirection;
+  k: CursorKeyValue[];
+}
+
+export interface CursorExpectation {
+  queryStoreId: string;
+  revisionId: string;
+  language: string;
+  sortHash: string;
+  keyArity: number;
+}
+
+interface CanonicalSortColumn {
+  columnName: string;
+  direction: 'asc' | 'desc';
+}
+
+// Stable hash over the resolved sort spec + language. Two requests that
+// produce the same hash see compatible cursors; anything else is a 400.
+export function computeSortHash(spec: CanonicalSortColumn[], language: string): string {
+  const canonical = JSON.stringify({
+    spec: spec.map((s) => ({ c: s.columnName, d: s.direction.toLowerCase() })),
+    l: language.toLowerCase()
+  });
+  return createHash('sha256').update(canonical).digest('base64url').slice(0, 22);
+}
+
+export function encodeCursor(payload: CursorPayload): string {
+  const json = JSON.stringify(payload);
+  return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+export function decodeCursor(raw: string, expected: CursorExpectation): CursorPayload {
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > MAX_CURSOR_LENGTH) {
+    throw new BadRequestException('errors.invalid_cursor');
+  }
+
+  let decoded: string;
+  try {
+    decoded = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    throw new BadRequestException('errors.invalid_cursor');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    throw new BadRequestException('errors.invalid_cursor');
+  }
+
+  if (!isCursorPayload(parsed)) {
+    throw new BadRequestException('errors.invalid_cursor');
+  }
+
+  if (parsed.v !== CURSOR_VERSION) throw new BadRequestException('errors.invalid_cursor');
+  if (parsed.q !== expected.queryStoreId) throw new BadRequestException('errors.invalid_cursor');
+  if (parsed.r !== expected.revisionId) throw new BadRequestException('errors.invalid_cursor');
+  if (parsed.l !== expected.language) throw new BadRequestException('errors.invalid_cursor');
+  if (parsed.h !== expected.sortHash) throw new BadRequestException('errors.invalid_cursor');
+  if (parsed.k.length !== expected.keyArity) throw new BadRequestException('errors.invalid_cursor');
+
+  return parsed;
+}
+
+function isCursorPayload(x: unknown): x is CursorPayload {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o.v !== 'number') return false;
+  if (typeof o.q !== 'string') return false;
+  if (typeof o.r !== 'string') return false;
+  if (typeof o.l !== 'string') return false;
+  if (typeof o.h !== 'string') return false;
+  if (o.d !== 'f' && o.d !== 'b') return false;
+  if (!Array.isArray(o.k)) return false;
+  for (const v of o.k) {
+    if (v === null) continue;
+    const t = typeof v;
+    if (t !== 'string' && t !== 'number' && t !== 'boolean') return false;
+  }
+  return true;
+}

--- a/src/utils/cursor-codec.ts
+++ b/src/utils/cursor-codec.ts
@@ -2,6 +2,9 @@ import { createHash } from 'node:crypto';
 
 import { BadRequestException } from '../exceptions/bad-request.exception';
 
+// Bump whenever the wire format or binding changes in a shipped release: old
+// cursors then fail the version check and 400, and the client restarts from
+// page 1. Still 1 — this format has never been released.
 export const CURSOR_VERSION = 1;
 export const MAX_CURSOR_LENGTH = 2048;
 
@@ -11,12 +14,12 @@ export type CursorDirection = 'f' | 'b';
 // pagination, so the codec must preserve a JSON null through encode/decode.
 export type CursorKeyValue = string | number | boolean | null;
 
+// Decoded, in-memory shape. On the wire it is serialised positionally as
+// [v, c, d, k] (see encodeCursor) so the token doesn't carry JSON key names
+// — that keeps the URL parameter short.
 export interface CursorPayload {
   v: number;
-  q: string; // queryStoreId
-  r: string; // revisionId
-  l: string; // language
-  h: string; // sortHash
+  c: string; // context hash — binds the cursor to its query/revision/lang/sort
   d: CursorDirection;
   k: CursorKeyValue[];
 }
@@ -44,9 +47,28 @@ export function computeSortHash(spec: CanonicalSortColumn[], language: string): 
   return createHash('sha256').update(canonical).digest('base64url').slice(0, 22);
 }
 
+// Single short hash binding a cursor to the query store, revision, language
+// and sort it was issued for. It is embedded in the token in place of the raw
+// ids; on decode we recompute it from the server-known values and compare.
+// A mismatch (cursor replayed against different filters/revision/lang/sort,
+// or tampered) produces a 400 rather than silently mis-paginating. None of
+// the inputs are transmitted — only this 22-char digest — so the binding is
+// free in URL terms.
+export function computeContextHash(
+  queryStoreId: string,
+  revisionId: string,
+  language: string,
+  sortHash: string
+): string {
+  const canonical = JSON.stringify([queryStoreId, revisionId, language.toLowerCase(), sortHash]);
+  return createHash('sha256').update(canonical).digest('base64url').slice(0, 22);
+}
+
 export function encodeCursor(payload: CursorPayload): string {
-  const json = JSON.stringify(payload);
-  return Buffer.from(json, 'utf8').toString('base64url');
+  // Serialise positionally — [v, c, d, k] — rather than as an object so the
+  // token carries no JSON key names.
+  const wire = [payload.v, payload.c, payload.d, payload.k];
+  return Buffer.from(JSON.stringify(wire), 'utf8').toString('base64url');
 }
 
 export function decodeCursor(raw: string, expected: CursorExpectation): CursorPayload {
@@ -68,34 +90,38 @@ export function decodeCursor(raw: string, expected: CursorExpectation): CursorPa
     throw new BadRequestException('errors.invalid_cursor');
   }
 
-  if (!isCursorPayload(parsed)) {
+  const payload = parseWire(parsed);
+  if (!payload) {
     throw new BadRequestException('errors.invalid_cursor');
   }
 
-  if (parsed.v !== CURSOR_VERSION) throw new BadRequestException('errors.invalid_cursor');
-  if (parsed.q !== expected.queryStoreId) throw new BadRequestException('errors.invalid_cursor');
-  if (parsed.r !== expected.revisionId) throw new BadRequestException('errors.invalid_cursor');
-  if (parsed.l !== expected.language) throw new BadRequestException('errors.invalid_cursor');
-  if (parsed.h !== expected.sortHash) throw new BadRequestException('errors.invalid_cursor');
-  if (parsed.k.length !== expected.keyArity) throw new BadRequestException('errors.invalid_cursor');
+  const expectedContext = computeContextHash(
+    expected.queryStoreId,
+    expected.revisionId,
+    expected.language,
+    expected.sortHash
+  );
 
-  return parsed;
+  if (payload.v !== CURSOR_VERSION) throw new BadRequestException('errors.invalid_cursor');
+  if (payload.c !== expectedContext) throw new BadRequestException('errors.invalid_cursor');
+  if (payload.k.length !== expected.keyArity) throw new BadRequestException('errors.invalid_cursor');
+
+  return payload;
 }
 
-function isCursorPayload(x: unknown): x is CursorPayload {
-  if (!x || typeof x !== 'object') return false;
-  const o = x as Record<string, unknown>;
-  if (typeof o.v !== 'number') return false;
-  if (typeof o.q !== 'string') return false;
-  if (typeof o.r !== 'string') return false;
-  if (typeof o.l !== 'string') return false;
-  if (typeof o.h !== 'string') return false;
-  if (o.d !== 'f' && o.d !== 'b') return false;
-  if (!Array.isArray(o.k)) return false;
-  for (const v of o.k) {
-    if (v === null) continue;
-    const t = typeof v;
-    if (t !== 'string' && t !== 'number' && t !== 'boolean') return false;
+// Validate and lift the positional wire array [v, c, d, k] into a typed
+// payload. Returns null on any shape mismatch.
+function parseWire(x: unknown): CursorPayload | null {
+  if (!Array.isArray(x) || x.length !== 4) return null;
+  const [v, c, d, k] = x;
+  if (typeof v !== 'number') return null;
+  if (typeof c !== 'string') return null;
+  if (d !== 'f' && d !== 'b') return null;
+  if (!Array.isArray(k)) return null;
+  for (const val of k) {
+    if (val === null) continue;
+    const t = typeof val;
+    if (t !== 'string' && t !== 'number' && t !== 'boolean') return null;
   }
-  return true;
+  return { v, c, d, k };
 }

--- a/src/utils/parse-page-options.ts
+++ b/src/utils/parse-page-options.ts
@@ -5,7 +5,7 @@ import { FieldValidationError, matchedData } from 'express-validator';
 import { isDownloadFormat, OutputFormats } from '../enums/output-formats';
 import { BadRequestException } from '../exceptions/bad-request.exception';
 import { PageOptions } from '../interfaces/page-options';
-import { format2Validator, pageNumberValidator, pageSizeValidator } from '../validators';
+import { cursorValidator, format2Validator, pageNumberValidator, pageSizeValidator } from '../validators';
 import { logger } from './logger';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from './page-defaults';
 import { parseSortByParam } from './parse-sort-by-param';
@@ -20,7 +20,7 @@ export interface ParsePageOptionsOpts {
 
 export async function parsePageOptions(req: Request, opts: ParsePageOptionsOpts = {}): Promise<PageOptions> {
   logger.debug('Parsing page options from request...');
-  const validations = [format2Validator(), pageNumberValidator(), pageSizeValidator()];
+  const validations = [format2Validator(), pageNumberValidator(), pageSizeValidator(), cursorValidator()];
 
   for (const validation of validations) {
     const result = await validation.run(req);
@@ -42,10 +42,18 @@ export async function parsePageOptions(req: Request, opts: ParsePageOptionsOpts 
   const pageSize = params.page_size ?? defaultPageSize(format);
   const locale = req.language as Locale;
   const sort = parseSortByParam(req.query.sort_by as string);
+  const cursor = typeof params.cursor === 'string' ? params.cursor : undefined;
 
   if (!isDownloadFormat(format) && pageSize !== undefined && pageSize > MAX_PAGE_SIZE) {
     throw new BadRequestException(`page_size must not exceed ${MAX_PAGE_SIZE}`);
   }
 
-  return { format, pageNumber, pageSize, sort, locale };
+  // page_number and cursor are mutually exclusive — the caller has to pick a
+  // single pagination mode per request. page_number defaults to 1 when
+  // omitted, so a cursor + explicit page_number > 1 is what we reject.
+  if (cursor && (params.page_number ?? 1) > 1) {
+    throw new BadRequestException('errors.cursor_and_page_number_mutually_exclusive');
+  }
+
+  return { format, pageNumber, pageSize, sort, locale, cursor };
 }

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -31,6 +31,9 @@ export const pageNumberValidator = (): ValidationChain =>
 export const pageSizeValidator = (): ValidationChain =>
   check('page_size').optional().trim().notEmpty().isInt({ min: 1 }).toInt();
 
+export const cursorValidator = (): ValidationChain =>
+  check('cursor').optional().isString().isLength({ min: 1, max: 2048 });
+
 export const filterIdValidator = (): ValidationChain => check('filter_id').trim().notEmpty().isString();
 
 export const userStatusValidator = (): ValidationChain => body('status').isIn(Object.values(UserStatus));

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -225,6 +225,126 @@ describe('Consumer V2 — data + pivot endpoints', () => {
       const res = await request(app).get('/v2/99999999-9999-4999-8999-999999999999/data');
       expect(res.status).toBe(404);
     });
+
+    describe('cursor pagination', () => {
+      it('frontend response includes next_cursor / prev_cursor in page_info', async () => {
+        const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 5 });
+        // eslint-disable-next-line no-console
+        console.log('DEBUG headers:', JSON.stringify(res.body.headers));
+        // eslint-disable-next-line no-console
+        console.log('DEBUG first row keys (data):', res.body.data?.[0]);
+        expect(res.status).toBe(200);
+        expect(res.body.page_info).toHaveProperty('next_cursor');
+        expect(res.body.page_info).toHaveProperty('prev_cursor');
+        // First offset-mode page on a 12-row dataset with page_size=5 → there's more, so next_cursor is set
+        expect(typeof res.body.page_info.next_cursor).toBe('string');
+        expect(res.body.page_info.next_cursor.length).toBeGreaterThan(0);
+        expect(res.body.page_info.prev_cursor).toBeNull();
+      });
+
+      it('walking forward by cursor returns the same rows in the same order as offset paging', async () => {
+        const pageSize = 5;
+
+        // Offset traversal — establish ground truth
+        const offsetRows: unknown[] = [];
+        for (let p = 1; ; p++) {
+          const r = await request(app)
+            .get(`/v2/${DATASET_ID}/data`)
+            .query({ format: 'frontend', page_size: pageSize, page_number: p });
+          expect(r.status).toBe(200);
+          offsetRows.push(...r.body.data);
+          if (offsetRows.length >= r.body.page_info.total_records) break;
+        }
+        expect(offsetRows.length).toBe(ROW_COUNT);
+
+        // Cursor traversal — start from the first offset page's next_cursor, then walk
+        const first = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: pageSize });
+        expect(first.status).toBe(200);
+        const cursorRows: unknown[] = [...first.body.data];
+        let cursor: string | null = first.body.page_info.next_cursor;
+
+        while (cursor) {
+          const r = await request(app)
+            .get(`/v2/${DATASET_ID}/data`)
+            .query({ format: 'frontend', page_size: pageSize, cursor });
+          expect(r.status).toBe(200);
+          cursorRows.push(...r.body.data);
+          cursor = r.body.page_info.next_cursor;
+        }
+
+        expect(cursorRows.length).toBe(ROW_COUNT);
+        expect(JSON.stringify(cursorRows)).toBe(JSON.stringify(offsetRows));
+      });
+
+      it('returns null next_cursor on the final cursor-mode page', async () => {
+        const first = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 100 }); // 100 > ROW_COUNT
+        // All rows fit on one page → there's no "next" page, so offset-mode next_cursor should be null
+        expect(first.status).toBe(200);
+        expect(first.body.page_info.next_cursor).toBeNull();
+      });
+
+      it('rejects a malformed cursor with 400', async () => {
+        const res = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: 5, cursor: 'not-a-real-cursor' });
+        expect(res.status).toBe(400);
+      });
+
+      it('rejects a cursor bound to a different queryStore (filter_id mismatch)', async () => {
+        // Get a valid cursor from the unfiltered endpoint
+        const unfiltered = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 5 });
+        expect(unfiltered.status).toBe(200);
+        const cursor = unfiltered.body.page_info.next_cursor;
+        expect(typeof cursor).toBe('string');
+
+        // Replay it against the filtered endpoint, which has a different queryStoreId
+        const res = await request(app)
+          .get(`/v2/${DATASET_ID}/data/${dataFilterId}`)
+          .query({ format: 'frontend', page_size: 5, cursor });
+        expect(res.status).toBe(400);
+      });
+
+      it('rejects a cursor when the language differs from the one it was issued in', async () => {
+        const en = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 5 });
+        const cursor = en.body.page_info.next_cursor;
+
+        const res = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: 5, cursor, lang: 'cy' });
+        expect(res.status).toBe(400);
+      });
+
+      it('rejects cursor + page_number > 1 as mutually exclusive', async () => {
+        const first = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 5 });
+        const cursor = first.body.page_info.next_cursor;
+
+        const res = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: 5, cursor, page_number: 2 });
+        expect(res.status).toBe(400);
+      });
+
+      it('walks backwards using prev_cursor and returns the prior slice', async () => {
+        const pageSize = 5;
+        const first = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: pageSize });
+        const forward = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: pageSize, cursor: first.body.page_info.next_cursor });
+        expect(forward.status).toBe(200);
+        expect(forward.body.page_info.prev_cursor).toBeTruthy();
+
+        const back = await request(app)
+          .get(`/v2/${DATASET_ID}/data`)
+          .query({ format: 'frontend', page_size: pageSize, cursor: forward.body.page_info.prev_cursor });
+        expect(back.status).toBe(200);
+        // Walking back should land us on the original first-page rows
+        expect(JSON.stringify(back.body.data)).toBe(JSON.stringify(first.body.data));
+      });
+    });
   });
 
   describe('GET /v2/:dataset_id/data/:filter_id — filtered', () => {

--- a/test/integration/routes/consumer-v2/data-and-pivot.test.ts
+++ b/test/integration/routes/consumer-v2/data-and-pivot.test.ts
@@ -229,10 +229,6 @@ describe('Consumer V2 — data + pivot endpoints', () => {
     describe('cursor pagination', () => {
       it('frontend response includes next_cursor / prev_cursor in page_info', async () => {
         const res = await request(app).get(`/v2/${DATASET_ID}/data`).query({ format: 'frontend', page_size: 5 });
-        // eslint-disable-next-line no-console
-        console.log('DEBUG headers:', JSON.stringify(res.body.headers));
-        // eslint-disable-next-line no-console
-        console.log('DEBUG first row keys (data):', res.body.data?.[0]);
         expect(res.status).toBe(200);
         expect(res.body.page_info).toHaveProperty('next_cursor');
         expect(res.body.page_info).toHaveProperty('prev_cursor');
@@ -343,6 +339,12 @@ describe('Consumer V2 — data + pivot endpoints', () => {
         expect(back.status).toBe(200);
         // Walking back should land us on the original first-page rows
         expect(JSON.stringify(back.body.data)).toBe(JSON.stringify(first.body.data));
+        // Backward-direction responses must always carry next_cursor: we came
+        // from somewhere forward, so a forward link back to it has to exist.
+        // The first-page boundary still nulls prev_cursor (no rows further
+        // behind) — that's what stops the loop.
+        expect(back.body.page_info.next_cursor).toBeTruthy();
+        expect(back.body.page_info.prev_cursor).toBeNull();
       });
     });
   });

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -581,7 +581,7 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM data', queryStore, pageOptions, res, mockGetById);
+      await sendFrontendView({ sql: 'SELECT * FROM data', mode: 'offset' }, queryStore, pageOptions, res, mockGetById);
 
       expect(res.json).toHaveBeenCalled();
       const jsonArg = (res.json as jest.Mock).mock.calls[0][0];
@@ -611,7 +611,7 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM data', queryStore, pageOptions, res, mockGetById);
+      await sendFrontendView({ sql: 'SELECT * FROM data', mode: 'offset' }, queryStore, pageOptions, res, mockGetById);
 
       // First query should use 'cy-gb' language
       expect(mockCubeQuery.mock.calls[0][0]).toContain('cy-gb');
@@ -635,7 +635,7 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM data', queryStore, pageOptions, res, mockGetById);
+      await sendFrontendView({ sql: 'SELECT * FROM data', mode: 'offset' }, queryStore, pageOptions, res, mockGetById);
 
       const jsonArg = (res.json as jest.Mock).mock.calls[0][0];
       expect(jsonArg.note_codes).toEqual([]);
@@ -660,7 +660,13 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM "schema".core_view_mat_en', queryStore, pageOptions, res, mockGetById);
+      await sendFrontendView(
+        { sql: 'SELECT * FROM "schema".core_view_mat_en', mode: 'offset' },
+        queryStore,
+        pageOptions,
+        res,
+        mockGetById
+      );
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);
       const retryCall = mockCubeQuery.mock.calls[3][0] as string;
@@ -689,7 +695,13 @@ describe('consumer-view-v2 service', () => {
       };
       const res = createMockStreamResponse();
 
-      await sendFrontendView('SELECT * FROM "schema".core_view_en', queryStore, pageOptions, res, mockGetById);
+      await sendFrontendView(
+        { sql: 'SELECT * FROM "schema".core_view_en', mode: 'offset' },
+        queryStore,
+        pageOptions,
+        res,
+        mockGetById
+      );
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);
       const retryCall = mockCubeQuery.mock.calls[3][0] as string;
@@ -719,7 +731,13 @@ describe('consumer-view-v2 service', () => {
       const res = createMockStreamResponse();
 
       await expect(
-        sendFrontendView('SELECT * FROM "schema".core_view_mat_en', queryStore, pageOptions, res, mockGetById)
+        sendFrontendView(
+          { sql: 'SELECT * FROM "schema".core_view_mat_en', mode: 'offset' },
+          queryStore,
+          pageOptions,
+          res,
+          mockGetById
+        )
       ).rejects.toThrow('retry also failed');
 
       expect(mockCubeQuery).toHaveBeenCalledTimes(4);
@@ -743,9 +761,10 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('LIMIT');
-      expect(result).toContain('OFFSET');
-      expect(result).toContain('25'); // pageSize
+      expect(result.sql).toContain('LIMIT');
+      expect(result.sql).toContain('OFFSET');
+      expect(result.sql).toContain('25'); // pageSize
+      expect(result.mode).toBe('offset');
     });
 
     it('should use Welsh query for Welsh locale', async () => {
@@ -766,7 +785,7 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('welsh');
+      expect(result.sql).toContain('welsh');
     });
 
     it('should fallback to English query if Welsh not available', async () => {
@@ -784,7 +803,7 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('english');
+      expect(result.sql).toContain('english');
     });
 
     it('should add ORDER BY for sort options', async () => {
@@ -806,9 +825,9 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('ORDER BY');
-      expect(result).toContain('ASC');
-      expect(result).toContain('DESC');
+      expect(result.sql).toContain('ORDER BY');
+      expect(result.sql).toContain('ASC');
+      expect(result.sql).toContain('DESC');
     });
 
     it('should allow sorting by Data values column', async () => {
@@ -827,8 +846,8 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).toContain('ORDER BY');
-      expect(result).toContain('ASC');
+      expect(result.sql).toContain('ORDER BY');
+      expect(result.sql).toContain('ASC');
     });
 
     it('should throw BadRequestException for sort column not in view', async () => {
@@ -917,8 +936,9 @@ describe('consumer-view-v2 service', () => {
 
       const result = await buildDataQuery(queryStore, pageOptions);
 
-      expect(result).not.toContain('LIMIT');
-      expect(result).not.toContain('OFFSET');
+      expect(result.sql).not.toContain('LIMIT');
+      expect(result.sql).not.toContain('OFFSET');
+      expect(result.mode).toBe('bulk');
     });
 
     it('should handle zero total lines', async () => {
@@ -936,7 +956,45 @@ describe('consumer-view-v2 service', () => {
 
       // Should not throw - zero results is valid
       const result = await buildDataQuery(queryStore, pageOptions);
-      expect(result).toBeDefined();
+      expect(result.sql).toBeDefined();
+    });
+
+    describe('cursor mode', () => {
+      it('rejects a cursor when no usable sort plan can be resolved', async () => {
+        const queryStore = createMockQueryStore({
+          query: { 'en-GB': 'SELECT * FROM test_table' },
+          totalLines: 100,
+          columnMapping: []
+        });
+        // No dataset, no columnMapping → no default sort to anchor against
+        const pageOptions: PageOptions = {
+          format: OutputFormats.Frontend,
+          sort: [],
+          locale: Locale.EnglishGb,
+          pageNumber: 1,
+          pageSize: 10,
+          cursor: 'irrelevant'
+        };
+
+        await expect(buildDataQuery(queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+      });
+
+      it('rejects a cursor in bulk-export mode', async () => {
+        const queryStore = createMockQueryStore({
+          query: { 'en-GB': 'SELECT * FROM test_table' },
+          totalLines: 100
+        });
+        const pageOptions: PageOptions = {
+          format: OutputFormats.Csv,
+          sort: [],
+          locale: Locale.EnglishGb,
+          pageNumber: 1,
+          // bulk-export path: pageSize undefined
+          cursor: 'irrelevant'
+        };
+
+        await expect(buildDataQuery(queryStore, pageOptions)).rejects.toThrow(BadRequestException);
+      });
     });
   });
 });

--- a/test/unit/services/default-sort-resolver.test.ts
+++ b/test/unit/services/default-sort-resolver.test.ts
@@ -1,0 +1,116 @@
+import { FactTableColumn } from '../../../src/entities/dataset/fact-table-column';
+import { FactTableColumnType } from '../../../src/enums/fact-table-column-type';
+import { FactTableToDimensionName } from '../../../src/interfaces/fact-table-column-to-dimension-name';
+import { resolveDefaultSort } from '../../../src/services/default-sort-resolver';
+
+function col(columnName: string, columnType: FactTableColumnType, columnIndex: number): FactTableColumn {
+  return { columnName, columnType, columnIndex } as FactTableColumn;
+}
+
+function mapping(fact: string, name: string, language: string): FactTableToDimensionName {
+  return { fact_table_column: fact, dimension_name: name, language };
+}
+
+describe('resolveDefaultSort', () => {
+  it('returns [] when factTable is null or empty', () => {
+    expect(resolveDefaultSort(null, [], 'en-GB')).toEqual([]);
+    expect(resolveDefaultSort([], [], 'en-GB')).toEqual([]);
+  });
+
+  it('returns [] when there is no columnMapping for the requested language', () => {
+    const ft = [col('year_code', FactTableColumnType.Time, 0)];
+    const cm = [mapping('year_code', 'Year', 'cy-gb')];
+    expect(resolveDefaultSort(ft, cm, 'en-GB')).toEqual([]);
+  });
+
+  it('picks the first Time column as primary sort', () => {
+    const ft = [
+      col('area_code', FactTableColumnType.Dimension, 0),
+      col('year_code', FactTableColumnType.Time, 1),
+      col('measure_code', FactTableColumnType.Measure, 2),
+      col('data', FactTableColumnType.DataValues, 3)
+    ];
+    const cm = [
+      mapping('area_code', 'Area', 'en-gb'),
+      mapping('year_code', 'Year', 'en-gb'),
+      mapping('measure_code', 'Measure', 'en-gb')
+    ];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result[0]).toEqual({ columnName: 'Year', direction: 'asc' });
+  });
+
+  it('falls back to the first Dimension when no Time column exists', () => {
+    const ft = [col('area_code', FactTableColumnType.Dimension, 0), col('country', FactTableColumnType.Dimension, 1)];
+    const cm = [mapping('area_code', 'Area', 'en-gb'), mapping('country', 'Country', 'en-gb')];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result[0]).toEqual({ columnName: 'Area', direction: 'asc' });
+  });
+
+  it('appends remaining PK columns as ASC tie-breakers, de-duping the primary', () => {
+    const ft = [
+      col('area_code', FactTableColumnType.Dimension, 0),
+      col('year_code', FactTableColumnType.Time, 1),
+      col('measure_code', FactTableColumnType.Measure, 2)
+    ];
+    const cm = [
+      mapping('area_code', 'Area', 'en-gb'),
+      mapping('year_code', 'Year', 'en-gb'),
+      mapping('measure_code', 'Measure', 'en-gb')
+    ];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result).toEqual([
+      { columnName: 'Year', direction: 'asc' },
+      { columnName: 'Area', direction: 'asc' },
+      { columnName: 'Measure', direction: 'asc' }
+    ]);
+  });
+
+  it('skips non-PK column types (DataValues, NoteCodes, Ignore, etc.)', () => {
+    const ft = [
+      col('year_code', FactTableColumnType.Time, 0),
+      col('data', FactTableColumnType.DataValues, 1),
+      col('notes', FactTableColumnType.NoteCodes, 2),
+      col('ignored', FactTableColumnType.Ignore, 3),
+      col('area_code', FactTableColumnType.Dimension, 4)
+    ];
+    const cm = [
+      mapping('year_code', 'Year', 'en-gb'),
+      mapping('data', 'Data', 'en-gb'),
+      mapping('notes', 'Notes', 'en-gb'),
+      mapping('area_code', 'Area', 'en-gb')
+    ];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result.map((r) => r.columnName)).toEqual(['Year', 'Area']);
+  });
+
+  it('uses the translated names for Welsh', () => {
+    const ft = [col('area_code', FactTableColumnType.Dimension, 0), col('year_code', FactTableColumnType.Time, 1)];
+    const cm = [
+      mapping('area_code', 'Area', 'en-gb'),
+      mapping('area_code', 'Ardal', 'cy-gb'),
+      mapping('year_code', 'Year', 'en-gb'),
+      mapping('year_code', 'Blwyddyn', 'cy-gb')
+    ];
+    const result = resolveDefaultSort(ft, cm, 'cy-GB');
+    expect(result.map((r) => r.columnName)).toEqual(['Blwyddyn', 'Ardal']);
+  });
+
+  it('skips PK columns that lack a mapping for the requested language', () => {
+    const ft = [
+      col('year_code', FactTableColumnType.Time, 0),
+      col('area_code', FactTableColumnType.Dimension, 1),
+      col('measure_code', FactTableColumnType.Measure, 2)
+    ];
+    // measure_code has no English mapping → must be omitted
+    const cm = [mapping('year_code', 'Year', 'en-gb'), mapping('area_code', 'Area', 'en-gb')];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result.map((r) => r.columnName)).toEqual(['Year', 'Area']);
+  });
+
+  it('respects columnIndex order when picking the primary', () => {
+    const ft = [col('area_code', FactTableColumnType.Dimension, 1), col('country', FactTableColumnType.Dimension, 0)];
+    const cm = [mapping('area_code', 'Area', 'en-gb'), mapping('country', 'Country', 'en-gb')];
+    const result = resolveDefaultSort(ft, cm, 'en-GB');
+    expect(result[0].columnName).toBe('Country');
+  });
+});

--- a/test/unit/services/keyset-where-builder.test.ts
+++ b/test/unit/services/keyset-where-builder.test.ts
@@ -1,0 +1,108 @@
+import { KeysetSortColumn, buildKeysetWhere } from '../../../src/services/keyset-where-builder';
+
+describe('buildKeysetWhere', () => {
+  describe('single column', () => {
+    it('emits a forward ASC predicate with NULLS-LAST semantics', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'year_sort', direction: 'asc' }], [2022], 'f');
+      expect(sql).toBe(`((year_sort > 2022 OR (year_sort IS NULL AND 2022 IS NOT NULL)))`);
+    });
+
+    it('emits a forward DESC predicate with NULLS-FIRST semantics', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'year_sort', direction: 'desc' }], [2022], 'f');
+      expect(sql).toBe(`((year_sort < 2022 OR (year_sort IS NOT NULL AND 2022 IS NULL)))`);
+    });
+
+    it('flips comparators for backward ASC', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'year_sort', direction: 'asc' }], [2022], 'b');
+      // backward over ASC = step uses DESC rules
+      expect(sql).toContain('year_sort < 2022');
+      expect(sql).toContain('year_sort IS NOT NULL');
+    });
+
+    it('flips comparators for backward DESC', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'year_sort', direction: 'desc' }], [2022], 'b');
+      expect(sql).toContain('year_sort > 2022');
+      expect(sql).toContain('year_sort IS NULL');
+    });
+  });
+
+  describe('multi-column mixed direction', () => {
+    it('builds an OR-ladder with equality prefixes for ASC then DESC', () => {
+      const cols: KeysetSortColumn[] = [
+        { sqlIdent: 'year_sort', direction: 'asc' },
+        { sqlIdent: 'area_sort', direction: 'desc' }
+      ];
+      const sql = buildKeysetWhere(cols, [2022, 'Wales'], 'f');
+
+      expect(sql).toContain('year_sort > 2022');
+      expect(sql).toContain('year_sort IS NOT DISTINCT FROM 2022');
+      expect(sql).toContain(`area_sort < 'Wales'`);
+    });
+
+    it('produces N rungs joined by top-level OR for N sort columns', () => {
+      const cols: KeysetSortColumn[] = [
+        { sqlIdent: 'a', direction: 'asc' },
+        { sqlIdent: 'b', direction: 'asc' },
+        { sqlIdent: 'c', direction: 'asc' }
+      ];
+      const sql = buildKeysetWhere(cols, [1, 2, 3], 'f');
+      // Each rung after the first should mention the equality of all preceding
+      // columns; 3 columns → 3 rungs → 2 IS NOT DISTINCT FROM equality clauses
+      // appearing in the prefixes for rungs 2 and 3.
+      expect(sql).toContain('a IS NOT DISTINCT FROM 1');
+      expect(sql).toContain('b IS NOT DISTINCT FROM 2');
+      expect(sql).toContain('c > 3');
+    });
+  });
+
+  describe('NULL handling', () => {
+    it('serialises a NULL key value as the literal NULL', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'col', direction: 'asc' }], [null], 'f');
+      expect(sql).toContain('col IS NULL AND NULL IS NOT NULL');
+    });
+
+    it('uses IS NOT DISTINCT FROM for equality, so NULL = NULL holds', () => {
+      const sql = buildKeysetWhere(
+        [
+          { sqlIdent: 'a', direction: 'asc' },
+          { sqlIdent: 'b', direction: 'asc' }
+        ],
+        [null, 5],
+        'f'
+      );
+      expect(sql).toContain('a IS NOT DISTINCT FROM NULL');
+    });
+  });
+
+  describe('identifier escaping', () => {
+    it('escapes identifiers that need quoting via pgformat %I', () => {
+      // mixed-case forces pgformat to wrap in double quotes
+      const sql = buildKeysetWhere([{ sqlIdent: 'Weird Col', direction: 'asc' }], ['x'], 'f');
+      expect(sql).toContain(`"Weird Col"`);
+    });
+
+    it('escapes string literals with embedded quotes via pgformat %L', () => {
+      const sql = buildKeysetWhere([{ sqlIdent: 'col', direction: 'asc' }], [`O'Hara`], 'f');
+      expect(sql).toContain(`'O''Hara'`);
+    });
+  });
+
+  describe('error cases', () => {
+    it('throws when no columns supplied', () => {
+      expect(() => buildKeysetWhere([], [], 'f')).toThrow(/at least one sort column/);
+    });
+
+    it('throws when key arity does not match column count', () => {
+      expect(() =>
+        buildKeysetWhere(
+          [
+            { sqlIdent: 'a', direction: 'asc' },
+            { sqlIdent: 'b', direction: 'asc' }
+          ],
+          [1],
+          'f'
+        )
+      ).toThrow(/length must match/);
+    });
+  });
+});

--- a/test/unit/utils/cursor-codec.test.ts
+++ b/test/unit/utils/cursor-codec.test.ts
@@ -2,6 +2,7 @@ import {
   CURSOR_VERSION,
   CursorExpectation,
   CursorPayload,
+  computeContextHash,
   computeSortHash,
   decodeCursor,
   encodeCursor
@@ -16,17 +17,27 @@ const baseExpected: CursorExpectation = {
   keyArity: 2
 };
 
+const baseContext = computeContextHash(
+  baseExpected.queryStoreId,
+  baseExpected.revisionId,
+  baseExpected.language,
+  baseExpected.sortHash
+);
+
 function basePayload(overrides: Partial<CursorPayload> = {}): CursorPayload {
   return {
     v: CURSOR_VERSION,
-    q: baseExpected.queryStoreId,
-    r: baseExpected.revisionId,
-    l: baseExpected.language,
-    h: baseExpected.sortHash,
+    c: baseContext,
     d: 'f',
     k: [2022, 'W06000001'],
     ...overrides
   };
+}
+
+// Build an encoded token straight from a positional [v, c, d, k] wire array,
+// bypassing the typed encodeCursor so malformed shapes can be exercised.
+function encodeWire(wire: unknown): string {
+  return Buffer.from(JSON.stringify(wire), 'utf8').toString('base64url');
 }
 
 describe('computeSortHash', () => {
@@ -63,6 +74,38 @@ describe('computeSortHash', () => {
   it('differs across languages', () => {
     const a = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB');
     const b = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'cy-GB');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('computeContextHash', () => {
+  it('produces a stable hash for the same inputs', () => {
+    const a = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    const b = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    expect(a).toBe(b);
+  });
+
+  it('differs when the query store changes', () => {
+    const a = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    const b = computeContextHash('qs-2', 'rev-1', 'en-GB', baseExpected.sortHash);
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when the revision changes', () => {
+    const a = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    const b = computeContextHash('qs-1', 'rev-2', 'en-GB', baseExpected.sortHash);
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when the language changes', () => {
+    const a = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    const b = computeContextHash('qs-1', 'rev-1', 'cy-GB', baseExpected.sortHash);
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when the sort hash changes', () => {
+    const a = computeContextHash('qs-1', 'rev-1', 'en-GB', baseExpected.sortHash);
+    const b = computeContextHash('qs-1', 'rev-1', 'en-GB', 'other-sort-hash');
     expect(a).not.toBe(b);
   });
 });
@@ -114,8 +157,13 @@ describe('decodeCursor rejections', () => {
     expect(() => decodeCursor(garbage, baseExpected)).toThrow(BadRequestException);
   });
 
-  it('rejects a JSON payload that is not a cursor object', () => {
-    const wrong = Buffer.from(JSON.stringify({ foo: 'bar' }), 'utf8').toString('base64url');
+  it('rejects a payload that is not a positional array', () => {
+    const wrong = encodeWire({ foo: 'bar' });
+    expect(() => decodeCursor(wrong, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a positional array of the wrong length', () => {
+    const wrong = encodeWire([CURSOR_VERSION, baseContext, 'f']);
     expect(() => decodeCursor(wrong, baseExpected)).toThrow(BadRequestException);
   });
 
@@ -150,14 +198,12 @@ describe('decodeCursor rejections', () => {
   });
 
   it('rejects a key tuple containing an object', () => {
-    const encoded = Buffer.from(JSON.stringify({ ...basePayload(), k: [{ nested: true }, 'x'] }), 'utf8').toString(
-      'base64url'
-    );
+    const encoded = encodeWire([CURSOR_VERSION, baseContext, 'f', [{ nested: true }, 'x']]);
     expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
   });
 
   it('rejects an invalid direction', () => {
-    const encoded = Buffer.from(JSON.stringify({ ...basePayload(), d: 'x' }), 'utf8').toString('base64url');
+    const encoded = encodeWire([CURSOR_VERSION, baseContext, 'x', [2022, 'x']]);
     expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
   });
 });

--- a/test/unit/utils/cursor-codec.test.ts
+++ b/test/unit/utils/cursor-codec.test.ts
@@ -1,0 +1,163 @@
+import {
+  CURSOR_VERSION,
+  CursorExpectation,
+  CursorPayload,
+  computeSortHash,
+  decodeCursor,
+  encodeCursor
+} from '../../../src/utils/cursor-codec';
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+
+const baseExpected: CursorExpectation = {
+  queryStoreId: 'qs-1',
+  revisionId: 'rev-1',
+  language: 'en-GB',
+  sortHash: computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB'),
+  keyArity: 2
+};
+
+function basePayload(overrides: Partial<CursorPayload> = {}): CursorPayload {
+  return {
+    v: CURSOR_VERSION,
+    q: baseExpected.queryStoreId,
+    r: baseExpected.revisionId,
+    l: baseExpected.language,
+    h: baseExpected.sortHash,
+    d: 'f',
+    k: [2022, 'W06000001'],
+    ...overrides
+  };
+}
+
+describe('computeSortHash', () => {
+  it('produces a stable hash for the same spec + language', () => {
+    const a = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB');
+    const b = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB');
+    expect(a).toBe(b);
+  });
+
+  it('differs when the direction changes', () => {
+    const a = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB');
+    const b = computeSortHash([{ columnName: 'Year', direction: 'desc' }], 'en-GB');
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when the column order changes', () => {
+    const a = computeSortHash(
+      [
+        { columnName: 'Year', direction: 'asc' },
+        { columnName: 'Area', direction: 'asc' }
+      ],
+      'en-GB'
+    );
+    const b = computeSortHash(
+      [
+        { columnName: 'Area', direction: 'asc' },
+        { columnName: 'Year', direction: 'asc' }
+      ],
+      'en-GB'
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('differs across languages', () => {
+    const a = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'en-GB');
+    const b = computeSortHash([{ columnName: 'Year', direction: 'asc' }], 'cy-GB');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('encode / decode round-trip', () => {
+  it('round-trips a forward cursor', () => {
+    const encoded = encodeCursor(basePayload());
+    const decoded = decodeCursor(encoded, baseExpected);
+    expect(decoded).toEqual(basePayload());
+  });
+
+  it('round-trips a backward cursor', () => {
+    const encoded = encodeCursor(basePayload({ d: 'b' }));
+    const decoded = decodeCursor(encoded, baseExpected);
+    expect(decoded.d).toBe('b');
+  });
+
+  it('preserves null key values', () => {
+    const encoded = encodeCursor(basePayload({ k: [null, 'x'] }));
+    const decoded = decodeCursor(encoded, baseExpected);
+    expect(decoded.k[0]).toBeNull();
+    expect(decoded.k[1]).toBe('x');
+  });
+
+  it('preserves numeric key values without coercion to string', () => {
+    const encoded = encodeCursor(basePayload({ k: [2022, 'x'] }));
+    const decoded = decodeCursor(encoded, baseExpected);
+    expect(decoded.k[0]).toBe(2022);
+    expect(typeof decoded.k[0]).toBe('number');
+  });
+});
+
+describe('decodeCursor rejections', () => {
+  it('rejects an empty string', () => {
+    expect(() => decodeCursor('', baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a non-string input', () => {
+    expect(() => decodeCursor(undefined as unknown as string, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a cursor longer than the maximum', () => {
+    const huge = 'a'.repeat(3000);
+    expect(() => decodeCursor(huge, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects malformed base64url that does not parse as JSON', () => {
+    const garbage = Buffer.from('not json at all', 'utf8').toString('base64url');
+    expect(() => decodeCursor(garbage, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a JSON payload that is not a cursor object', () => {
+    const wrong = Buffer.from(JSON.stringify({ foo: 'bar' }), 'utf8').toString('base64url');
+    expect(() => decodeCursor(wrong, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a version mismatch', () => {
+    const encoded = encodeCursor(basePayload({ v: 999 }));
+    expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a different queryStoreId', () => {
+    const encoded = encodeCursor(basePayload());
+    expect(() => decodeCursor(encoded, { ...baseExpected, queryStoreId: 'qs-other' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a different revisionId', () => {
+    const encoded = encodeCursor(basePayload());
+    expect(() => decodeCursor(encoded, { ...baseExpected, revisionId: 'rev-other' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a different language', () => {
+    const encoded = encodeCursor(basePayload());
+    expect(() => decodeCursor(encoded, { ...baseExpected, language: 'cy-GB' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a different sortHash', () => {
+    const encoded = encodeCursor(basePayload());
+    expect(() => decodeCursor(encoded, { ...baseExpected, sortHash: 'something-else' })).toThrow(BadRequestException);
+  });
+
+  it('rejects a key tuple with the wrong arity', () => {
+    const encoded = encodeCursor(basePayload({ k: [2022] }));
+    expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects a key tuple containing an object', () => {
+    const encoded = Buffer.from(JSON.stringify({ ...basePayload(), k: [{ nested: true }, 'x'] }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
+  });
+
+  it('rejects an invalid direction', () => {
+    const encoded = Buffer.from(JSON.stringify({ ...basePayload(), d: 'x' }), 'utf8').toString('base64url');
+    expect(() => decodeCursor(encoded, baseExpected)).toThrow(BadRequestException);
+  });
+});

--- a/test/unit/utils/parse-page-options.test.ts
+++ b/test/unit/utils/parse-page-options.test.ts
@@ -9,7 +9,8 @@ import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../../src/utils/page-defaul
 jest.mock('../../../src/validators', () => ({
   format2Validator: jest.fn(),
   pageNumberValidator: jest.fn(),
-  pageSizeValidator: jest.fn()
+  pageSizeValidator: jest.fn(),
+  cursorValidator: jest.fn()
 }));
 
 // Mock express-validator
@@ -28,7 +29,7 @@ jest.mock('../../../src/utils/logger', () => ({
   }
 }));
 
-import { format2Validator, pageNumberValidator, pageSizeValidator } from '../../../src/validators';
+import { cursorValidator, format2Validator, pageNumberValidator, pageSizeValidator } from '../../../src/validators';
 import { matchedData } from 'express-validator';
 
 type MockRequest = Partial<Request> & { language?: Locale };
@@ -58,6 +59,9 @@ describe('parsePageOptions', () => {
       run: jest.fn().mockResolvedValue(mockValidationResult)
     });
     (pageSizeValidator as jest.Mock).mockReturnValue({
+      run: jest.fn().mockResolvedValue(mockValidationResult)
+    });
+    (cursorValidator as jest.Mock).mockReturnValue({
       run: jest.fn().mockResolvedValue(mockValidationResult)
     });
 
@@ -463,6 +467,51 @@ describe('parsePageOptions', () => {
 
       const result = await parsePageOptions(mockRequest as Request);
       expect(result.pageSize).toBe(MAX_PAGE_SIZE);
+    });
+  });
+
+  describe('cursor parameter', () => {
+    it('passes a valid cursor through to the returned options', async () => {
+      (matchedData as jest.Mock).mockReturnValue({ cursor: 'opaque-token' });
+
+      const result = await parsePageOptions(mockRequest as Request);
+      expect(result.cursor).toBe('opaque-token');
+    });
+
+    it('leaves cursor undefined when not supplied', async () => {
+      const result = await parsePageOptions(mockRequest as Request);
+      expect(result.cursor).toBeUndefined();
+    });
+
+    it('accepts cursor + page_number=1 (default page_number, treated as no jump)', async () => {
+      (matchedData as jest.Mock).mockReturnValue({ cursor: 'tok', page_number: 1 });
+
+      const result = await parsePageOptions(mockRequest as Request);
+      expect(result.cursor).toBe('tok');
+      expect(result.pageNumber).toBe(1);
+    });
+
+    it('rejects cursor + page_number > 1 as mutually exclusive', async () => {
+      (matchedData as jest.Mock).mockReturnValue({ cursor: 'tok', page_number: 5 });
+
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow(BadRequestException);
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow(
+        'errors.cursor_and_page_number_mutually_exclusive'
+      );
+    });
+
+    it('throws BadRequestException when cursor validation fails', async () => {
+      const errorResult = {
+        isEmpty: jest.fn().mockReturnValue(false),
+        array: jest.fn().mockReturnValue([{ msg: 'Invalid cursor', path: 'cursor', type: 'field' }])
+      };
+
+      (cursorValidator as jest.Mock).mockReturnValue({
+        run: jest.fn().mockResolvedValue(errorResult)
+      });
+
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow(BadRequestException);
+      await expect(parsePageOptions(mockRequest as Request)).rejects.toThrow('Invalid cursor for cursor');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds keyset (cursor) pagination to the v2 `GET /:dataset_id/data` endpoint as a faster, more attack-resistant alternative to deep `LIMIT/OFFSET` reads. v1 is out of scope (legacy, deprecate). Pivot endpoint is out of scope (separate ticket).

[SW-1246](https://marvell-consulting.atlassian.net/browse/SW-1246) — follow-up to the 2026-04-23 incident, where deep-paginated requests with rotating `page_number` bypassed Front Door cache and saturated the application DB pool.

## What changed

- **New `cursor` query param** on `/v2/:dataset_id/data` (and the filtered variant). Opaque base64url token, serialised as a compact positional array `[version, contextHash, direction, keyTuple]`. Bound to `queryStoreId` + `revisionId` + `language` + `sortHash` via a single context hash that is recomputed and revalidated on every decode. Any mismatch → `400 errors.invalid_cursor`.
- **Default ordering** when the caller passes no `sort_by`: first `Time` column on the fact table, falling back to first `Dimension`, with the composite PK appended as tie-breakers. Applied to both cursor and offset paths so the offset→cursor handover at the page-100 boundary is seamless.
- **Multi-column `sort_by`** supported on the cursor path. OR-ladder WHERE construction handles mixed ASC/DESC and NULLs explicitly (`IS NOT DISTINCT FROM` for equality rungs; explicit NULL placement rungs for inequality; Postgres NULLS LAST on ASC / NULLS FIRST on DESC).
- **Response envelope** gains `next_cursor` / `prev_cursor` (nullable). In cursor mode `current_page` / `start_record` / `end_record` are `null` — they're not meaningful when paginating by keyset. `total_records` / `total_pages` stay (cached on `QueryStore`).
- **Swagger** regenerated with the new `cursor` parameter and updated `PageInfoV2`.

## What did *not* change

- `page_number` is still accepted as before (no cap enforced server-side in this PR — the frontend caps at 100 today; backend cap will land separately).
- Offset behaviour for callers passing an explicit `sort_by` is unchanged.
- v1 endpoint is untouched.

## Notable design choices

- **Cursors are not signed.** Integrity comes from binding to server-side facts (`queryStoreId`, `revisionId`, `lang`, `sortHash`) and revalidating on every decode. Tampering produces a 400, not silent corruption.
- **Compact token.** The cursor carries only a version, a 22-char context hash, the direction and the key tuple — positional, not an object with named keys. The raw `queryStoreId` / `revisionId` are folded into the hash rather than transmitted, so a typical cursor is ~70 chars instead of ~220. The binding is unchanged in effect: a cursor replayed against different filters / revision / language / sort recomputes a different hash and 400s rather than silently mis-paginating.
- **`sort_by` change, language switch, or revision change all invalidate the cursor.** Frontend strips `cursor` on language/sort changes (see paired frontend PR) so users land on page 1 of the new traversal rather than hitting a 400.
- **No new indexes.** The "deep cursor reads ≈ shallow" perf guarantee only holds when the sort is index-served — composite PK is, arbitrary `sort_by` may not be. Treated as aspirational; per-cube sort indexes are a follow-up.

## Test plan

- [ ] `npm run check` is green
- [ ] Forward cursor traversal across a small dataset matches offset-paged concatenation
- [ ] Backward cursor traversal returns rows in the correct order
- [ ] `next_cursor` is `null` on the last page
- [ ] Cross-queryStore / cross-revision / cross-language / cross-sort cursors → 400
- [ ] `cursor` + `page_number > 1` → 400 (mutually exclusive)
- [ ] Dataset with a time column orders by it; dataset without orders by first dim
- [ ] No duplicates or gaps when sort-key values tie
- [ ] Swagger UI shows the new `cursor` parameter on both v2 data routes
- [ ] Manual perf smoke against a 3M+ row cube: compare `page_number=1` vs `page_number=100` (offset) vs `cursor=<deep>` (cursor) — record in PR before merge


[SW-1246]: https://marvellconsulting.atlassian.net/browse/SW-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
