### PR TITLE
Add unit tests for dataset, revision and task services (#686)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,10 +25,10 @@ const config: Config = {
   coverageReporters: ['cobertura', 'lcov', 'html', 'text'],
   coverageThreshold: {
     global: {
-      statements: 61,
-      branches: 49,
-      functions: 57,
-      lines: 61
+      statements: 79,
+      branches: 67,
+      functions: 75,
+      lines: 79
     }
   },
   projects: [

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -45,7 +45,6 @@ import {
 import { StorageService } from '../interfaces/storage-service';
 import { TempFile } from '../interfaces/temp-file';
 import { dbManager } from '../db/database-manager';
-import { getFileService } from '../utils/get-file-service';
 import { bootstrapCubeBuildProcess } from '../utils/lookup-table-utils';
 
 export class DatasetService {
@@ -118,6 +117,8 @@ export class DatasetService {
       col.factTableColumn = col.columnName;
     });
 
+    // the guard above already guarantees this is the first revision; keep the explicit check as a
+    // defensive backstop in case that guard is ever relaxed, so we never reset a later revision
     if (draftRevision.revisionIndex === 1) {
       await removeAllDimensions(dataset);
       await removeMeasure(dataset);
@@ -356,13 +357,12 @@ export class DatasetService {
     }
 
     const cubeDB = dbManager.getCubeDataSource().createQueryRunner();
-    const fileService = getFileService();
     try {
       logger.warn(`Deleting draft revision ${revisionId} from cube database and data lake...`);
       await cubeDB.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', revisionId));
       if (draft.dataTable?.id) {
         await cubeDB.query(pgformat('DROP TABLE IF EXISTS data_tables.%I;', draft.dataTable?.id));
-        await fileService.delete(draft.dataTable.id, datasetId);
+        await this.fileService.delete(draft.dataTable.id, datasetId);
       }
     } catch (err) {
       logger.warn(

--- a/test/unit/services/dataset.test.ts
+++ b/test/unit/services/dataset.test.ts
@@ -1,0 +1,631 @@
+import { Locale } from '../../../src/enums/locale';
+import { TaskAction } from '../../../src/enums/task-action';
+import { TaskStatus } from '../../../src/enums/task-status';
+import { PublishingStatus } from '../../../src/enums/publishing-status';
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+import { uuidV4 } from '../../../src/utils/uuid';
+import { User } from '../../../src/entities/user/user';
+import { StorageService } from '../../../src/interfaces/storage-service';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+// --- DatasetRepository ---
+const mockDatasetCreate = jest.fn();
+const mockDatasetSave = jest.fn();
+const mockDatasetGetById = jest.fn();
+const mockDatasetFindOneOrFail = jest.fn();
+const mockDatasetFindOneByOrFail = jest.fn();
+const mockDatasetReplaceFactTable = jest.fn();
+const mockDatasetPublish = jest.fn();
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: {
+    create: (...a: unknown[]) => mockDatasetCreate(...a),
+    save: (...a: unknown[]) => mockDatasetSave(...a),
+    getById: (...a: unknown[]) => mockDatasetGetById(...a),
+    findOneOrFail: (...a: unknown[]) => mockDatasetFindOneOrFail(...a),
+    findOneByOrFail: (...a: unknown[]) => mockDatasetFindOneByOrFail(...a),
+    replaceFactTable: (...a: unknown[]) => mockDatasetReplaceFactTable(...a),
+    publish: (...a: unknown[]) => mockDatasetPublish(...a)
+  },
+  withDraftAndMetadata: {},
+  withDraftAndProviders: {},
+  withDraftAndTopics: {}
+}));
+
+// --- RevisionRepository ---
+const mockRevCreate = jest.fn();
+const mockRevSave = jest.fn();
+const mockRevCreateMetadata = jest.fn();
+const mockRevUpdateMetadata = jest.fn();
+const mockRevReplaceDataTable = jest.fn();
+const mockRevRevertToDraft = jest.fn();
+const mockRevApprovePublication = jest.fn();
+const mockRevDeepClone = jest.fn();
+const mockRevGetById = jest.fn();
+jest.mock('../../../src/repositories/revision', () => ({
+  RevisionRepository: {
+    create: (...a: unknown[]) => mockRevCreate(...a),
+    save: (...a: unknown[]) => mockRevSave(...a),
+    createMetadata: (...a: unknown[]) => mockRevCreateMetadata(...a),
+    updateMetadata: (...a: unknown[]) => mockRevUpdateMetadata(...a),
+    replaceDataTable: (...a: unknown[]) => mockRevReplaceDataTable(...a),
+    revertToDraft: (...a: unknown[]) => mockRevRevertToDraft(...a),
+    approvePublication: (...a: unknown[]) => mockRevApprovePublication(...a),
+    deepCloneRevision: (...a: unknown[]) => mockRevDeepClone(...a),
+    getById: (...a: unknown[]) => mockRevGetById(...a)
+  }
+}));
+
+const mockDimensionSave = jest.fn();
+jest.mock('../../../src/repositories/dimension', () => ({
+  DimensionRepository: { save: (...a: unknown[]) => mockDimensionSave(...a) }
+}));
+
+const mockUserGroupFindOneByOrFail = jest.fn();
+jest.mock('../../../src/repositories/user-group', () => ({
+  UserGroupRepository: { findOneByOrFail: (...a: unknown[]) => mockUserGroupFindOneByOrFail(...a) }
+}));
+
+// --- TaskService (instantiated in the constructor) ---
+const mockTaskCreate = jest.fn();
+const mockTaskUpdate = jest.fn();
+const mockTaskWithdrawPending = jest.fn();
+const mockTaskWithdrawApproved = jest.fn();
+const mockTaskGetTasksForDataset = jest.fn();
+jest.mock('../../../src/services/task', () => ({
+  TaskService: jest.fn().mockImplementation(() => ({
+    create: (...a: unknown[]) => mockTaskCreate(...a),
+    update: (...a: unknown[]) => mockTaskUpdate(...a),
+    withdrawPending: (...a: unknown[]) => mockTaskWithdrawPending(...a),
+    withdrawApproved: (...a: unknown[]) => mockTaskWithdrawApproved(...a),
+    getTasksForDataset: (...a: unknown[]) => mockTaskGetTasksForDataset(...a)
+  }))
+}));
+
+// --- Entity repositories with getRepository() ---
+const mockProviderSave = jest.fn();
+const mockProviderRemove = jest.fn();
+jest.mock('../../../src/entities/dataset/revision-provider', () => ({
+  RevisionProvider: {
+    getRepository: () => ({
+      save: (...a: unknown[]) => mockProviderSave(...a),
+      remove: (...a: unknown[]) => mockProviderRemove(...a)
+    })
+  }
+}));
+
+const mockTopicCreate = jest.fn((...args: unknown[]) => args[0]);
+const mockTopicSave = jest.fn();
+const mockTopicRemove = jest.fn();
+jest.mock('../../../src/entities/dataset/revision-topic', () => ({
+  RevisionTopic: {
+    getRepository: () => ({
+      create: (...a: unknown[]) => mockTopicCreate(...a),
+      save: (...a: unknown[]) => mockTopicSave(...a),
+      remove: (...a: unknown[]) => mockTopicRemove(...a)
+    })
+  }
+}));
+
+const mockRevMetadataSave = jest.fn();
+jest.mock('../../../src/entities/dataset/revision-metadata', () => ({
+  RevisionMetadata: { getRepository: () => ({ save: (...a: unknown[]) => mockRevMetadataSave(...a) }) }
+}));
+
+const mockEventLogFind = jest.fn();
+const mockEventLogRepoFind = jest.fn();
+jest.mock('../../../src/entities/event-log', () => ({
+  EventLog: {
+    find: (...a: unknown[]) => mockEventLogFind(...a),
+    getRepository: () => ({ find: (...a: unknown[]) => mockEventLogRepoFind(...a) })
+  }
+}));
+
+// --- DTOs / helpers ---
+jest.mock('../../../src/dtos/revision-provider-dto', () => ({
+  RevisionProviderDTO: { toRevisionProvider: (p: unknown) => ({ ...(p as object) }) }
+}));
+
+const mockTasklistFromDataset = jest.fn();
+jest.mock('../../../src/dtos/tasklist-state-dto', () => ({
+  TasklistStateDTO: { fromDataset: (...a: unknown[]) => mockTasklistFromDataset(...a) }
+}));
+
+const mockCreateAllCubeFiles = jest.fn();
+jest.mock('../../../src/services/cube-builder', () => ({
+  createAllCubeFiles: (...a: unknown[]) => mockCreateAllCubeFiles(...a)
+}));
+
+const mockValidateAndUpload = jest.fn();
+jest.mock('../../../src/services/incoming-file-processor', () => ({
+  validateAndUpload: (...a: unknown[]) => mockValidateAndUpload(...a)
+}));
+
+const mockRemoveAllDimensions = jest.fn();
+const mockRemoveMeasure = jest.fn();
+jest.mock('../../../src/services/dimension-processor', () => ({
+  removeAllDimensions: (...a: unknown[]) => mockRemoveAllDimensions(...a),
+  removeMeasure: (...a: unknown[]) => mockRemoveMeasure(...a)
+}));
+
+const mockIsPublished = jest.fn();
+jest.mock('../../../src/utils/revision', () => ({
+  isPublished: (...a: unknown[]) => mockIsPublished(...a)
+}));
+
+const mockGetPublishingStatus = jest.fn();
+jest.mock('../../../src/utils/dataset-status', () => ({
+  getPublishingStatus: (...a: unknown[]) => mockGetPublishingStatus(...a)
+}));
+
+const mockBootstrapCubeBuildProcess = jest.fn();
+jest.mock('../../../src/utils/lookup-table-utils', () => ({
+  bootstrapCubeBuildProcess: (...a: unknown[]) => mockBootstrapCubeBuildProcess(...a)
+}));
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: jest.fn().mockReturnValue({
+      createQueryRunner: jest.fn().mockReturnValue({
+        query: (...a: unknown[]) => mockQuery(...a),
+        release: (...a: unknown[]) => mockRelease(...a)
+      })
+    })
+  }
+}));
+
+jest.mock('../../../src/utils/dataset-history', () => ({
+  omitDatasetUpdates: () => true,
+  omitRevisionUpdates: () => true,
+  flagUpdateTask: (_ds: unknown, e: unknown) => e,
+  generateSimulatedEvents: () => []
+}));
+
+// Import after mocks
+import { DatasetService } from '../../../src/services/dataset';
+
+// --- Helpers ---
+function makeUser(): User {
+  return { id: uuidV4(), name: 'test-user' } as unknown as User;
+}
+
+function withSave<T extends object>(obj: T): T & { save: jest.Mock } {
+  const o = obj as T & { save: jest.Mock };
+  o.save = jest.fn().mockResolvedValue(o);
+  return o;
+}
+
+describe('DatasetService', () => {
+  let service: DatasetService;
+  let fileService: StorageService & { delete: jest.Mock };
+  let user: User;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fileService = { delete: jest.fn() } as unknown as StorageService & { delete: jest.Mock };
+    service = new DatasetService(Locale.EnglishGb, fileService);
+    user = makeUser();
+  });
+
+  describe('createNew', () => {
+    it('creates a dataset, first revision and metadata then returns the loaded dataset', async () => {
+      const dataset = { id: 'ds-1' };
+      const firstRev = { id: 'rev-1' };
+      mockDatasetCreate.mockReturnValue({ save: jest.fn().mockResolvedValue(dataset) });
+      mockRevCreate.mockReturnValue({ save: jest.fn().mockResolvedValue(firstRev) });
+      mockRevCreateMetadata.mockResolvedValue(undefined);
+      mockDatasetSave.mockResolvedValue(undefined);
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', loaded: true });
+
+      const result = await service.createNew('My Title', 'group-1', user);
+
+      expect(mockRevCreate).toHaveBeenCalledWith({ dataset, createdBy: user, revisionIndex: 1 });
+      expect(mockRevCreateMetadata).toHaveBeenCalledWith(firstRev, 'My Title', Locale.EnglishGb);
+      expect(mockDatasetSave).toHaveBeenCalledWith(
+        expect.objectContaining({ draftRevision: firstRev, startRevision: firstRev, endRevision: firstRev })
+      );
+      expect(result).toEqual({ id: 'ds-1', loaded: true });
+    });
+  });
+
+  describe('getDatasetOverview', () => {
+    it('loads the dataset with overview relations', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1' });
+      const result = await service.getDatasetOverview('ds-1');
+      expect(mockDatasetGetById).toHaveBeenCalledWith('ds-1', expect.objectContaining({ tasks: expect.anything() }));
+      expect(result).toEqual({ id: 'ds-1' });
+    });
+  });
+
+  describe('updateMetadata', () => {
+    it('updates the draft revision metadata', async () => {
+      mockDatasetGetById.mockResolvedValueOnce({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockDatasetGetById.mockResolvedValueOnce({ id: 'ds-1' });
+
+      await service.updateMetadata('ds-1', { title: 'X' } as never);
+
+      expect(mockRevUpdateMetadata).toHaveBeenCalledWith({ id: 'rev-1' }, { title: 'X' });
+    });
+  });
+
+  describe('updateFactTable', () => {
+    it('uploads, replaces and rebuilds the cube for the first revision', async () => {
+      mockDatasetGetById.mockResolvedValueOnce({
+        id: 'ds-1',
+        draftRevision: { id: 'rev-1', revisionIndex: 1 }
+      });
+      mockDatasetGetById.mockResolvedValueOnce({ id: 'ds-1' });
+      mockValidateAndUpload.mockResolvedValue({
+        dataTableDescriptions: [{ columnName: 'a', factTableColumn: undefined }]
+      });
+
+      await service.updateFactTable('ds-1', { originalname: 'f.csv' } as never, user.id);
+
+      expect(mockRemoveAllDimensions).toHaveBeenCalled();
+      expect(mockRemoveMeasure).toHaveBeenCalled();
+      expect(mockRevReplaceDataTable).toHaveBeenCalled();
+      expect(mockDatasetReplaceFactTable).toHaveBeenCalled();
+      expect(mockCreateAllCubeFiles).toHaveBeenCalledWith('ds-1', 'rev-1', user.id);
+    });
+
+    it('throws when there is no draft revision', async () => {
+      mockDatasetGetById.mockResolvedValueOnce({ id: 'ds-1', draftRevision: null });
+      const err = await captureError(service.updateFactTable('ds-1', {} as never));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws when the draft revision is not the first revision', async () => {
+      mockDatasetGetById.mockResolvedValueOnce({ id: 'ds-1', draftRevision: { id: 'rev-1', revisionIndex: 2 } });
+      const err = await captureError(service.updateFactTable('ds-1', {} as never));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('addDataProvider', () => {
+    it('saves the provider in both languages', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1' });
+
+      await service.addDataProvider('ds-1', { language: 'en-gb', groupId: 'g1' } as never);
+
+      const saved = mockProviderSave.mock.calls[0][0];
+      expect(saved).toHaveLength(2);
+      expect(saved[1].language).toBe('cy-gb');
+    });
+  });
+
+  describe('updateDataProviders', () => {
+    it('removes providers no longer present and updates the rest', async () => {
+      mockDatasetGetById.mockResolvedValue({
+        id: 'ds-1',
+        draftRevision: {
+          revisionProviders: [
+            { groupId: 'keep', providerId: 'old', providerSourceId: 'old' },
+            { groupId: 'remove', providerId: 'x', providerSourceId: 'y' }
+          ]
+        }
+      });
+
+      await service.updateDataProviders('ds-1', [
+        { groupId: 'keep', providerId: 'new', providerSourceId: 'newSrc' } as never
+      ]);
+
+      expect(mockProviderRemove).toHaveBeenCalledWith([expect.objectContaining({ groupId: 'remove' })]);
+      expect(mockProviderSave).toHaveBeenCalledWith([
+        expect.objectContaining({ groupId: 'keep', providerId: 'new', providerSourceId: 'newSrc' })
+      ]);
+    });
+  });
+
+  describe('updateTopics', () => {
+    it('replaces the existing topic relations', async () => {
+      mockDatasetGetById.mockResolvedValue({
+        id: 'ds-1',
+        draftRevision: { id: 'rev-1', revisionTopics: [{ id: 1 }] }
+      });
+
+      await service.updateTopics('ds-1', ['10', '20']);
+
+      expect(mockTopicRemove).toHaveBeenCalledWith([{ id: 1 }]);
+      expect(mockTopicSave).toHaveBeenCalledWith([
+        { revisionId: 'rev-1', topicId: 10 },
+        { revisionId: 'rev-1', topicId: 20 }
+      ]);
+    });
+  });
+
+  describe('updateTranslations', () => {
+    it('applies dimension, metadata and link translations', async () => {
+      mockDatasetGetById.mockResolvedValue({
+        id: 'ds-1',
+        draftRevision: {
+          id: 'rev-1',
+          metadata: [{ language: Locale.EnglishGb }, { language: Locale.WelshGb }],
+          relatedLinks: [{ id: 'link-1' }]
+        },
+        dimensions: [
+          {
+            factTableColumn: 'col1',
+            metadata: [{ language: 'en-GB' }, { language: 'cy-GB' }]
+          }
+        ],
+        measure: { metadata: [] }
+      });
+
+      const translations = [
+        { type: 'dimension', key: 'col1', english: 'EN', cymraeg: 'CY' },
+        { type: 'metadata', key: 'title', english: 'Title', cymraeg: 'Teitl' },
+        { type: 'link', key: 'link-1', english: 'Link', cymraeg: 'Dolen' }
+      ];
+
+      await service.updateTranslations('ds-1', translations as never);
+
+      expect(mockDimensionSave).toHaveBeenCalled();
+      expect(mockRevMetadataSave).toHaveBeenCalled();
+      expect(mockRevSave).toHaveBeenCalled();
+    });
+  });
+
+  describe('submitForPublication', () => {
+    it('creates a publish task on first submission', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockTaskGetTasksForDataset.mockResolvedValue([]); // no rejected task
+
+      await service.submitForPublication('ds-1', 'rev-1', user);
+
+      expect(mockTaskCreate).toHaveBeenCalledWith('ds-1', TaskAction.Publish, user, undefined, { revisionId: 'rev-1' });
+    });
+
+    it('reopens a previously rejected publish task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockTaskGetTasksForDataset.mockResolvedValue([
+        { id: 'task-1', action: TaskAction.Publish, status: TaskStatus.Rejected }
+      ]);
+
+      await service.submitForPublication('ds-1', 'rev-1', user);
+
+      expect(mockTaskUpdate).toHaveBeenCalledWith('task-1', TaskStatus.Requested, true, user, null);
+      expect(mockTaskCreate).not.toHaveBeenCalled();
+    });
+
+    it('throws when the revision id does not match the draft revision', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'other' } });
+      const err = await captureError(service.submitForPublication('ds-1', 'rev-1', user));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('withdrawFromPublication', () => {
+    it('withdraws a pending publication and deletes the online cube file', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', endRevision: {}, tasks: [] });
+      mockGetPublishingStatus.mockReturnValue(PublishingStatus.PendingApproval);
+      mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1', onlineCubeFilename: 'cube.duckdb' });
+      mockTaskGetTasksForDataset.mockResolvedValue([
+        { id: 'task-1', action: TaskAction.Publish, status: TaskStatus.Requested }
+      ]);
+
+      await service.withdrawFromPublication('ds-1', 'rev-1', user);
+
+      expect(fileService.delete).toHaveBeenCalledWith('cube.duckdb', 'ds-1');
+      expect(mockTaskWithdrawPending).toHaveBeenCalledWith('task-1', user);
+    });
+
+    it('withdraws an approved (but unpublished) publication when there is no pending task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', endRevision: {}, tasks: [] });
+      mockGetPublishingStatus.mockReturnValue(PublishingStatus.Scheduled);
+      mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1' });
+      mockTaskGetTasksForDataset.mockResolvedValue([]);
+
+      await service.withdrawFromPublication('ds-1', 'rev-1', user);
+
+      expect(mockTaskWithdrawApproved).toHaveBeenCalledWith('ds-1', 'rev-1', user);
+    });
+
+    it('throws when there is no pending publication to withdraw', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', endRevision: {}, tasks: [] });
+      mockGetPublishingStatus.mockReturnValue(PublishingStatus.Published);
+      const err = await captureError(service.withdrawFromPublication('ds-1', 'rev-1', user));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('approvePublication', () => {
+    it('bootstraps, builds, approves and publishes', async () => {
+      mockRevApprovePublication.mockResolvedValue({ id: 'rev-1' });
+      mockDatasetPublish.mockResolvedValue({ id: 'ds-1', published: true });
+
+      const result = await service.approvePublication('ds-1', 'rev-1', user);
+
+      expect(mockBootstrapCubeBuildProcess).toHaveBeenCalledWith('ds-1', 'rev-1');
+      expect(mockCreateAllCubeFiles).toHaveBeenCalled();
+      expect(result).toEqual({ id: 'ds-1', published: true });
+    });
+  });
+
+  describe('rejectPublication', () => {
+    it('reverts to draft and deletes the online cube file when present', async () => {
+      mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1', onlineCubeFilename: 'cube.duckdb' });
+      await service.rejectPublication('ds-1', 'rev-1');
+      expect(fileService.delete).toHaveBeenCalledWith('cube.duckdb', 'ds-1');
+    });
+
+    it('reverts to draft without deleting when no online cube file', async () => {
+      mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1' });
+      await service.rejectPublication('ds-1', 'rev-1');
+      expect(fileService.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createRevision', () => {
+    it('clones the published revision into a new draft', async () => {
+      mockDatasetFindOneOrFail.mockResolvedValue({
+        revisions: [{ id: 'r1' }],
+        publishedRevision: { id: 'pub-1' }
+      });
+      mockIsPublished.mockReturnValue(true);
+      mockRevDeepClone.mockResolvedValue({ id: 'new-rev' });
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1' });
+
+      await service.createRevision('ds-1', user);
+
+      expect(mockRevDeepClone).toHaveBeenCalledWith('pub-1', user);
+      expect(mockDatasetSave).toHaveBeenCalledWith(
+        expect.objectContaining({ draftRevision: { id: 'new-rev' }, endRevision: { id: 'new-rev' } })
+      );
+    });
+
+    it('throws when an unpublished (draft) revision already exists', async () => {
+      mockDatasetFindOneOrFail.mockResolvedValue({ revisions: [{ id: 'r1' }], publishedRevision: { id: 'pub-1' } });
+      mockIsPublished.mockReturnValue(false);
+      const err = await captureError(service.createRevision('ds-1', user));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('deleteDraftRevision', () => {
+    it('drops the schema, deletes the data table and removes the revision', async () => {
+      const draft = {
+        id: 'rev-1',
+        dataTable: { id: 'dt-1' },
+        previousRevision: { id: 'prev' },
+        remove: jest.fn()
+      };
+      const dataset = withSave({ id: 'ds-1', draftRevision: draft, endRevision: undefined });
+      mockDatasetGetById.mockResolvedValue(dataset);
+
+      await service.deleteDraftRevision('ds-1', 'rev-1');
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('DROP SCHEMA'));
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('DROP TABLE'));
+      expect(fileService.delete).toHaveBeenCalledWith('dt-1', 'ds-1');
+      expect(mockRelease).toHaveBeenCalled();
+      expect(dataset.save).toHaveBeenCalled();
+      expect(draft.remove).toHaveBeenCalled();
+    });
+
+    it('throws when the draft revision id does not match', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: null });
+      const err = await captureError(service.deleteDraftRevision('ds-1', 'rev-1'));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getTasklistState', () => {
+    it('builds the tasklist state including the previous revision', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevisionId: 'rev-1' });
+      mockRevGetById
+        .mockResolvedValueOnce({ id: 'rev-1', previousRevisionId: 'prev' })
+        .mockResolvedValueOnce({ id: 'prev' });
+      mockEventLogRepoFind.mockResolvedValue([]);
+      mockTasklistFromDataset.mockReturnValue({ state: 'ok' });
+
+      const result = await service.getTasklistState('ds-1', Locale.EnglishGb);
+
+      expect(mockTasklistFromDataset).toHaveBeenCalled();
+      expect(result).toEqual({ state: 'ok' });
+    });
+
+    it('throws when the draft revision cannot be loaded', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevisionId: 'rev-1' });
+      mockRevGetById.mockResolvedValueOnce(null);
+      const err = await captureError(service.getTasklistState('ds-1', Locale.EnglishGb));
+      expect(err).toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('updateDatasetGroup', () => {
+    it('assigns the dataset to the new user group', async () => {
+      const dataset = withSave({ id: 'ds-1', userGroupId: 'old' });
+      mockDatasetFindOneByOrFail.mockResolvedValue(dataset);
+      mockUserGroupFindOneByOrFail.mockResolvedValue({ id: 'group-2' });
+
+      await service.updateDatasetGroup('ds-1', 'group-2');
+
+      expect(dataset.userGroupId).toBe('group-2');
+      expect(dataset.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('task queries', () => {
+    it('getOpenTasks requests only open tasks', async () => {
+      mockTaskGetTasksForDataset.mockResolvedValue([]);
+      await service.getOpenTasks('ds-1');
+      expect(mockTaskGetTasksForDataset).toHaveBeenCalledWith('ds-1', true);
+    });
+
+    it('getAllTasks requests all tasks', async () => {
+      mockTaskGetTasksForDataset.mockResolvedValue([]);
+      await service.getAllTasks('ds-1');
+      expect(mockTaskGetTasksForDataset).toHaveBeenCalledWith('ds-1');
+    });
+
+    it('getPendingPublishTask finds the requested publish task', async () => {
+      mockTaskGetTasksForDataset.mockResolvedValue([
+        { action: TaskAction.Publish, status: TaskStatus.Requested, id: 'task-1' }
+      ]);
+      const result = await service.getPendingPublishTask('ds-1');
+      expect(result).toEqual(expect.objectContaining({ id: 'task-1' }));
+    });
+
+    it('getRejectedPublishTask finds the rejected publish task', async () => {
+      mockTaskGetTasksForDataset.mockResolvedValue([
+        { action: TaskAction.Publish, status: TaskStatus.Rejected, id: 'task-2' }
+      ]);
+      const result = await service.getRejectedPublishTask('ds-1');
+      expect(result).toEqual(expect.objectContaining({ id: 'task-2' }));
+    });
+  });
+
+  describe('getHistory', () => {
+    it('combines event log and simulated events sorted descending', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', revisions: [{ id: 'r1' }, { id: 'r2' }] });
+      mockEventLogFind.mockResolvedValue([
+        { entity: 'task', createdAt: new Date('2024-01-01') },
+        { entity: 'revision', createdAt: new Date('2024-02-01') }
+      ]);
+
+      const result = await service.getHistory('ds-1');
+
+      expect(mockEventLogFind).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      // sorted descending: Feb before Jan
+      expect(result[0].createdAt).toEqual(new Date('2024-02-01'));
+    });
+  });
+
+  describe('approveUnpublish', () => {
+    it('marks the published revision unpublished and creates a fresh draft', async () => {
+      mockDatasetGetById
+        .mockResolvedValueOnce({ id: 'ds-1', publishedRevision: { id: 'pub-1' } }) // initial load
+        .mockResolvedValueOnce({ id: 'ds-1', draftRevision: { id: 'new-rev' } }); // from createRevision
+      mockDatasetFindOneOrFail.mockResolvedValue({ revisions: [{ id: 'r1' }], publishedRevision: { id: 'pub-1' } });
+      mockIsPublished.mockReturnValue(true);
+      mockRevDeepClone.mockResolvedValue({ id: 'new-rev' });
+
+      await service.approveUnpublish('ds-1', user);
+
+      expect(mockRevSave).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'pub-1', unpublishedAt: expect.any(Date) })
+      );
+      expect(mockCreateAllCubeFiles).toHaveBeenCalledWith('ds-1', 'new-rev', user.id);
+    });
+
+    it('throws when the dataset has no published revision', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', publishedRevision: null });
+      const err = await captureError(service.approveUnpublish('ds-1', user));
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});
+
+async function captureError(p: Promise<unknown>): Promise<unknown> {
+  try {
+    await p;
+    return undefined;
+  } catch (e) {
+    return e;
+  }
+}

--- a/test/unit/services/revision.test.ts
+++ b/test/unit/services/revision.test.ts
@@ -1,0 +1,560 @@
+import { DataTableAction } from '../../../src/enums/data-table-action';
+import { DimensionType } from '../../../src/enums/dimension-type';
+import { FactTableColumnType } from '../../../src/enums/fact-table-column-type';
+import { CubeBuildType } from '../../../src/enums/cube-build-type';
+import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
+import { FactTableValidationException } from '../../../src/exceptions/fact-table-validation-exception';
+import { CubeValidationException } from '../../../src/exceptions/cube-error-exception';
+import { UnknownException } from '../../../src/exceptions/unknown.exception';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+// --- DB manager / query runner ---
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: jest.fn().mockReturnValue({
+      createQueryRunner: jest.fn().mockReturnValue({
+        query: (...args: unknown[]) => mockQuery(...args),
+        release: (...args: unknown[]) => mockRelease(...args)
+      })
+    })
+  }
+}));
+
+// --- Repositories ---
+const mockDatasetGetById = jest.fn();
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: { getById: (...args: unknown[]) => mockDatasetGetById(...args) }
+}));
+
+const mockRevisionSave = jest.fn();
+jest.mock('../../../src/repositories/revision', () => ({
+  RevisionRepository: { save: (...args: unknown[]) => mockRevisionSave(...args) }
+}));
+
+// --- Entities with static methods ---
+const mockStartBuild = jest.fn();
+jest.mock('../../../src/entities/dataset/build-log', () => ({
+  BuildLog: { startBuild: (...args: unknown[]) => mockStartBuild(...args) }
+}));
+
+const mockFactTableColumnFindOneOrFail = jest.fn();
+jest.mock('../../../src/entities/dataset/fact-table-column', () => ({
+  FactTableColumn: { findOneOrFail: (...args: unknown[]) => mockFactTableColumnFindOneOrFail(...args) }
+}));
+
+// --- cube-builder ---
+const mockCreateAllCubeFiles = jest.fn();
+const mockCreateLookupTableDimension = jest.fn();
+const mockCreateMeasureLookupTable = jest.fn();
+const mockUpdateFilterTableToLatest = jest.fn();
+jest.mock('../../../src/services/cube-builder', () => ({
+  createAllCubeFiles: (...args: unknown[]) => mockCreateAllCubeFiles(...args),
+  createLookupTableDimension: (...args: unknown[]) => mockCreateLookupTableDimension(...args),
+  createMeasureLookupTable: (...args: unknown[]) => mockCreateMeasureLookupTable(...args),
+  makeCubeSafeString: (s: string) => s,
+  updateFilterTableToLatest: (...args: unknown[]) => mockUpdateFilterTableToLatest(...args),
+  FACT_TABLE_NAME: 'fact_table'
+}));
+
+// --- dimension-processor ---
+const mockCreateDateDimensionLookup = jest.fn();
+jest.mock('../../../src/services/dimension-processor', () => ({
+  createDateDimensionLookup: (...args: unknown[]) => mockCreateDateDimensionLookup(...args)
+}));
+
+// --- lookup-table-utils ---
+const mockBootstrapCubeBuildProcess = jest.fn();
+const mockValidateHierarchy = jest.fn();
+const mockValidateReference = jest.fn();
+jest.mock('../../../src/utils/lookup-table-utils', () => ({
+  bootstrapCubeBuildProcess: (...args: unknown[]) => mockBootstrapCubeBuildProcess(...args),
+  validateLookupTableHierarchyValues: (...args: unknown[]) => mockValidateHierarchy(...args),
+  validateLookupTableReferenceValues: (...args: unknown[]) => mockValidateReference(...args)
+}));
+
+// --- fact-table-validator ---
+const mockFactTableValidatorFromSource = jest.fn();
+const mockSourceAssignmentFromFactTable = jest.fn();
+jest.mock('../../../src/services/fact-table-validator', () => ({
+  factTableValidatorFromSource: (...args: unknown[]) => mockFactTableValidatorFromSource(...args),
+  sourceAssignmentFromFactTable: (...args: unknown[]) => mockSourceAssignmentFromFactTable(...args)
+}));
+
+// --- revision utils ---
+const mockRevisionStartAndEndDateFinder = jest.fn();
+const mockWidenCoverageRange = jest.fn();
+jest.mock('../../../src/utils/revision', () => ({
+  revisionStartAndEndDateFinder: (...args: unknown[]) => mockRevisionStartAndEndDateFinder(...args),
+  widenCoverageRange: (...args: unknown[]) => mockWidenCoverageRange(...args)
+}));
+
+// --- config ---
+jest.mock('../../../src/config', () => ({
+  config: { cube_builder: { preserve_failed: false } }
+}));
+
+// Import after mocks
+import {
+  attachUpdateDataTableToRevision,
+  createDateTableInValidationCube,
+  rebuildCubesForRevisions,
+  rebuildAllFilterTablesForRevisions,
+  updateRevisionTasks
+} from '../../../src/services/revision';
+
+// --- Helpers ---
+
+function makeBuild(overrides: Record<string, unknown> = {}) {
+  const build = {
+    id: 'build-1',
+    status: CubeBuildStatus.Completed,
+    errors: null as string | null,
+    completeBuild: jest.fn(),
+    save: jest.fn(),
+    reload: jest.fn(),
+    ...overrides
+  };
+  build.save.mockResolvedValue(build);
+  build.reload.mockResolvedValue(build);
+  return build;
+}
+
+function makeDataset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ds-1',
+    factTable: [{ columnName: 'col1', columnType: FactTableColumnType.Dimension }],
+    measure: { id: 'measure-1', factTableColumn: 'measureCol', measureTable: [], metadata: [] },
+    dimensions: [
+      {
+        id: 'dim-1',
+        type: DimensionType.LookupTable,
+        factTableColumn: 'col1',
+        extractor: {},
+        metadata: [],
+        lookupTable: {},
+        save: jest.fn()
+      }
+    ],
+    revisions: [],
+    ...overrides
+  };
+}
+
+function makeDataTable() {
+  return {
+    action: undefined as DataTableAction | undefined,
+    dataTableDescriptions: [{ columnName: 'col1', factTableColumn: undefined as string | undefined }],
+    revision: undefined as unknown,
+    save: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+function makeRevision() {
+  return {
+    id: 'rev-1',
+    startDate: new Date('2020-01-01'),
+    endDate: new Date('2020-12-31'),
+    dataTable: undefined as unknown,
+    tasks: undefined as unknown,
+    save: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe('revision service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // happy-path defaults
+    mockDatasetGetById.mockImplementation(async () => makeDataset());
+    mockStartBuild.mockImplementation(async () => makeBuild());
+    mockCreateAllCubeFiles.mockResolvedValue(undefined);
+    mockSourceAssignmentFromFactTable.mockReturnValue({});
+    mockFactTableValidatorFromSource.mockResolvedValue(undefined);
+    mockFactTableColumnFindOneOrFail.mockResolvedValue({ columnName: 'measureCol' });
+    mockCreateMeasureLookupTable.mockReturnValue(['SQL']);
+    mockCreateLookupTableDimension.mockReturnValue('LOOKUP SQL');
+    mockValidateReference.mockResolvedValue(false);
+    mockValidateHierarchy.mockResolvedValue(false);
+    mockRevisionStartAndEndDateFinder.mockReturnValue({ startDate: undefined, endDate: undefined });
+    mockWidenCoverageRange.mockReturnValue({ startDate: new Date('2019-01-01'), endDate: new Date('2021-12-31') });
+    mockBootstrapCubeBuildProcess.mockResolvedValue(undefined);
+    mockUpdateFilterTableToLatest.mockResolvedValue(undefined);
+  });
+
+  describe('attachUpdateDataTableToRevision', () => {
+    it('validates and attaches the data table on the happy path (auto column matching)', async () => {
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+
+      expect(dataTable.action).toBe(DataTableAction.Add);
+      expect(revision.dataTable).toBe(dataTable);
+      expect(mockCreateAllCubeFiles).toHaveBeenCalled();
+      expect(mockFactTableValidatorFromSource).toHaveBeenCalled();
+      expect(revision.save).toHaveBeenCalled();
+      expect(dataTable.save).toHaveBeenCalled();
+      // preserve_failed is false → validation cube cleaned up (DROP SCHEMA)
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('DROP SCHEMA'));
+    });
+
+    it('matches columns explicitly when a column matcher is supplied', async () => {
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+      const matcher = [{ fact_table_column_name: 'col1', data_table_column_name: 'col1' }];
+
+      await attachUpdateDataTableToRevision(
+        'ds-1',
+        revision as never,
+        dataTable as never,
+        DataTableAction.Add,
+        matcher as never
+      );
+
+      expect(dataTable.dataTableDescriptions[0].factTableColumn).toBe('col1');
+      expect(mockCreateAllCubeFiles).toHaveBeenCalled();
+    });
+
+    it('throws UnknownException when the column matcher cannot match all fact table columns', async () => {
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+      const matcher = [{ fact_table_column_name: 'nope', data_table_column_name: 'col1' }];
+
+      await expect(
+        attachUpdateDataTableToRevision(
+          'ds-1',
+          revision as never,
+          dataTable as never,
+          DataTableAction.Add,
+          matcher as never
+        )
+      ).rejects.toThrow(UnknownException);
+      expect(mockCreateAllCubeFiles).not.toHaveBeenCalled();
+    });
+
+    it('throws FactTableValidationException when auto matching leaves unmatched columns', async () => {
+      mockDatasetGetById.mockResolvedValue(
+        makeDataset({ factTable: [{ columnName: 'other', columnType: FactTableColumnType.Dimension }] })
+      );
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      let caught: unknown;
+      try {
+        await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(FactTableValidationException);
+    });
+
+    it('removes the data table and rethrows when the validation cube build fails', async () => {
+      const error = new CubeValidationException('boom');
+      mockCreateAllCubeFiles.mockRejectedValue(error);
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await expect(
+        attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add)
+      ).rejects.toBe(error);
+      expect(dataTable.remove).toHaveBeenCalled();
+    });
+
+    it('cleans up and rethrows when fact table validation fails', async () => {
+      const error = new Error('fact table invalid');
+      mockFactTableValidatorFromSource.mockRejectedValue(error);
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await expect(
+        attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add)
+      ).rejects.toBe(error);
+      expect(dataTable.remove).toHaveBeenCalled();
+    });
+
+    it('records a measure revision task when measure validation fails', async () => {
+      mockValidateReference.mockResolvedValueOnce(true); // first call is for the measure
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+
+      expect((revision.tasks as { measure?: unknown }).measure).toEqual({ id: 'measure-1', lookupTableUpdated: false });
+    });
+
+    it('records a dimension revision task on non-matched lookup rows', async () => {
+      // measure validation passes (false), dimension reference check returns true → DimensionNonMatchedRows
+      mockValidateReference.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+
+      expect((revision.tasks as { dimensions: unknown[] }).dimensions).toEqual([
+        { id: 'dim-1', lookupTableUpdated: false }
+      ]);
+    });
+
+    it('throws BadRequestException when a dimension has no matching fact table column', async () => {
+      mockDatasetGetById.mockResolvedValue(
+        makeDataset({
+          dimensions: [{ id: 'dim-1', type: DimensionType.LookupTable, factTableColumn: 'missing', save: jest.fn() }]
+        })
+      );
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await expect(
+        attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add)
+      ).rejects.toThrow('errors.data_table_validation_error');
+    });
+  });
+
+  describe('createDateTableInValidationCube', () => {
+    it('updates the extractor coverage and saves the dimension', async () => {
+      const savedDimension = { id: 'dim-1' };
+      const dimension = {
+        id: 'dim-1',
+        extractor: {},
+        lookupTable: undefined as unknown,
+        save: jest.fn().mockResolvedValue(savedDimension)
+      };
+      mockCreateDateDimensionLookup.mockResolvedValue({
+        startDate: new Date('2020-01-01'),
+        endDate: new Date('2020-12-31'),
+        lookupTable: { id: 'lt-1' }
+      });
+
+      const result = await createDateTableInValidationCube(
+        'build-1',
+        'ds-1',
+        'col1_lookup',
+        { columnName: 'col1' } as never,
+        dimension as never
+      );
+
+      expect((dimension.extractor as { lookupTableStart?: Date }).lookupTableStart).toEqual(new Date('2020-01-01'));
+      expect(dimension.lookupTable).toEqual({ id: 'lt-1' });
+      expect(dimension.save).toHaveBeenCalled();
+      expect(result).toBe(savedDimension);
+    });
+  });
+
+  describe('rebuildCubesForRevisions', () => {
+    function makeBuildLog(overrides: Record<string, unknown> = {}) {
+      const log = {
+        id: 'log-1',
+        type: CubeBuildType.FullCube,
+        buildScript: '',
+        status: '' as CubeBuildStatus | string,
+        errors: undefined as string | undefined,
+        completeBuild: jest.fn(),
+        save: jest.fn(),
+        ...overrides
+      };
+      log.save.mockResolvedValue(log);
+      return log;
+    }
+
+    const user = { id: 'user-1' } as never;
+
+    it('marks the build log completed when every revision rebuilds successfully', async () => {
+      const log = makeBuildLog();
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+
+      expect(mockBootstrapCubeBuildProcess).toHaveBeenCalledWith('ds-1', 'rev-1');
+      expect(mockCreateAllCubeFiles).toHaveBeenCalled();
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+      expect(log.errors).toBeUndefined();
+    });
+
+    it('uses the draft cubes label when building draft cubes', async () => {
+      const log = makeBuildLog({ type: CubeBuildType.DraftCubes });
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+    });
+
+    it('records a failed build when bootstrapping throws', async () => {
+      mockBootstrapCubeBuildProcess.mockRejectedValue(new Error('bootstrap failed'));
+      const build = makeBuild();
+      mockStartBuild.mockResolvedValue(build);
+      const log = makeBuildLog();
+
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+
+      expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+      expect(mockCreateAllCubeFiles).not.toHaveBeenCalled();
+      expect(log.errors).toEqual(expect.stringContaining('bootstrap failed'));
+    });
+
+    it('records a failed build when building the cube files throws', async () => {
+      mockCreateAllCubeFiles.mockRejectedValue(new Error('cube files failed'));
+      const build = makeBuild();
+      mockStartBuild.mockResolvedValue(build);
+      const log = makeBuildLog();
+
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+
+      expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+      expect(log.errors).toEqual(expect.stringContaining('cube files failed'));
+    });
+
+    it('records a failure when the reloaded build is not in the completed state', async () => {
+      const build = makeBuild({ status: CubeBuildStatus.Failed, errors: 'kaboom' });
+      mockStartBuild.mockResolvedValue(build);
+      const log = makeBuildLog();
+
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+
+      expect(log.errors).toEqual(expect.stringContaining('kaboom'));
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+    });
+
+    it('fails the whole build log when an unexpected error escapes the loop', async () => {
+      mockStartBuild.mockRejectedValue(new Error('catastrophic'));
+      const log = makeBuildLog();
+
+      await rebuildCubesForRevisions(log as never, [{ id: 'rev-1', dataset_id: 'ds-1' } as never], user);
+
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+    });
+  });
+
+  describe('rebuildAllFilterTablesForRevisions', () => {
+    function makeBuildLog() {
+      const log = {
+        id: 'log-1',
+        buildScript: '',
+        status: '' as CubeBuildStatus | string,
+        errors: undefined as string | undefined,
+        completeBuild: jest.fn(),
+        save: jest.fn()
+      };
+      log.save.mockResolvedValue(log);
+      return log;
+    }
+
+    it('rebuilds filter tables for eligible revisions', async () => {
+      const log = makeBuildLog();
+      await rebuildAllFilterTablesForRevisions(log as never, [
+        { id: 'rev-2', dataset_id: 'ds-1', data_table_id: 'dt-1', revision_index: 2 } as never
+      ]);
+
+      expect(mockUpdateFilterTableToLatest).toHaveBeenCalledWith('ds-1', 'rev-2');
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+    });
+
+    it('skips the first revision when it has no data table', async () => {
+      const log = makeBuildLog();
+      await rebuildAllFilterTablesForRevisions(log as never, [
+        { id: 'rev-1', dataset_id: 'ds-1', data_table_id: null, revision_index: 1 } as never
+      ]);
+
+      expect(mockUpdateFilterTableToLatest).not.toHaveBeenCalled();
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+    });
+
+    it('records failures when rebuilding a filter table throws', async () => {
+      mockUpdateFilterTableToLatest.mockRejectedValue(new Error('filter failed'));
+      const log = makeBuildLog();
+
+      await rebuildAllFilterTablesForRevisions(log as never, [
+        { id: 'rev-2', dataset_id: 'ds-1', data_table_id: 'dt-1', revision_index: 2 } as never
+      ]);
+
+      expect(log.errors).toEqual(expect.stringContaining('filter failed'));
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Completed);
+    });
+
+    it('fails the whole build log when an unexpected error escapes the loop', async () => {
+      const log = makeBuildLog();
+      // completeBuild(Completed) at the end of the happy path throws, dropping into the outer catch
+      log.completeBuild.mockImplementationOnce(() => {
+        throw new Error('completeBuild exploded');
+      });
+
+      await rebuildAllFilterTablesForRevisions(log as never, [
+        { id: 'rev-2', dataset_id: 'ds-1', data_table_id: 'dt-1', revision_index: 2 } as never
+      ]);
+
+      expect(log.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+    });
+  });
+
+  describe('updateRevisionTasks', () => {
+    it('does nothing for the first revision', async () => {
+      const dataset = { draftRevision: { revisionIndex: 1, tasks: undefined } } as never;
+      await updateRevisionTasks(dataset, 'dim-1', 'dimension');
+      expect(mockRevisionSave).not.toHaveBeenCalled();
+    });
+
+    it('initialises dimension tasks when none exist', async () => {
+      const revision = { revisionIndex: 2, tasks: undefined as unknown };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'dim-1', 'dimension');
+
+      expect(revision.tasks).toEqual({ dimensions: [{ id: 'dim-1', lookupTableUpdated: true }], measure: undefined });
+      expect(mockRevisionSave).toHaveBeenCalledWith(revision);
+    });
+
+    it('initialises measure task when none exist', async () => {
+      const revision = { revisionIndex: 2, tasks: undefined as unknown };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'measure-1', 'measure');
+
+      expect(revision.tasks).toEqual({ dimensions: [], measure: { id: 'measure-1', lookupTableUpdated: true } });
+    });
+
+    it('marks an existing dimension task as updated', async () => {
+      const revision = {
+        revisionIndex: 2,
+        tasks: { dimensions: [{ id: 'dim-1', lookupTableUpdated: false }], measure: undefined }
+      };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'dim-1', 'dimension');
+
+      expect(revision.tasks.dimensions[0].lookupTableUpdated).toBe(true);
+    });
+
+    it('appends a new dimension task when not already present', async () => {
+      const revision = {
+        revisionIndex: 2,
+        tasks: { dimensions: [{ id: 'other', lookupTableUpdated: true }], measure: undefined }
+      };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'dim-1', 'dimension');
+
+      expect(revision.tasks.dimensions).toHaveLength(2);
+    });
+
+    it('marks an existing measure task as updated', async () => {
+      const revision = {
+        revisionIndex: 2,
+        tasks: { dimensions: [], measure: { id: 'measure-1', lookupTableUpdated: false } }
+      };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'measure-1', 'measure');
+
+      expect(revision.tasks.measure.lookupTableUpdated).toBe(true);
+    });
+
+    it('sets the measure task when tasks exist but the measure is absent', async () => {
+      const revision = { revisionIndex: 2, tasks: { dimensions: [], measure: undefined as unknown } };
+      const dataset = { draftRevision: revision } as never;
+
+      await updateRevisionTasks(dataset, 'measure-1', 'measure');
+
+      expect(revision.tasks.measure).toEqual({ id: 'measure-1', lookupTableUpdated: true });
+    });
+  });
+});

--- a/test/unit/services/task.test.ts
+++ b/test/unit/services/task.test.ts
@@ -1,0 +1,410 @@
+import { TaskStatus } from '../../../src/enums/task-status';
+import { TaskAction } from '../../../src/enums/task-action';
+import { PublishingStatus } from '../../../src/enums/publishing-status';
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+import { uuidV4 } from '../../../src/utils/uuid';
+import { User } from '../../../src/entities/user/user';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    trace: jest.fn()
+  }
+}));
+
+// --- Task entity mock ---
+const mockTaskCreate = jest.fn();
+const mockTaskMerge = jest.fn();
+const mockTaskFindOneOrFail = jest.fn();
+const mockTaskFindOneByOrFail = jest.fn();
+const mockTaskFind = jest.fn();
+jest.mock('../../../src/entities/task/task', () => ({
+  Task: {
+    create: (...args: unknown[]) => mockTaskCreate(...args),
+    merge: (...args: unknown[]) => mockTaskMerge(...args),
+    findOneOrFail: (...args: unknown[]) => mockTaskFindOneOrFail(...args),
+    findOneByOrFail: (...args: unknown[]) => mockTaskFindOneByOrFail(...args),
+    find: (...args: unknown[]) => mockTaskFind(...args)
+  }
+}));
+
+// --- Repository mocks ---
+const mockDatasetGetById = jest.fn();
+const mockDatasetArchive = jest.fn();
+const mockDatasetUnarchive = jest.fn();
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: {
+    getById: (...args: unknown[]) => mockDatasetGetById(...args),
+    archive: (...args: unknown[]) => mockDatasetArchive(...args),
+    unarchive: (...args: unknown[]) => mockDatasetUnarchive(...args)
+  }
+}));
+
+const mockPublishedGetById = jest.fn();
+jest.mock('../../../src/repositories/published-dataset', () => ({
+  PublishedDatasetRepository: {
+    getById: (...args: unknown[]) => mockPublishedGetById(...args)
+  }
+}));
+
+const mockGetPublishingStatus = jest.fn();
+jest.mock('../../../src/utils/dataset-status', () => ({
+  getPublishingStatus: (...args: unknown[]) => mockGetPublishingStatus(...args)
+}));
+
+// Import after mocks
+import { TaskService } from '../../../src/services/task';
+
+// --- Helpers ---
+
+interface MockTask {
+  id: string;
+  action: TaskAction;
+  status: TaskStatus;
+  open: boolean;
+  datasetId?: string;
+  metadata?: Record<string, unknown>;
+  comment?: string | null;
+  createdBy?: User | null;
+  updatedBy?: User | null;
+  dataset?: unknown;
+  save: jest.Mock;
+}
+
+function makeTask(overrides: Partial<MockTask> = {}): MockTask {
+  const task = {
+    id: uuidV4(),
+    action: TaskAction.Publish,
+    status: TaskStatus.Requested,
+    open: true,
+    datasetId: uuidV4(),
+    createdBy: null,
+    updatedBy: null,
+    ...overrides
+  } as MockTask;
+  task.save = jest.fn().mockResolvedValue(task);
+  return task;
+}
+
+function makeUser(): User {
+  return { id: uuidV4(), name: 'test-user' } as unknown as User;
+}
+
+describe('TaskService', () => {
+  let service: TaskService;
+  let user: User;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TaskService();
+    user = makeUser();
+
+    // sensible defaults
+    mockTaskCreate.mockImplementation((props: Partial<MockTask>) => makeTask(props));
+    mockTaskMerge.mockImplementation((task: MockTask, props: Partial<MockTask>) => Object.assign(task, props));
+    mockTaskFindOneByOrFail.mockImplementation(({ id }: { id: string }) => Promise.resolve(makeTask({ id })));
+    mockTaskFindOneOrFail.mockImplementation(({ where }: { where: { id: string } }) =>
+      Promise.resolve(makeTask({ id: where.id, dataset: { id: uuidV4() } }))
+    );
+    mockTaskFind.mockResolvedValue([]);
+  });
+
+  describe('create', () => {
+    it('creates a Requested, open task and saves it', async () => {
+      const metadata = { revisionId: 'rev-1' };
+      const result = await service.create('ds-1', TaskAction.Publish, user, 'a comment', metadata);
+
+      expect(mockTaskCreate).toHaveBeenCalledWith({
+        datasetId: 'ds-1',
+        action: TaskAction.Publish,
+        createdBy: user,
+        status: TaskStatus.Requested,
+        open: true,
+        comment: 'a comment',
+        metadata
+      });
+      expect(result.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('getById', () => {
+    it('fetches a task with the supplied relations', async () => {
+      await service.getById('task-1', { dataset: true });
+      expect(mockTaskFindOneOrFail).toHaveBeenCalledWith({ where: { id: 'task-1' }, relations: { dataset: true } });
+    });
+
+    it('defaults to no relations', async () => {
+      await service.getById('task-1');
+      expect(mockTaskFindOneOrFail).toHaveBeenCalledWith({ where: { id: 'task-1' }, relations: {} });
+    });
+  });
+
+  describe('update', () => {
+    it('merges the new status/open/comment and saves', async () => {
+      const existing = makeTask({ id: 'task-1' });
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(existing);
+
+      const result = await service.update('task-1', TaskStatus.Approved, false, user, 'done');
+
+      expect(mockTaskMerge).toHaveBeenCalledWith(existing, {
+        status: TaskStatus.Approved,
+        open: false,
+        updatedBy: user,
+        comment: 'done'
+      });
+      expect(existing.save).toHaveBeenCalled();
+      expect(result.status).toBe(TaskStatus.Approved);
+      expect(result.open).toBe(false);
+    });
+  });
+
+  describe('withdrawPending', () => {
+    it('sets status Withdrawn and closes the task', async () => {
+      const existing = makeTask({ id: 'task-1' });
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(existing);
+
+      await service.withdrawPending('task-1', user);
+
+      expect(mockTaskMerge).toHaveBeenCalledWith(existing, {
+        status: TaskStatus.Withdrawn,
+        open: false,
+        updatedBy: user
+      });
+      expect(existing.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('withdrawApproved', () => {
+    it('creates a closed withdrawn publish task carrying the revision id', async () => {
+      const result = await service.withdrawApproved('ds-1', 'rev-1', user);
+
+      expect(mockTaskCreate).toHaveBeenCalledWith({
+        datasetId: 'ds-1',
+        action: TaskAction.Publish,
+        status: TaskStatus.Withdrawn,
+        open: false,
+        metadata: { revisionId: 'rev-1', note: 'previously approved' },
+        createdBy: user,
+        updatedBy: user
+      });
+      expect(result.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('requestUnpublish', () => {
+    it('creates an Unpublish task when the dataset is published with no open tasks', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevision: {}, endRevisionId: 'rev-1' });
+      mockGetPublishingStatus.mockReturnValue(PublishingStatus.Published);
+
+      await service.requestUnpublish('ds-1', user, 'because');
+
+      expect(mockTaskCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          datasetId: 'ds-1',
+          action: TaskAction.Unpublish,
+          status: TaskStatus.Requested,
+          metadata: { revisionId: 'rev-1' }
+        })
+      );
+    });
+
+    it('rejects when the dataset has an open task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [{ open: true }], endRevision: {} });
+
+      await expect(service.requestUnpublish('ds-1', user, 'because')).rejects.toThrow(BadRequestException);
+      expect(mockTaskCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the dataset is not in a published state', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevision: {} });
+      mockGetPublishingStatus.mockReturnValue(PublishingStatus.Incomplete);
+
+      await expect(service.requestUnpublish('ds-1', user, 'because')).rejects.toThrow(BadRequestException);
+      expect(mockTaskCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejectUnpublish', () => {
+    it('updates the task to Rejected and closes it', async () => {
+      const task = makeTask({ id: 'task-1', dataset: { id: 'ds-1' } });
+      mockTaskFindOneOrFail.mockResolvedValueOnce(task);
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(task);
+
+      await service.rejectUnpublish('task-1', user, 'no');
+
+      expect(mockTaskMerge).toHaveBeenCalledWith(
+        task,
+        expect.objectContaining({ status: TaskStatus.Rejected, open: false, comment: 'no' })
+      );
+    });
+  });
+
+  describe('requestArchive', () => {
+    it('creates an Archive task with no replacement', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+
+      await service.requestArchive('ds-1', user, 'reason');
+
+      expect(mockTaskCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ action: TaskAction.Archive, metadata: { revisionId: 'rev-1' } })
+      );
+    });
+
+    it('rejects when the dataset has an open task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [{ open: true }] });
+      await expect(service.requestArchive('ds-1', user, 'reason')).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the replacement is the dataset itself', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+      await expect(service.requestArchive('ds-1', user, 'reason', 'ds-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the replacement is itself archived', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+      mockPublishedGetById.mockResolvedValue({
+        archivedAt: new Date('2020-01-01'),
+        publishedRevision: { metadata: [] }
+      });
+
+      await expect(service.requestArchive('ds-1', user, 'reason', 'ds-2')).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the replacement is not published', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+      mockPublishedGetById.mockRejectedValue(new Error('not found'));
+
+      await expect(service.requestArchive('ds-1', user, 'reason', 'ds-2')).rejects.toThrow(BadRequestException);
+    });
+
+    it('records the replacement title and auto-redirect in the task metadata', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+      mockPublishedGetById.mockResolvedValue({
+        archivedAt: null,
+        publishedRevision: { metadata: [{ language: 'en-GB', title: 'Replacement title' }] }
+      });
+
+      await service.requestArchive('ds-1', user, 'reason', 'ds-2', true);
+
+      expect(mockTaskCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: TaskAction.Archive,
+          metadata: expect.objectContaining({
+            replacementDatasetId: 'ds-2',
+            replacementDatasetTitle: 'Replacement title',
+            autoRedirect: true
+          })
+        })
+      );
+    });
+  });
+
+  describe('approveArchive', () => {
+    it('archives the dataset and approves the task', async () => {
+      const task = makeTask({
+        id: 'task-1',
+        dataset: { id: 'ds-1' },
+        metadata: { replacementDatasetId: 'ds-2', autoRedirect: true }
+      });
+      mockTaskFindOneOrFail.mockResolvedValueOnce(task);
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(task);
+
+      await service.approveArchive('task-1', user);
+
+      expect(mockDatasetArchive).toHaveBeenCalledWith('ds-1', 'ds-2', true);
+      expect(mockTaskMerge).toHaveBeenCalledWith(
+        task,
+        expect.objectContaining({ status: TaskStatus.Approved, open: false })
+      );
+    });
+  });
+
+  describe('rejectArchive', () => {
+    it('updates the task to Rejected', async () => {
+      const task = makeTask({ id: 'task-1', dataset: { id: 'ds-1' } });
+      mockTaskFindOneOrFail.mockResolvedValueOnce(task);
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(task);
+
+      await service.rejectArchive('task-1', user, 'nope');
+
+      expect(mockTaskMerge).toHaveBeenCalledWith(
+        task,
+        expect.objectContaining({ status: TaskStatus.Rejected, open: false, comment: 'nope' })
+      );
+    });
+  });
+
+  describe('requestUnarchive', () => {
+    it('creates an Unarchive task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [], endRevisionId: 'rev-1' });
+
+      await service.requestUnarchive('ds-1', user, 'reason');
+
+      expect(mockTaskCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ action: TaskAction.Unarchive, metadata: { revisionId: 'rev-1' } })
+      );
+    });
+
+    it('rejects when the dataset has an open task', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', tasks: [{ open: true }] });
+      await expect(service.requestUnarchive('ds-1', user, 'reason')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('approveUnarchive', () => {
+    it('unarchives the dataset and approves the task', async () => {
+      const task = makeTask({ id: 'task-1', dataset: { id: 'ds-1' } });
+      mockTaskFindOneOrFail.mockResolvedValueOnce(task);
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(task);
+
+      await service.approveUnarchive('task-1', user);
+
+      expect(mockDatasetUnarchive).toHaveBeenCalledWith('ds-1');
+      expect(mockTaskMerge).toHaveBeenCalledWith(
+        task,
+        expect.objectContaining({ status: TaskStatus.Approved, open: false })
+      );
+    });
+  });
+
+  describe('rejectUnarchive', () => {
+    it('updates the task to Rejected', async () => {
+      const task = makeTask({ id: 'task-1', dataset: { id: 'ds-1' } });
+      mockTaskFindOneOrFail.mockResolvedValueOnce(task);
+      mockTaskFindOneByOrFail.mockResolvedValueOnce(task);
+
+      await service.rejectUnarchive('task-1', user, 'nope');
+
+      expect(mockTaskMerge).toHaveBeenCalledWith(
+        task,
+        expect.objectContaining({ status: TaskStatus.Rejected, open: false, comment: 'nope' })
+      );
+    });
+  });
+
+  describe('getTasksForDataset', () => {
+    it('queries tasks ordered by creation date, filtered by open flag', async () => {
+      const tasks = [makeTask(), makeTask()];
+      mockTaskFind.mockResolvedValueOnce(tasks);
+
+      const result = await service.getTasksForDataset('ds-1', true);
+
+      expect(mockTaskFind).toHaveBeenCalledWith({
+        where: { datasetId: 'ds-1', open: true },
+        order: { createdAt: 'DESC' }
+      });
+      expect(result).toBe(tasks);
+    });
+
+    it('passes undefined open flag through when omitted', async () => {
+      await service.getTasksForDataset('ds-1');
+      expect(mockTaskFind).toHaveBeenCalledWith({
+        where: { datasetId: 'ds-1', open: undefined },
+        order: { createdAt: 'DESC' }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for three under-covered services flagged in #686, bringing each above the 70% statement-coverage target used across the testing initiative.

| File | Before | After |
|---|---:|---:|
| `src/services/dataset.ts` | 50.2% | **99.6%** |
| `src/services/revision.ts` | 30.9% | **93.5%** |
| `src/services/task.ts` | 14.0% | **100%** |

84 new tests covering both happy and unhappy paths across each service's public methods — task lifecycle and status transitions, revision draft/approval flows, and dataset fact-table replacement.

## Source changes

`src/services/dataset.ts`:
- Switched the draft-revision delete path from `getFileService()` to the injected `this.fileService`, so the path can be exercised in a unit test.
- Kept the `revisionIndex === 1` guard around the dimension/measure reset as a deliberate defensive backstop. The outer guard in `updateFactTable` already throws for any revision other than the first, so the inner check is currently redundant — but it stays as cheap protection against that outer guard being relaxed later, so we never reset a non-first revision's dimensions/measure.

`jest.config.ts`:
- Raised the global coverage thresholds to match the new floor: statements 79, branches 67, functions 75, lines 79. Full-suite coverage now sits at 80.97% / 68.2% / 76.7% / 80.8%.

## Scope

This PR covers the three **services** from #686. The four controllers (`admin`, `build-log`, `measure`, `translation`) are handled separately in #693.

## Verification

- `jest --coverage` — 1551 tests pass, global thresholds met.
- `tsc` build and lint clean.

Part of #686.
