### PR TITLE
Add unit tests for admin, build-log, measure and translation controllers (#686)

### DIFF
--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -39,6 +39,7 @@ export const loadUserGroup = async (req: Request, res: Response, next: NextFunct
     res.locals.userGroupId = group.id;
   } catch (_err) {
     next(new NotFoundException('errors.no_user_group'));
+    return;
   }
 
   next();
@@ -57,6 +58,7 @@ export const loadUser = async (req: Request, res: Response, next: NextFunction):
     res.locals.userId = user.id;
   } catch (_err) {
     next(new NotFoundException('errors.no_user'));
+    return;
   }
 
   next();

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -142,6 +142,7 @@ export const updateMeasureMetadata = async (req: Request, res: Response, next: N
   const measure = dataset.measure;
   if (!measure) {
     next(new NotFoundException('errors.measure_invalid'));
+    return;
   }
 
   const draftRevision = dataset.draftRevision;

--- a/test/unit/controllers/admin.test.ts
+++ b/test/unit/controllers/admin.test.ts
@@ -155,11 +155,10 @@ describe('Admin controller', () => {
       expect(userGroupRepo.getById).not.toHaveBeenCalled();
     });
 
-    // BUG (#686 review): on the not-found path the catch calls next(NotFoundException) but does not
-    // `return`, so it falls through to the unconditional next() at the end of the function and calls
-    // next TWICE (once with the error, once without). The canonical datasetAuth middleware returns
-    // after next(error). Double next() lets the request continue to the route handler with no group
-    // loaded and risks ERR_HTTP_HEADERS_SENT. This asserts the correct behaviour and is expected to FAIL.
+    // Regression (#686): the catch block previously called next(NotFoundException) without a `return`,
+    // falling through to the unconditional next() at the end and calling next TWICE (once with the
+    // error, once without) — the "responds twice" class of bug. It now returns after next(error),
+    // matching the canonical datasetAuth middleware.
     it('calls next exactly once with NotFound when the group cannot be loaded', async () => {
       userGroupRepo.getById.mockRejectedValue(new Error('not in db'));
 
@@ -199,8 +198,8 @@ describe('Admin controller', () => {
       expect(userRepo.getById).not.toHaveBeenCalled();
     });
 
-    // BUG (#686 review): same missing `return` as loadUserGroup — next() is called twice on the
-    // not-found path. This asserts the correct behaviour and is expected to FAIL until the return is added.
+    // Regression (#686): same missing `return` as loadUserGroup — next() used to be called twice on
+    // the not-found path. It now returns after next(error).
     it('calls next exactly once with NotFound when the user cannot be loaded', async () => {
       userRepo.getById.mockRejectedValue(new Error('not in db'));
 

--- a/test/unit/controllers/admin.test.ts
+++ b/test/unit/controllers/admin.test.ts
@@ -1,0 +1,665 @@
+import { Request, Response, NextFunction } from 'express';
+import { QueryFailedError } from 'typeorm';
+
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+import { NotFoundException } from '../../../src/exceptions/not-found.exception';
+import { UnknownException } from '../../../src/exceptions/unknown.exception';
+import { GlobalRole } from '../../../src/enums/global-role';
+import { GroupRole } from '../../../src/enums/group-role';
+import { UserGroupStatus } from '../../../src/enums/user-group-status';
+import { UserStatus } from '../../../src/enums/user-status';
+import { DatasetSimilarBy } from '../../../src/enums/dataset-similar-by';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+const userGroupRepo = {
+  getById: jest.fn(),
+  createGroup: jest.fn(),
+  getAll: jest.fn(),
+  listByLanguage: jest.fn(),
+  getByIdWithDatasets: jest.fn(),
+  updateGroup: jest.fn(),
+  updateGroupStatus: jest.fn(),
+  getDashboardStats: jest.fn()
+};
+jest.mock('../../../src/repositories/user-group', () => ({ UserGroupRepository: userGroupRepo }));
+
+const userRepo = {
+  getById: jest.fn(),
+  listByLanguage: jest.fn(),
+  createUser: jest.fn(),
+  updateUserRoles: jest.fn(),
+  updateUserStatus: jest.fn(),
+  getDashboardStats: jest.fn()
+};
+jest.mock('../../../src/repositories/user', () => ({ UserRepository: userRepo }));
+
+const datasetStatsRepo = {
+  getDashboardStats: jest.fn(),
+  shareSources: jest.fn(),
+  shareDimensions: jest.fn(),
+  similarTitles: jest.fn(),
+  sameFactTable: jest.fn()
+};
+jest.mock('../../../src/repositories/dataset-stats', () => ({ DatasetStatsRepository: datasetStatsRepo }));
+
+const searchLogRepo = { getByPeriod: jest.fn() };
+jest.mock('../../../src/repositories/search-log', () => ({ SearchLogRepository: searchLogRepo }));
+
+const mockHasError = jest.fn();
+jest.mock('../../../src/validators', () => ({
+  hasError: (...args: unknown[]) => mockHasError(...args),
+  uuidValidator: jest.fn(() => 'uuidValidator'),
+  groupStatusValidator: jest.fn(() => 'groupStatusValidator'),
+  userStatusValidator: jest.fn(() => 'userStatusValidator'),
+  similarByValidator: jest.fn(() => 'similarByValidator')
+}));
+
+const mockArrayValidator = jest.fn();
+const mockDtoValidator = jest.fn();
+jest.mock('../../../src/validators/dto-validator', () => ({
+  arrayValidator: (...args: unknown[]) => mockArrayValidator(...args),
+  dtoValidator: (...args: unknown[]) => mockDtoValidator(...args)
+}));
+
+const mockGroupFromUserGroup = jest.fn();
+jest.mock('../../../src/dtos/user/user-group-dto', () => ({
+  UserGroupDTO: { fromUserGroup: (...args: unknown[]) => mockGroupFromUserGroup(...args) }
+}));
+jest.mock('../../../src/dtos/user/user-group-metadata-dto', () => ({ UserGroupMetadataDTO: class {} }));
+
+const mockUserFromUser = jest.fn();
+jest.mock('../../../src/dtos/user/user-dto', () => ({
+  UserDTO: { fromUser: (...args: unknown[]) => mockUserFromUser(...args) }
+}));
+jest.mock('../../../src/dtos/user/user-create-dto', () => ({ UserCreateDTO: class {} }));
+jest.mock('../../../src/dtos/user/role-selection-dto', () => ({ RoleSelectionDTO: class {} }));
+
+const mockStringifyStream = { pipe: jest.fn() };
+const mockStringify = jest.fn((..._args: unknown[]) => mockStringifyStream);
+jest.mock('csv-stringify', () => ({ stringify: (...args: unknown[]) => mockStringify(...args) }));
+
+import {
+  loadUserGroup,
+  loadUser,
+  listRoles,
+  createUserGroup,
+  getAllUserGroups,
+  listUserGroups,
+  getUserGroupById,
+  updateUserGroup,
+  updateUserGroupStatus,
+  listUsers,
+  createUser,
+  getUserById,
+  updateUserRoles,
+  updateUserStatus,
+  dashboard,
+  similarDatasets,
+  downloadSearchLogs
+} from '../../../src/controllers/admin';
+
+function createMockRequest(overrides: Partial<Request> = {}): Request {
+  return { params: {}, query: {}, body: {}, language: 'en-GB', ...overrides } as unknown as Request;
+}
+
+function createMockResponse(locals: Record<string, unknown> = {}): Response {
+  const res = {
+    locals,
+    json: jest.fn(),
+    status: jest.fn(),
+    setHeader: jest.fn()
+  } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  (res.json as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+describe('Admin controller', () => {
+  let mockNext: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNext = jest.fn();
+    mockHasError.mockReset();
+    mockHasError.mockResolvedValue(false);
+  });
+
+  describe('loadUserGroup', () => {
+    it('loads the group into res.locals and calls next', async () => {
+      const group = { id: uuidV4() };
+      userGroupRepo.getById.mockResolvedValue(group);
+
+      const req = createMockRequest({ params: { user_group_id: group.id } });
+      const res = createMockResponse();
+      await loadUserGroup(req, res, mockNext);
+
+      expect(res.locals.userGroup).toBe(group);
+      expect(res.locals.userGroupId).toBe(group.id);
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeUndefined();
+    });
+
+    it('passes NotFound to next when the id is not a valid uuid', async () => {
+      mockHasError.mockResolvedValueOnce(true);
+
+      const req = createMockRequest({ params: { user_group_id: 'not-a-uuid' } });
+      const res = createMockResponse();
+      await loadUserGroup(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+      expect(userGroupRepo.getById).not.toHaveBeenCalled();
+    });
+
+    // BUG (#686 review): on the not-found path the catch calls next(NotFoundException) but does not
+    // `return`, so it falls through to the unconditional next() at the end of the function and calls
+    // next TWICE (once with the error, once without). The canonical datasetAuth middleware returns
+    // after next(error). Double next() lets the request continue to the route handler with no group
+    // loaded and risks ERR_HTTP_HEADERS_SENT. This asserts the correct behaviour and is expected to FAIL.
+    it('calls next exactly once with NotFound when the group cannot be loaded', async () => {
+      userGroupRepo.getById.mockRejectedValue(new Error('not in db'));
+
+      const req = createMockRequest({ params: { user_group_id: uuidV4() } });
+      const res = createMockResponse();
+      await loadUserGroup(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('loadUser', () => {
+    it('loads the user into res.locals and calls next', async () => {
+      const user = { id: uuidV4() };
+      userRepo.getById.mockResolvedValue(user);
+
+      const req = createMockRequest({ params: { user_id: user.id } });
+      const res = createMockResponse();
+      await loadUser(req, res, mockNext);
+
+      expect(res.locals.user).toBe(user);
+      expect(res.locals.userId).toBe(user.id);
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeUndefined();
+    });
+
+    it('passes NotFound to next when the id is not a valid uuid', async () => {
+      mockHasError.mockResolvedValueOnce(true);
+
+      const req = createMockRequest({ params: { user_id: 'nope' } });
+      const res = createMockResponse();
+      await loadUser(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+      expect(userRepo.getById).not.toHaveBeenCalled();
+    });
+
+    // BUG (#686 review): same missing `return` as loadUserGroup — next() is called twice on the
+    // not-found path. This asserts the correct behaviour and is expected to FAIL until the return is added.
+    it('calls next exactly once with NotFound when the user cannot be loaded', async () => {
+      userRepo.getById.mockRejectedValue(new Error('not in db'));
+
+      const req = createMockRequest({ params: { user_id: uuidV4() } });
+      const res = createMockResponse();
+      await loadUser(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('listRoles', () => {
+    it('returns the available global and group roles', async () => {
+      const res = createMockResponse();
+      await listRoles(createMockRequest(), res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        global: Object.values(GlobalRole),
+        group: Object.values(GroupRole)
+      });
+    });
+  });
+
+  describe('createUserGroup', () => {
+    it('validates the body, creates the group and returns its DTO', async () => {
+      const meta = [{ name: 'Group' }];
+      const group = { id: uuidV4() };
+      mockArrayValidator.mockResolvedValue(meta);
+      userGroupRepo.createGroup.mockResolvedValue(group);
+      mockGroupFromUserGroup.mockReturnValue({ id: group.id });
+
+      const res = createMockResponse();
+      await createUserGroup(createMockRequest({ body: meta as never }), res, mockNext);
+
+      expect(userGroupRepo.createGroup).toHaveBeenCalledWith(meta);
+      expect(res.json).toHaveBeenCalledWith({ id: group.id });
+    });
+
+    it('forwards a BadRequest from validation to next', async () => {
+      const badRequest = new BadRequestException('errors.invalid');
+      mockArrayValidator.mockRejectedValue(badRequest);
+
+      const res = createMockResponse();
+      await createUserGroup(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(badRequest);
+    });
+
+    it('passes UnknownException to next on an unexpected error', async () => {
+      mockArrayValidator.mockResolvedValue([]);
+      userGroupRepo.createGroup.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await createUserGroup(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('getAllUserGroups', () => {
+    it('returns all groups mapped to DTOs', async () => {
+      userGroupRepo.getAll.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+      mockGroupFromUserGroup.mockImplementation((g: { id: string }) => ({ dto: g.id }));
+
+      const res = createMockResponse();
+      await getAllUserGroups(createMockRequest({ query: { status: UserGroupStatus.Active } as never }), res, mockNext);
+
+      expect(userGroupRepo.getAll).toHaveBeenCalledWith(UserGroupStatus.Active);
+      expect(res.json).toHaveBeenCalledWith([{ dto: '1' }, { dto: '2' }]);
+    });
+
+    it('passes UnknownException to next on error', async () => {
+      userGroupRepo.getAll.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await getAllUserGroups(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('listUserGroups', () => {
+    it('returns the paged listing results', async () => {
+      const results = { data: [], count: 0 };
+      userGroupRepo.listByLanguage.mockResolvedValue(results);
+
+      const res = createMockResponse();
+      await listUserGroups(
+        createMockRequest({ query: { page: '2', limit: '5', search: '  hello  ' } as never }),
+        res,
+        mockNext
+      );
+
+      expect(userGroupRepo.listByLanguage).toHaveBeenCalledWith('en-GB', 2, 5, 'hello');
+      expect(res.json).toHaveBeenCalledWith(results);
+    });
+
+    it('passes UnknownException to next on error', async () => {
+      userGroupRepo.listByLanguage.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await listUserGroups(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('getUserGroupById', () => {
+    it('returns the group with datasets', async () => {
+      const group = { id: uuidV4() };
+      userGroupRepo.getByIdWithDatasets.mockResolvedValue(group);
+      mockGroupFromUserGroup.mockReturnValue({ id: group.id });
+
+      const res = createMockResponse({ userGroupId: group.id });
+      await getUserGroupById(createMockRequest(), res);
+
+      expect(userGroupRepo.getByIdWithDatasets).toHaveBeenCalledWith(group.id);
+      expect(res.json).toHaveBeenCalledWith({ id: group.id });
+    });
+  });
+
+  describe('updateUserGroup', () => {
+    it('validates and updates the group', async () => {
+      const dto = { name: 'X' };
+      const group = { id: uuidV4() };
+      mockDtoValidator.mockResolvedValue(dto);
+      userGroupRepo.updateGroup.mockResolvedValue(group);
+      mockGroupFromUserGroup.mockReturnValue({ id: group.id });
+
+      const res = createMockResponse({ userGroupId: group.id });
+      await updateUserGroup(createMockRequest(), res, mockNext);
+
+      expect(userGroupRepo.updateGroup).toHaveBeenCalledWith(group.id, dto);
+      expect(res.json).toHaveBeenCalledWith({ id: group.id });
+    });
+
+    it('forwards a BadRequest from validation to next', async () => {
+      const badRequest = new BadRequestException('errors.invalid');
+      mockDtoValidator.mockRejectedValue(badRequest);
+
+      const res = createMockResponse({ userGroupId: uuidV4() });
+      await updateUserGroup(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(badRequest);
+    });
+
+    it('throws UnknownException on an unexpected error', async () => {
+      mockDtoValidator.mockResolvedValue({});
+      userGroupRepo.updateGroup.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse({ userGroupId: uuidV4() });
+      await expect(updateUserGroup(createMockRequest(), res, mockNext)).rejects.toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('updateUserGroupStatus', () => {
+    it('updates the status when valid', async () => {
+      const group = { id: uuidV4(), datasets: [] };
+      userGroupRepo.getByIdWithDatasets.mockResolvedValue(group);
+      userGroupRepo.updateGroupStatus.mockResolvedValue(group);
+      mockGroupFromUserGroup.mockReturnValue({ id: group.id });
+
+      const req = createMockRequest({ body: { status: UserGroupStatus.Active } as never });
+      const res = createMockResponse({ userGroupId: group.id });
+      await updateUserGroupStatus(req, res, mockNext);
+
+      expect(userGroupRepo.updateGroupStatus).toHaveBeenCalledWith(group.id, UserGroupStatus.Active);
+      expect(res.json).toHaveBeenCalledWith({ id: group.id });
+    });
+
+    it('rejects deactivation when the group still has datasets', async () => {
+      userGroupRepo.getByIdWithDatasets.mockResolvedValue({ id: uuidV4(), datasets: [{ id: 'd1' }] });
+
+      const req = createMockRequest({ body: { status: UserGroupStatus.Inactive } as never });
+      const res = createMockResponse({ userGroupId: uuidV4() });
+      await updateUserGroupStatus(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect(userGroupRepo.updateGroupStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the status value is invalid', async () => {
+      userGroupRepo.getByIdWithDatasets.mockResolvedValue({ id: uuidV4(), datasets: [] });
+      mockHasError.mockResolvedValueOnce(true);
+
+      const req = createMockRequest({ body: { status: 'bogus' } as never });
+      const res = createMockResponse({ userGroupId: uuidV4() });
+      await updateUserGroupStatus(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect(userGroupRepo.updateGroupStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listUsers', () => {
+    it('returns the paged user listing', async () => {
+      const results = { data: [], count: 0 };
+      userRepo.listByLanguage.mockResolvedValue(results);
+
+      const res = createMockResponse();
+      await listUsers(createMockRequest({ query: { page: '1', limit: '20' } as never }), res);
+
+      expect(userRepo.listByLanguage).toHaveBeenCalledWith('en-GB', 1, 20, undefined);
+      expect(res.json).toHaveBeenCalledWith(results);
+    });
+
+    it('throws UnknownException on error', async () => {
+      userRepo.listByLanguage.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await expect(listUsers(createMockRequest(), res)).rejects.toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('createUser', () => {
+    it('validates and creates the user', async () => {
+      const dto = { email: 'a@b.c' };
+      const user = { id: uuidV4() };
+      mockDtoValidator.mockResolvedValue(dto);
+      userRepo.createUser.mockResolvedValue(user);
+      mockUserFromUser.mockReturnValue({ id: user.id });
+
+      const res = createMockResponse();
+      await createUser(createMockRequest(), res);
+
+      expect(userRepo.createUser).toHaveBeenCalledWith(dto);
+      expect(res.json).toHaveBeenCalledWith({ id: user.id });
+    });
+
+    it('throws BadRequest when the user already exists (unique constraint)', async () => {
+      mockDtoValidator.mockResolvedValue({});
+      const dbError = new QueryFailedError('query', [], new Error('duplicate key value violates unique constraint'));
+      userRepo.createUser.mockRejectedValue(dbError);
+
+      const res = createMockResponse();
+      await expect(createUser(createMockRequest(), res)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws UnknownException on other errors', async () => {
+      mockDtoValidator.mockResolvedValue({});
+      userRepo.createUser.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await expect(createUser(createMockRequest(), res)).rejects.toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('getUserById', () => {
+    it('returns the user DTO from res.locals', async () => {
+      const user = { id: uuidV4() };
+      mockUserFromUser.mockReturnValue({ id: user.id });
+
+      const res = createMockResponse({ user });
+      await getUserById(createMockRequest({ params: { user_id: user.id } }), res);
+
+      expect(mockUserFromUser).toHaveBeenCalledWith(user, 'en-GB');
+      expect(res.json).toHaveBeenCalledWith({ id: user.id });
+    });
+  });
+
+  describe('updateUserRoles', () => {
+    it('validates the selections and updates the roles', async () => {
+      const selections = [{ type: 'group', groupId: uuidV4(), roles: [GroupRole.Editor] }];
+      const user = { id: uuidV4() };
+      mockArrayValidator.mockResolvedValue(selections);
+      userRepo.updateUserRoles.mockResolvedValue(user);
+      mockUserFromUser.mockReturnValue({ id: user.id });
+
+      const res = createMockResponse({ userId: user.id });
+      await updateUserRoles(createMockRequest({ body: selections as never }), res);
+
+      expect(userRepo.updateUserRoles).toHaveBeenCalledWith(user.id, selections);
+      expect(res.json).toHaveBeenCalledWith({ id: user.id });
+    });
+
+    it('throws UnknownException when a group selection is missing its group id', async () => {
+      // the controller wraps the thrown BadRequest in its catch and rethrows UnknownException
+      mockArrayValidator.mockResolvedValue([{ type: 'group', roles: [GroupRole.Editor] }]);
+
+      const res = createMockResponse({ userId: uuidV4() });
+      await expect(updateUserRoles(createMockRequest(), res)).rejects.toBeInstanceOf(UnknownException);
+      expect(userRepo.updateUserRoles).not.toHaveBeenCalled();
+    });
+
+    it('throws UnknownException when a role value is invalid', async () => {
+      mockArrayValidator.mockResolvedValue([{ type: 'global', roles: ['not-a-role'] }]);
+
+      const res = createMockResponse({ userId: uuidV4() });
+      await expect(updateUserRoles(createMockRequest(), res)).rejects.toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('updateUserStatus', () => {
+    it('updates the user status when valid', async () => {
+      const user = { id: uuidV4() };
+      userRepo.updateUserStatus.mockResolvedValue(user);
+      mockUserFromUser.mockReturnValue({ id: user.id });
+
+      const req = createMockRequest({ body: { status: UserStatus.Active } as never });
+      const res = createMockResponse({ userId: user.id });
+      await updateUserStatus(req, res, mockNext);
+
+      expect(userRepo.updateUserStatus).toHaveBeenCalledWith(user.id, UserStatus.Active);
+      expect(res.json).toHaveBeenCalledWith({ id: user.id });
+    });
+
+    it('rejects when the status is invalid', async () => {
+      mockHasError.mockResolvedValueOnce(true);
+
+      const req = createMockRequest({ body: { status: 'bogus' } as never });
+      const res = createMockResponse({ userId: uuidV4() });
+      await updateUserStatus(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect(userRepo.updateUserStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws UnknownException on an unexpected error', async () => {
+      userRepo.updateUserStatus.mockRejectedValue(new Error('boom'));
+
+      const req = createMockRequest({ body: { status: UserStatus.Active } as never });
+      const res = createMockResponse({ userId: uuidV4() });
+      await expect(updateUserStatus(req, res, mockNext)).rejects.toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('dashboard', () => {
+    it('aggregates dataset, user and group stats', async () => {
+      datasetStatsRepo.getDashboardStats.mockResolvedValue({ d: 1 });
+      userRepo.getDashboardStats.mockResolvedValue({ u: 2 });
+      userGroupRepo.getDashboardStats.mockResolvedValue({ g: 3 });
+
+      const res = createMockResponse();
+      await dashboard(createMockRequest(), res, mockNext);
+
+      expect(res.json).toHaveBeenCalledWith({ datasets: { d: 1 }, users: { u: 2 }, groups: { g: 3 } });
+    });
+
+    it('passes UnknownException to next on error', async () => {
+      datasetStatsRepo.getDashboardStats.mockRejectedValue(new Error('boom'));
+      userRepo.getDashboardStats.mockResolvedValue({});
+      userGroupRepo.getDashboardStats.mockResolvedValue({});
+
+      const res = createMockResponse();
+      await dashboard(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('similarDatasets', () => {
+    it('streams the shared-sources report as CSV by default', async () => {
+      datasetStatsRepo.shareSources.mockResolvedValue([
+        {
+          sources: ['s1'],
+          datasets_count: 2,
+          datasets: ['a', 'b'],
+          dataset_ids: ['1', '2'],
+          revision_ids: ['r1'],
+          dimensions_count: 1,
+          dimensions: ['d'],
+          dimensions_common_count: 1,
+          dimensions_common: ['d'],
+          topics_count: 0,
+          topics: null
+        }
+      ]);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest(), res, mockNext);
+
+      expect(datasetStatsRepo.shareSources).toHaveBeenCalled();
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('streams the shared-dimensions report when by=dimensions', async () => {
+      datasetStatsRepo.shareDimensions.mockResolvedValue([
+        { dimensions: ['d'], datasets_count: 1, datasets: ['a'], dataset_ids: ['1'] }
+      ]);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest({ query: { by: DatasetSimilarBy.Dimensions } as never }), res, mockNext);
+
+      expect(datasetStatsRepo.shareDimensions).toHaveBeenCalled();
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('streams the title-similarity report when by=title', async () => {
+      datasetStatsRepo.similarTitles.mockResolvedValue([{ title_1: 'a', title_2: 'b', similarity_score: 0.5 }]);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest({ query: { by: DatasetSimilarBy.Title } as never }), res, mockNext);
+
+      expect(datasetStatsRepo.similarTitles).toHaveBeenCalled();
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('streams the same-fact-table report when by=facts', async () => {
+      datasetStatsRepo.sameFactTable.mockResolvedValue([
+        { original_filenames: ['f.csv'], datatable_hash: 'h', count: 2, datasets: ['a', 'b'] }
+      ]);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest({ query: { by: DatasetSimilarBy.Facts } as never }), res, mockNext);
+
+      expect(datasetStatsRepo.sameFactTable).toHaveBeenCalled();
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('rejects when the by value is invalid', async () => {
+      mockHasError.mockResolvedValueOnce(true);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest({ query: { by: 'bogus' } as never }), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+    });
+
+    it('passes UnknownException to next when the report query throws', async () => {
+      datasetStatsRepo.shareSources.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('downloadSearchLogs', () => {
+    it('streams the search-log report as CSV', async () => {
+      searchLogRepo.getByPeriod.mockResolvedValue([
+        { createdAt: new Date('2026-01-01T00:00:00Z'), mode: 'simple', keywords: 'tax', resultCount: 3 }
+      ]);
+
+      const res = createMockResponse();
+      await downloadSearchLogs(
+        createMockRequest({ query: { start: '2026-01-01', end: '2026-02-01' } as never }),
+        res,
+        mockNext
+      );
+
+      expect(searchLogRepo.getByPeriod).toHaveBeenCalled();
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('passes UnknownException to next on error', async () => {
+      searchLogRepo.getByPeriod.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await downloadSearchLogs(createMockRequest(), res, mockNext);
+
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+});

--- a/test/unit/controllers/build-log.test.ts
+++ b/test/unit/controllers/build-log.test.ts
@@ -1,0 +1,163 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+import { NotFoundException } from '../../../src/exceptions/not-found.exception';
+import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
+import { CubeBuildType } from '../../../src/enums/cube-build-type';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+const mockGetBy = jest.fn();
+jest.mock('../../../src/repositories/build-log', () => ({
+  BuildLogRepository: {
+    getBy: (...args: unknown[]) => mockGetBy(...args)
+  }
+}));
+
+const mockFindOneByOrFail = jest.fn();
+jest.mock('../../../src/entities/dataset/build-log', () => ({
+  BuildLog: {
+    findOneByOrFail: (...args: unknown[]) => mockFindOneByOrFail(...args)
+  }
+}));
+
+const mockFromBuildLogLite = jest.fn();
+const mockFromBuildLogFull = jest.fn();
+jest.mock('../../../src/dtos/build-log', () => ({
+  BuiltLogEntryDto: {
+    fromBuildLogLite: (...args: unknown[]) => mockFromBuildLogLite(...args),
+    fromBuildLogFull: (...args: unknown[]) => mockFromBuildLogFull(...args)
+  }
+}));
+
+// validators: hasError is the only behaviour we vary per-test; the *Validator factories are inert
+const mockHasError = jest.fn();
+jest.mock('../../../src/validators', () => ({
+  hasError: (...args: unknown[]) => mockHasError(...args),
+  buildTypeValidator: jest.fn(() => 'buildTypeValidator'),
+  buildStatusValidator: jest.fn(() => 'buildStatusValidator')
+}));
+
+import { getBuildLog, getBuiltLogEntry } from '../../../src/controllers/build-log';
+
+function createMockRequest(overrides: Partial<Request> = {}): Request {
+  return { params: {}, query: {}, ...overrides } as unknown as Request;
+}
+
+function createMockResponse(): Response {
+  const res = { status: jest.fn(), send: jest.fn() } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  (res.send as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+describe('Build log controller', () => {
+  let mockNext: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNext = jest.fn();
+    // mockReset clears any leftover mockResolvedValueOnce queue from a prior test
+    mockHasError.mockReset();
+    mockHasError.mockResolvedValue(false);
+  });
+
+  describe('getBuildLog', () => {
+    it('returns mapped build logs with default paging when no query params supplied', async () => {
+      const logs = [{ id: 'a' }, { id: 'b' }];
+      mockGetBy.mockResolvedValue(logs);
+      mockFromBuildLogLite.mockImplementation((log: { id: string }) => ({ dto: log.id }));
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      // default size 30, page 0, no type/status filters
+      expect(mockGetBy).toHaveBeenCalledWith(undefined, undefined, 30, 0);
+      expect(mockFromBuildLogLite).toHaveBeenCalledTimes(2);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith([{ dto: 'a' }, { dto: 'b' }]);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('applies size/page paging and passes type and status filters through', async () => {
+      mockGetBy.mockResolvedValue([]);
+
+      const req = createMockRequest({
+        query: { size: '10', page: '2', type: CubeBuildType.FullCube, status: CubeBuildStatus.Completed } as never
+      });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      // pageNo = page * pageSize = 2 * 10 = 20
+      expect(mockGetBy).toHaveBeenCalledWith(CubeBuildType.FullCube, CubeBuildStatus.Completed, 10, 20);
+      expect(res.send).toHaveBeenCalledWith([]);
+    });
+
+    it('rejects with BadRequest when the type filter is invalid', async () => {
+      mockHasError.mockResolvedValueOnce(true); // typeError
+
+      const req = createMockRequest({ query: { type: 'nonsense' } as never });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect(mockGetBy).not.toHaveBeenCalled();
+    });
+
+    it('rejects with BadRequest when the status filter is invalid', async () => {
+      // type is absent so hasError is only called once (for status) -> make that call report an error
+      mockHasError.mockResolvedValueOnce(true);
+
+      const req = createMockRequest({ query: { status: 'nonsense' } as never });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect(mockGetBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getBuiltLogEntry', () => {
+    it('returns the full build log entry DTO when found', async () => {
+      const build = { id: uuidV4() };
+      mockFindOneByOrFail.mockResolvedValue(build);
+      mockFromBuildLogFull.mockReturnValue({ dto: build.id });
+
+      const req = createMockRequest({ params: { build_id: build.id } });
+      const res = createMockResponse();
+
+      await getBuiltLogEntry(req, res);
+
+      expect(mockFindOneByOrFail).toHaveBeenCalledWith({ id: build.id });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith({ dto: build.id });
+    });
+
+    it('throws NotFound when no build id is supplied', async () => {
+      const req = createMockRequest({ params: {} });
+      const res = createMockResponse();
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(NotFoundException);
+      expect(mockFindOneByOrFail).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when the build cannot be loaded', async () => {
+      mockFindOneByOrFail.mockRejectedValue(new Error('not in db'));
+
+      const req = createMockRequest({ params: { build_id: uuidV4() } });
+      const res = createMockResponse();
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/test/unit/controllers/measure.test.ts
+++ b/test/unit/controllers/measure.test.ts
@@ -333,11 +333,9 @@ describe('Measure controller', () => {
       expect(res.status).not.toHaveBeenCalledWith(202);
     });
 
-    // BUG (#686 review): when the dataset has no measure the handler calls next(NotFoundException)
-    // but does not `return`, so it falls through to `measure.metadata.find(...)` and throws a
-    // TypeError on the null measure. Correct behaviour: forward NotFoundException and stop.
-    // Compare getPreviewOfMeasure / getMeasureInfo which return after the guard.
-    // This test asserts the correct behaviour and is expected to FAIL until the missing return is added.
+    // Regression (#686): previously the handler called next(NotFoundException) without a `return`,
+    // fell through to `measure.metadata.find(...)` and threw a TypeError on the null measure.
+    // It now returns after the guard, like getPreviewOfMeasure / getMeasureInfo.
     it('forwards NotFound and does not throw when the dataset has no measure', async () => {
       const dataset = { id: uuidV4(), draftRevision: { id: uuidV4() }, measure: null };
       mockGetById.mockResolvedValue(dataset);

--- a/test/unit/controllers/measure.test.ts
+++ b/test/unit/controllers/measure.test.ts
@@ -1,0 +1,403 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { NotFoundException } from '../../../src/exceptions/not-found.exception';
+import { UnknownException } from '../../../src/exceptions/unknown.exception';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+const mockGetById = jest.fn();
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: { getById: (...args: unknown[]) => mockGetById(...args) }
+}));
+
+const mockDatasetFindOneByOrFail = jest.fn();
+jest.mock('../../../src/entities/dataset/dataset', () => ({
+  Dataset: { findOneByOrFail: (...args: unknown[]) => mockDatasetFindOneByOrFail(...args) }
+}));
+
+const mockFromDataset = jest.fn();
+jest.mock('../../../src/dtos/dataset-dto', () => ({
+  DatasetDTO: { fromDataset: (...args: unknown[]) => mockFromDataset(...args) }
+}));
+
+const mockFromMeasure = jest.fn();
+jest.mock('../../../src/dtos/measure-dto', () => ({
+  MeasureDTO: { fromMeasure: (...args: unknown[]) => mockFromMeasure(...args) }
+}));
+
+const mockFromLookupTable = jest.fn();
+jest.mock('../../../src/dtos/lookup-table-dto', () => ({
+  LookupTableDTO: { fromLookupTable: (...args: unknown[]) => mockFromLookupTable(...args) }
+}));
+
+const mockFromDimensionMetadata = jest.fn();
+jest.mock('../../../src/dtos/dimension-metadata-dto', () => ({
+  DimensionMetadataDTO: { fromDimensionMetadata: (...args: unknown[]) => mockFromDimensionMetadata(...args) }
+}));
+
+const mockGetMeasurePreview = jest.fn();
+const mockValidateMeasureLookupTable = jest.fn();
+jest.mock('../../../src/services/measure-handler', () => ({
+  getMeasurePreview: (...args: unknown[]) => mockGetMeasurePreview(...args),
+  validateMeasureLookupTable: (...args: unknown[]) => mockValidateMeasureLookupTable(...args)
+}));
+
+const mockValidateAndUpload = jest.fn();
+jest.mock('../../../src/services/incoming-file-processor', () => ({
+  validateAndUpload: (...args: unknown[]) => mockValidateAndUpload(...args)
+}));
+
+const mockCreateAllCubeFiles = jest.fn();
+jest.mock('../../../src/services/cube-builder', () => ({
+  createAllCubeFiles: (...args: unknown[]) => mockCreateAllCubeFiles(...args)
+}));
+
+const mockUploadAvScan = jest.fn();
+const mockCleanupTmpFile = jest.fn();
+jest.mock('../../../src/services/virus-scanner', () => ({
+  uploadAvScan: (...args: unknown[]) => mockUploadAvScan(...args),
+  cleanupTmpFile: (...args: unknown[]) => mockCleanupTmpFile(...args)
+}));
+
+const mockUpdateRevisionTasks = jest.fn();
+jest.mock('../../../src/services/revision', () => ({
+  updateRevisionTasks: (...args: unknown[]) => mockUpdateRevisionTasks(...args)
+}));
+
+const mockStartBuild = jest.fn();
+jest.mock('../../../src/entities/dataset/build-log', () => ({
+  BuildLog: { startBuild: (...args: unknown[]) => mockStartBuild(...args) }
+}));
+
+const mockMeasureMetadataCtor = jest.fn();
+jest.mock('../../../src/entities/dataset/measure-metadata', () => ({
+  MeasureMetadata: jest.fn().mockImplementation(() => mockMeasureMetadataCtor())
+}));
+
+import {
+  resetMeasure,
+  getPreviewOfMeasure,
+  updateMeasureMetadata,
+  getMeasureInfo,
+  getMeasureLookupTableInfo,
+  downloadMeasureLookupTable,
+  attachLookupTableToMeasure
+} from '../../../src/controllers/measure';
+
+function createMockRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    body: {},
+    language: 'en-GB',
+    user: { id: uuidV4() },
+    fileService: {
+      delete: jest.fn().mockResolvedValue(undefined),
+      loadStream: jest.fn()
+    },
+    ...overrides
+  } as unknown as Request;
+}
+
+function createMockResponse(locals: Record<string, unknown> = {}): Response {
+  const res = {
+    locals: { datasetId: uuidV4(), ...locals },
+    json: jest.fn(),
+    status: jest.fn(),
+    writeHead: jest.fn(),
+    end: jest.fn()
+  } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  (res.json as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+describe('Measure controller', () => {
+  let mockNext: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNext = jest.fn();
+    // the controllers call createAllCubeFiles(...).catch(...), so the mock must return a promise
+    mockCreateAllCubeFiles.mockResolvedValue(undefined);
+  });
+
+  describe('getMeasureInfo', () => {
+    it('returns the measure DTO when a measure exists', async () => {
+      const dataset = { measure: { id: uuidV4() } };
+      mockGetById.mockResolvedValue(dataset);
+      mockFromMeasure.mockReturnValue({ id: dataset.measure.id });
+
+      const res = createMockResponse();
+      await getMeasureInfo(createMockRequest(), res);
+
+      expect(mockFromMeasure).toHaveBeenCalledWith(dataset.measure);
+      expect(res.json).toHaveBeenCalledWith({ id: dataset.measure.id });
+    });
+
+    it('responds 404 when the dataset has no measure', async () => {
+      mockGetById.mockResolvedValue({ measure: null });
+
+      const res = createMockResponse();
+      await getMeasureInfo(createMockRequest(), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'No measure found' });
+    });
+  });
+
+  describe('getMeasureLookupTableInfo', () => {
+    it('returns the lookup table DTO when present', async () => {
+      const lookupTable = { id: uuidV4() };
+      mockGetById.mockResolvedValue({ measure: { lookupTable } });
+      mockFromLookupTable.mockReturnValue({ id: lookupTable.id });
+
+      const res = createMockResponse();
+      await getMeasureLookupTableInfo(createMockRequest(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ id: lookupTable.id });
+    });
+
+    it('responds 404 when there is no lookup table', async () => {
+      mockGetById.mockResolvedValue({ measure: { lookupTable: null } });
+
+      const res = createMockResponse();
+      await getMeasureLookupTableInfo(createMockRequest(), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'No lookup table found' });
+    });
+  });
+
+  describe('downloadMeasureLookupTable', () => {
+    it('streams the lookup table file to the response', async () => {
+      const lookupTable = { filename: 'lookup.csv', originalFilename: 'orig.csv', mimeType: 'text/csv' };
+      const dataset = { id: uuidV4(), measure: { lookupTable } };
+      mockGetById.mockResolvedValue(dataset);
+      // a plain mock stream — the controller only calls pipe()/on(), so we don't need a real Readable
+      const stream = { pipe: jest.fn(), on: jest.fn() };
+      const req = createMockRequest();
+      ((req as any).fileService.loadStream as jest.Mock).mockResolvedValue(stream);
+
+      const res = createMockResponse();
+      await downloadMeasureLookupTable(req, res);
+
+      expect((req as any).fileService.loadStream).toHaveBeenCalledWith('lookup.csv', dataset.id);
+      const [statusCode, headers] = (res.writeHead as jest.Mock).mock.calls[0];
+      expect(statusCode).toBe(200);
+      expect(headers['Content-Type']).toBe('text/csv');
+      expect(stream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('responds 404 when there is no lookup table', async () => {
+      mockGetById.mockResolvedValue({ id: uuidV4(), measure: { lookupTable: null } });
+
+      const res = createMockResponse();
+      await downloadMeasureLookupTable(createMockRequest(), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'No lookup table found' });
+    });
+
+    it('responds 500 when loading the file fails', async () => {
+      const lookupTable = { filename: 'lookup.csv', mimeType: 'text/csv' };
+      mockGetById.mockResolvedValue({ id: uuidV4(), measure: { lookupTable } });
+      const req = createMockRequest();
+      ((req as any).fileService.loadStream as jest.Mock).mockRejectedValue(new Error('data lake down'));
+
+      const res = createMockResponse();
+      await downloadMeasureLookupTable(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'An error occurred trying to load the file' });
+    });
+  });
+
+  describe('getPreviewOfMeasure', () => {
+    it('returns the measure preview', async () => {
+      const dataset = { measure: { id: uuidV4() } };
+      mockGetById.mockResolvedValue(dataset);
+      mockGetMeasurePreview.mockResolvedValue({ rows: [] });
+
+      const res = createMockResponse();
+      await getPreviewOfMeasure(createMockRequest(), res, mockNext);
+
+      expect(mockGetMeasurePreview).toHaveBeenCalledWith(dataset, 'en-gb');
+      expect(res.json).toHaveBeenCalledWith({ rows: [] });
+    });
+
+    it('passes NotFound to next when there is no measure', async () => {
+      mockGetById.mockResolvedValue({ measure: null });
+
+      const res = createMockResponse();
+      await getPreviewOfMeasure(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+      expect(mockGetMeasurePreview).not.toHaveBeenCalled();
+    });
+
+    it('passes UnknownException to next when the preview throws', async () => {
+      mockGetById.mockResolvedValue({ measure: { id: uuidV4() } });
+      mockGetMeasurePreview.mockRejectedValue(new Error('boom'));
+
+      const res = createMockResponse();
+      await getPreviewOfMeasure(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('resetMeasure', () => {
+    it('clears the extractor, lookup table and measure info, rebuilds and returns the dataset', async () => {
+      const lookupTableRemove = jest.fn().mockResolvedValue(undefined);
+      const infoRemove = jest.fn().mockResolvedValue(undefined);
+      const measureSave = jest.fn().mockResolvedValue(undefined);
+      const dataset = {
+        id: uuidV4(),
+        draftRevision: { id: uuidV4() },
+        measure: {
+          extractor: { some: 'extractor' },
+          lookup: { filename: 'lookup.csv' },
+          lookupTable: { remove: lookupTableRemove },
+          measureInfo: [{ remove: infoRemove }],
+          joinColumn: 'col',
+          save: measureSave
+        }
+      };
+      const reloaded = { id: dataset.id };
+      mockDatasetFindOneByOrFail.mockResolvedValue(reloaded);
+      mockFromDataset.mockReturnValue({ id: dataset.id });
+
+      const req = createMockRequest();
+      const res = createMockResponse({ dataset });
+      await resetMeasure(req, res, mockNext);
+
+      expect(lookupTableRemove).toHaveBeenCalled();
+      expect((req as any).fileService.delete).toHaveBeenCalledWith('lookup.csv', dataset.id);
+      expect(infoRemove).toHaveBeenCalled();
+      expect(measureSave).toHaveBeenCalled();
+      expect(dataset.measure.extractor).toBeNull();
+      expect(dataset.measure.joinColumn).toBeNull();
+      expect(mockCreateAllCubeFiles).toHaveBeenCalledWith(dataset.id, dataset.draftRevision.id, (req as any).user?.id);
+      expect(res.json).toHaveBeenCalledWith({ id: dataset.id });
+    });
+
+    it('passes NotFound to next when the dataset has no measure', async () => {
+      const res = createMockResponse({ dataset: { measure: null } });
+      await resetMeasure(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+      expect(mockCreateAllCubeFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateMeasureMetadata', () => {
+    it('updates the matching language metadata, starts a build and returns 202', async () => {
+      const metadataSave = jest.fn().mockResolvedValue({ id: uuidV4() });
+      const existingMeta = { language: 'en-GB', save: metadataSave };
+      const dataset = {
+        id: uuidV4(),
+        draftRevision: { id: uuidV4() },
+        measure: { id: uuidV4(), metadata: [existingMeta] }
+      };
+      mockGetById.mockResolvedValue(dataset);
+      mockStartBuild.mockResolvedValue({ id: 'build-1' });
+      mockFromDimensionMetadata.mockReturnValue({ name: 'Updated' });
+
+      const req = createMockRequest({ body: { language: 'en-GB', name: 'Updated', notes: 'note' } as never });
+      const res = createMockResponse();
+      await updateMeasureMetadata(req, res, mockNext);
+
+      expect(metadataSave).toHaveBeenCalled();
+      expect(mockUpdateRevisionTasks).toHaveBeenCalledWith(dataset, dataset.measure.id, 'measure');
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({ dimension: { name: 'Updated' }, build_id: 'build-1' });
+    });
+
+    it('passes UnknownException to next when there is no draft revision', async () => {
+      const dataset = { id: uuidV4(), draftRevision: null, measure: { id: uuidV4(), metadata: [] } };
+      mockGetById.mockResolvedValue(dataset);
+
+      const req = createMockRequest({ body: { language: 'en-GB', name: 'x' } as never });
+      const res = createMockResponse();
+      await updateMeasureMetadata(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+      expect(res.status).not.toHaveBeenCalledWith(202);
+    });
+
+    // BUG (#686 review): when the dataset has no measure the handler calls next(NotFoundException)
+    // but does not `return`, so it falls through to `measure.metadata.find(...)` and throws a
+    // TypeError on the null measure. Correct behaviour: forward NotFoundException and stop.
+    // Compare getPreviewOfMeasure / getMeasureInfo which return after the guard.
+    // This test asserts the correct behaviour and is expected to FAIL until the missing return is added.
+    it('forwards NotFound and does not throw when the dataset has no measure', async () => {
+      const dataset = { id: uuidV4(), draftRevision: { id: uuidV4() }, measure: null };
+      mockGetById.mockResolvedValue(dataset);
+
+      const req = createMockRequest({ body: { language: 'en-GB', name: 'x' } as never });
+      const res = createMockResponse();
+
+      await expect(updateMeasureMetadata(req, res, mockNext)).resolves.toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(NotFoundException);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachLookupTableToMeasure', () => {
+    it('forwards the av-scan error and never loads the dataset', async () => {
+      const scanError = new Error('virus');
+      mockUploadAvScan.mockRejectedValue(scanError);
+
+      const res = createMockResponse();
+      await attachLookupTableToMeasure(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(scanError);
+      expect(mockGetById).not.toHaveBeenCalled();
+    });
+
+    it('returns the validation error response without starting a build', async () => {
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/lookup.csv' });
+      mockGetById.mockResolvedValue({ id: uuidV4(), measure: { id: uuidV4() }, draftRevision: { id: uuidV4() } });
+      mockValidateAndUpload.mockResolvedValue({ id: 'data-table' });
+      mockValidateMeasureLookupTable.mockResolvedValue({ status: 400, errors: ['bad'] });
+
+      const req = createMockRequest({ body: {} as never });
+      const res = createMockResponse();
+      await attachLookupTableToMeasure(req, res, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ status: 400, errors: ['bad'] });
+      expect(mockStartBuild).not.toHaveBeenCalled();
+      expect(mockCleanupTmpFile).toHaveBeenCalled();
+    });
+
+    it('starts a build and returns the result when validation succeeds', async () => {
+      const dataset = { id: uuidV4(), measure: { id: uuidV4() }, draftRevision: { id: uuidV4() } };
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/lookup.csv' });
+      mockGetById.mockResolvedValue(dataset);
+      mockValidateAndUpload.mockResolvedValue({ id: 'data-table' });
+      mockValidateMeasureLookupTable.mockResolvedValue({ extension: {} });
+      mockStartBuild.mockResolvedValue({ id: 'build-9' });
+      mockCreateAllCubeFiles.mockResolvedValue(undefined);
+
+      const req = createMockRequest({ body: {} as never });
+      const res = createMockResponse();
+      await attachLookupTableToMeasure(req, res, mockNext);
+
+      expect(mockUpdateRevisionTasks).toHaveBeenCalledWith(dataset, dataset.measure.id, 'measure');
+      expect(mockStartBuild).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ extension: { build_id: 'build-9' } }));
+      expect(mockCleanupTmpFile).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/controllers/translation.test.ts
+++ b/test/unit/controllers/translation.test.ts
@@ -1,0 +1,288 @@
+import { Readable } from 'node:stream';
+
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
+import { UnknownException } from '../../../src/exceptions/unknown.exception';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+const mockGetById = jest.fn();
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: { getById: (...args: unknown[]) => mockGetById(...args) },
+  withMetadataForTranslation: { metadata: true }
+}));
+
+const mockCollectTranslations = jest.fn();
+jest.mock('../../../src/utils/collect-translations', () => ({
+  collectTranslations: (...args: unknown[]) => mockCollectTranslations(...args)
+}));
+
+const mockFromDataset = jest.fn();
+jest.mock('../../../src/dtos/dataset-dto', () => ({
+  DatasetDTO: { fromDataset: (...args: unknown[]) => mockFromDataset(...args) }
+}));
+
+const mockEventSave = jest.fn();
+jest.mock('../../../src/entities/event-log', () => ({
+  EventLog: { getRepository: () => ({ save: (...args: unknown[]) => mockEventSave(...args) }) }
+}));
+
+const mockUploadAvScan = jest.fn();
+jest.mock('../../../src/services/virus-scanner', () => ({
+  uploadAvScan: (...args: unknown[]) => mockUploadAvScan(...args)
+}));
+
+const mockCreateAllCubeFiles = jest.fn();
+jest.mock('../../../src/services/cube-builder', () => ({
+  createAllCubeFiles: (...args: unknown[]) => mockCreateAllCubeFiles(...args)
+}));
+
+// stringify is piped to the response; we only need to observe the pipe, not real CSV output
+const mockStringifyStream = { pipe: jest.fn() };
+const mockStringify = jest.fn((..._args: unknown[]) => mockStringifyStream);
+jest.mock('csv-stringify', () => ({ stringify: (...args: unknown[]) => mockStringify(...args) }));
+
+// real createReadStream is replaced with an in-memory CSV stream so the real csv-parse can run against it
+const mockCreateReadStream = jest.fn();
+jest.mock('node:fs', () => ({
+  ...(jest.requireActual('node:fs') as object),
+  createReadStream: (...args: unknown[]) => mockCreateReadStream(...args)
+}));
+
+import {
+  translationPreview,
+  translationExport,
+  validateImport,
+  applyImport
+} from '../../../src/controllers/translation';
+
+const CSV_HEADER = 'type,key,english,cymraeg';
+
+function csvStream(rows: string[]): Readable {
+  return Readable.from([`${CSV_HEADER}\n${rows.join('\n')}\n`]);
+}
+
+function createMockRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    body: {},
+    user: { id: uuidV4() },
+    fileService: {
+      saveStream: jest.fn().mockResolvedValue(undefined),
+      loadStream: jest.fn(),
+      delete: jest.fn().mockResolvedValue(undefined)
+    },
+    datasetService: {
+      updateTranslations: jest.fn()
+    },
+    ...overrides
+  } as unknown as Request;
+}
+
+function createMockResponse(locals: Record<string, unknown> = {}): Response {
+  const res = {
+    locals: { datasetId: uuidV4(), ...locals },
+    json: jest.fn(),
+    status: jest.fn(),
+    setHeader: jest.fn()
+  } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  (res.json as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+describe('Translation controller', () => {
+  let mockNext: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNext = jest.fn();
+  });
+
+  describe('translationPreview', () => {
+    it('returns collected translations (with ids) for the dataset', async () => {
+      const dataset = { id: uuidV4() };
+      const translations = [{ type: 'metadata', key: 'title', english: 'A', cymraeg: 'B' }];
+      mockGetById.mockResolvedValue(dataset);
+      mockCollectTranslations.mockReturnValue(translations);
+
+      const res = createMockResponse();
+      await translationPreview(createMockRequest(), res, mockNext);
+
+      expect(mockCollectTranslations).toHaveBeenCalledWith(dataset, true);
+      expect(res.json).toHaveBeenCalledWith(translations);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('passes an UnknownException to next when loading fails', async () => {
+      mockGetById.mockRejectedValue(new Error('db down'));
+
+      const res = createMockResponse();
+      await translationPreview(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('translationExport', () => {
+    it('records an export event and streams the CSV to the response', async () => {
+      const revisionId = uuidV4();
+      const dataset = { id: uuidV4(), draftRevision: { id: revisionId } };
+      const translations = [{ type: 'metadata', key: 'title', english: 'A', cymraeg: 'B' }];
+      mockGetById.mockResolvedValue(dataset);
+      mockCollectTranslations.mockReturnValue(translations);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await translationExport(req, res, mockNext);
+
+      expect(mockEventSave).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'export', entity: 'translations', entityId: revisionId, data: translations })
+      );
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
+      expect(mockStringify).toHaveBeenCalledWith(translations, expect.objectContaining({ header: true }));
+      expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('passes an UnknownException to next when the export fails', async () => {
+      mockGetById.mockRejectedValue(new Error('db down'));
+
+      const res = createMockResponse();
+      await translationExport(createMockRequest(), res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+
+  describe('validateImport', () => {
+    it('stores the upload and returns the dataset DTO when the CSV matches the existing translations', async () => {
+      const dataset = { id: uuidV4() };
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/import.csv' });
+      mockGetById.mockResolvedValue(dataset);
+      mockCollectTranslations.mockReturnValue([{ type: 'metadata', key: 'title', english: 'old', cymraeg: 'hen' }]);
+      mockCreateReadStream.mockImplementation(() => csvStream(['metadata,title,New EN,Newydd CY']));
+      mockFromDataset.mockReturnValue({ id: dataset.id });
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await validateImport(req, res, mockNext);
+
+      expect((req as any).fileService.saveStream).toHaveBeenCalledWith(
+        'translation-import.csv',
+        dataset.id,
+        expect.anything()
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: dataset.id });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('forwards the av-scan error to next when the upload fails', async () => {
+      const scanError = new BadRequestException('errors.upload.virus');
+      mockUploadAvScan.mockRejectedValue(scanError);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await validateImport(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(scanError);
+      expect(mockGetById).not.toHaveBeenCalled();
+    });
+
+    it('rejects with a row-count error when the CSV has a different number of rows', async () => {
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/import.csv' });
+      mockGetById.mockResolvedValue({ id: uuidV4() });
+      mockCollectTranslations.mockReturnValue([
+        { type: 'metadata', key: 'title', english: 'a', cymraeg: 'b' },
+        { type: 'metadata', key: 'summary', english: 'c', cymraeg: 'd' }
+      ]);
+      mockCreateReadStream.mockImplementation(() => csvStream(['metadata,title,New EN,Newydd CY']));
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await validateImport(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
+      expect((mockNext.mock.calls[0][0] as unknown as Error).message).toBe('errors.translation_file.invalid.row_count');
+      expect((req as any).fileService.saveStream).not.toHaveBeenCalled();
+    });
+
+    it('rejects with a keys error when a translation key is missing from the CSV', async () => {
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/import.csv' });
+      mockGetById.mockResolvedValue({ id: uuidV4() });
+      mockCollectTranslations.mockReturnValue([{ type: 'metadata', key: 'title', english: 'a', cymraeg: 'b' }]);
+      // same row count but a different key
+      mockCreateReadStream.mockImplementation(() => csvStream(['metadata,summary,New EN,Newydd CY']));
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await validateImport(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect((mockNext.mock.calls[0][0] as unknown as Error).message).toBe('errors.translation_file.invalid.keys');
+    });
+  });
+
+  describe('applyImport', () => {
+    it('updates translations, rebuilds the cube and returns the dataset DTO', async () => {
+      const dataset = { id: uuidV4(), draftRevisionId: uuidV4() };
+      const req = createMockRequest();
+      ((req as any).fileService.loadStream as jest.Mock).mockResolvedValue(
+        csvStream(['metadata,title,New EN,Newydd CY'])
+      );
+      ((req as any).datasetService.updateTranslations as jest.Mock).mockResolvedValue(dataset);
+      mockCreateAllCubeFiles.mockResolvedValue(undefined);
+      mockFromDataset.mockReturnValue({ id: dataset.id });
+
+      const res = createMockResponse();
+      await applyImport(req, res, mockNext);
+
+      expect((req as any).datasetService.updateTranslations).toHaveBeenCalledWith(
+        res.locals.datasetId,
+        expect.arrayContaining([expect.objectContaining({ type: 'metadata', key: 'title' })])
+      );
+      expect((req as any).fileService.delete).toHaveBeenCalledWith('translation-import.csv', dataset.id);
+      expect(mockEventSave).toHaveBeenCalledWith(expect.objectContaining({ action: 'import', entity: 'translations' }));
+      expect(mockCreateAllCubeFiles).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ id: dataset.id });
+    });
+
+    it('passes a cube-validation error to next when the rebuild fails', async () => {
+      const dataset = { id: uuidV4(), draftRevisionId: uuidV4() };
+      const req = createMockRequest();
+      ((req as any).fileService.loadStream as jest.Mock).mockResolvedValue(
+        csvStream(['metadata,title,New EN,Newydd CY'])
+      );
+      ((req as any).datasetService.updateTranslations as jest.Mock).mockResolvedValue(dataset);
+      mockCreateAllCubeFiles.mockRejectedValue(new Error('cube broke'));
+
+      const res = createMockResponse();
+      await applyImport(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('passes an UnknownException to next when loading the stored import fails', async () => {
+      const req = createMockRequest();
+      ((req as any).fileService.loadStream as jest.Mock).mockRejectedValue(new Error('not found'));
+
+      const res = createMockResponse();
+      await applyImport(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the four under-covered controllers flagged in #686, bringing each well above the 70% statement-coverage target, and fixes two bugs the tests surfaced.

| Controller | Before | After |
|---|---:|---:|
| `src/controllers/admin.ts` | 23.1% | **97.5%** |
| `src/controllers/build-log.ts` | 34.2% | **100%** |
| `src/controllers/measure.ts` | 19.9% | **92.4%** |
| `src/controllers/translation.ts` | 21.8% | **92.1%** |

Both happy and unhappy paths are exercised, including the authorization / validation guards (uuid validation, status validation, `by` validation, unique-constraint handling, av-scan failures, missing-measure / missing-revision guards).

## Bugs found and fixed

Writing the tests surfaced two real defects, each fixed here with a one-line `return`. The tests that caught them now pass and act as regression guards.

**Bug 1 — `admin.ts` `loadUserGroup` and `loadUser` called `next()` twice on the not-found path**

```ts
} catch (_err) {
  next(new NotFoundException('errors.no_user_group'));
  return; // <-- added
}
next(); // only runs on the success path now
```

Without the `return` the catch fell through to the unconditional `next()` at the end of the function, invoking `next` twice (once with the error, once without) and letting the request continue to the route handler with nothing loaded in `res.locals` — the same "responds twice" class of bug fixed in `95adb9db`. Now matches the canonical `datasetAuth` middleware (`src/middleware/dataset-auth.ts`).

**Bug 2 — `measure.ts` `updateMeasureMetadata` fell through its missing-measure guard**

```ts
const measure = dataset.measure;
if (!measure) {
  next(new NotFoundException('errors.measure_invalid'));
  return; // <-- added
}
... measure.metadata.find(...) // previously a TypeError on the null measure
```

Without the `return`, execution dereferenced the null `measure` and threw a `TypeError` instead of returning a clean 404. Now matches `getPreviewOfMeasure` / `getMeasureInfo`.

Regression tests:
- `admin.loadUserGroup › calls next exactly once with NotFound when the group cannot be loaded`
- `admin.loadUser › calls next exactly once with NotFound when the user cannot be loaded`
- `measure.updateMeasureMetadata › forwards NotFound and does not throw when the dataset has no measure`

## Scope

This PR covers the four **controllers** from #686. The three services (`dataset`, `revision`, `task`) are handled separately in #692. The `jest.config.ts` coverage thresholds are left unchanged here; raising them is best done once both PRs land.

## Verification

- Per-controller coverage measured via `jest --coverage` (figures above).
- Full suite: **1546 passing, 0 failing**.
- `eslint` and `tsc --noEmit` clean.

Part of #686.
