### PR TITLE
SW-1254: log image SHA on deploy for traceability

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,6 +98,8 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ HEALTHCHECK --interval=60s --timeout=3s --start-period=30s --retries=3 \
 ENV NODE_ENV=production
 EXPOSE 3000
 
+# Bake the git SHA into the image so the running app can report which commit it was built from.
+# Passed at build time by CI (build-args: GIT_SHA=${{ github.sha }}); defaults to "unknown" for local builds.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
 # set the user to non-root (node)
 USER node
 

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -22,6 +22,9 @@ export interface EntraIdConfig {
 
 export interface AppConfig {
   env: AppEnv;
+  build: {
+    gitSha: string;
+  };
   frontend: {
     port: number;
     url: string;

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -12,6 +12,9 @@ const DEFAULT_TIMEOUT_MS = 2500;
 export const getDefaultConfig = (): AppConfig => {
   return {
     env: AppEnv.Default, // MUST be overridden by other configs
+    build: {
+      gitSha: process.env.GIT_SHA || 'unknown'
+    },
     frontend: {
       port: parseInt(process.env.FRONTEND_PORT || '3000', 10),
       url: process.env.FRONTEND_URL!

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -92,7 +92,7 @@ const checkConnections = async (req: Request, res: Response): Promise<void> => {
 };
 
 healthcheck.get('/', (_req: Request, res: Response) => {
-  res.json({ message: 'success' }); // server is up
+  res.json({ message: 'success', gitSha: config.build.gitSha }); // server is up
 });
 
 healthcheck.get('/ready', checkConnections); // server is up and has active connections to dependencies

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,10 @@ Promise.resolve()
   })
   .then(() => {
     app.listen(PORT, async () => {
-      logger.info(`Server is running on port ${PORT}`);
+      logger.info(
+        { event: 'app_boot', gitSha: config.build.gitSha, appEnv: config.env, port: PORT },
+        `Server is running on port ${PORT}`
+      );
     });
   })
   .catch(async (err) => {

--- a/test/integration/routes/healthcheck.test.ts
+++ b/test/integration/routes/healthcheck.test.ts
@@ -31,7 +31,7 @@ describe('Healthcheck', () => {
     test('/healthcheck/ returns success', async () => {
       const res = await request(app).get('/healthcheck/');
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ message: 'success' });
+      expect(res.body).toEqual({ message: 'success', gitSha: 'unknown' });
     });
   });
 


### PR DESCRIPTION
## SW-1254 — Deploy → SHA → PR traceability (backend)

Part of [SW-1254](https://marvell-consulting.atlassian.net/browse/SW-1254). After the 2026-04-23 incident, identifying which code was running in production at a given moment took hours of cross-referencing. This change makes the backend self-report the commit it was built from.

### What changed
- **Bake the git SHA into the image.** `Dockerfile` accepts `ARG GIT_SHA` and exposes it as `ENV GIT_SHA`; the Docker build workflow passes `build-args: GIT_SHA=${{ github.sha }}`. Local builds default to `unknown`.
- **Expose it at runtime.** New `build.gitSha` config field (interface + `default.ts`), read from `process.env.GIT_SHA`.
- **Structured boot log.** The startup line is now `logger.info({ event: 'app_boot', gitSha, appEnv, port }, …)`. Container stdout already flows to the `swprod-log-analytics` workspace, so this is queryable with no new infra — filter `ContainerAppConsoleLogs_CL` on `app_boot` to see what SHA was running at any time.
- **Healthcheck.** `/healthcheck/` now returns `gitSha` alongside `message`, so "what's running right now" needs no log query. Updated the one integration test that pinned the exact response body.

### Companion PRs
- `statswales-frontend` — same boot-log pattern across publisher & consumer.
- `statswales-terraform` — SHA in the Azure DevOps run name + runbook lookup steps.

### Verification
`npm run check` passes (lint, build, 1714 tests). Local bake check: `docker build --build-arg GIT_SHA=test123 -t sw-be:t .` then hit `/healthcheck/` → `{"message":"success","gitSha":"test123"}`. End-to-end (ADO run name + KQL lookup) confirms once a build reaches prod.


[SW-1254]: https://marvellconsulting.atlassian.net/browse/SW-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ