### PR TITLE
SW-1290 Fix dimension validation and column type mismatch on data table update

### DIFF
--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1023,7 +1023,8 @@ export function dataTableActions(
         dataTableCol?.columnName
       )
     );
-    if (dataTableCol?.columnDatatype !== factTableCol.columnDatatype) {
+    const normalizedDataType = dataTableCol ? normalizeSqlDatatype(dataTableCol.columnDatatype) : undefined;
+    if (normalizedDataType && normalizedDataType !== normalizeSqlDatatype(factTableCol.columnDatatype)) {
       buildStatements.push(
         pgformat('ALTER TABLE %I.%I ALTER COLUMN %I TYPE TEXT;', buildId, FACT_TABLE_NAME, factTableCol.columnName)
       );

--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1023,6 +1023,11 @@ export function dataTableActions(
         dataTableCol?.columnName
       )
     );
+    if (dataTableCol?.columnDatatype !== factTableCol.columnDatatype) {
+      buildStatements.push(
+        pgformat('ALTER TABLE %I.%I ALTER COLUMN %I TYPE TEXT;', buildId, FACT_TABLE_NAME, factTableCol.columnName)
+      );
+    }
   }
   logger.debug(`Performing action ${dataTable.action} on fact table for data table ${dataTable.id}`);
   switch (dataTable.action) {

--- a/src/services/revision.ts
+++ b/src/services/revision.ts
@@ -44,6 +44,13 @@ import { BuildLog } from '../entities/dataset/build-log';
 import { User } from '../entities/user/user';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 
+const dimensionTypesNotToValidate = [
+  DimensionType.Text,
+  DimensionType.Numeric,
+  DimensionType.Symbol,
+  DimensionType.NoteCodes
+];
+
 export async function attachUpdateDataTableToRevision(
   datasetId: string,
   revision: Revision,
@@ -176,6 +183,11 @@ export async function attachUpdateDataTableToRevision(
     if (!factTableColumn) {
       logger.error(`Could not find fact table column for dimension ${dimension.id}`);
       throw new BadRequestException('errors.data_table_validation_error');
+    }
+
+    if (dimensionTypesNotToValidate.includes(dimension.type)) {
+      logger.debug(`Dimension ${dimension.id} is of type ${dimension.type}... Skipping validation`);
+      continue;
     }
 
     try {

--- a/test/unit/services/cube-builder.test.ts
+++ b/test/unit/services/cube-builder.test.ts
@@ -770,6 +770,48 @@ describe('dataTableActions', () => {
       expect(stmts).toHaveLength(0);
     });
   });
+
+  describe('column datatype mismatch', () => {
+    it('emits ALTER COLUMN TYPE TEXT when fact column datatype differs from data table column', () => {
+      const intYearCol = makeCol('year', 0, FactTableColumnType.Dimension, 'INTEGER');
+      const dataTable = makeDataTable(DataTableAction.ReplaceAll, matchingDescriptions);
+      const stmts = dataTableActions(buildId, dataTable, factTableDef, notesCol, dataValuesCol, [intYearCol]);
+      const alterStmt = stmts.find((s) => s.includes('ALTER COLUMN') && s.includes('TYPE TEXT'));
+      expect(alterStmt).toBeDefined();
+      expect(alterStmt).toContain('b1.fact_table');
+      expect(alterStmt).toContain('year');
+    });
+
+    it('emits no ALTER COLUMN statement when datatypes match', () => {
+      const dataTable = makeDataTable(DataTableAction.ReplaceAll, matchingDescriptions);
+      const stmts = dataTableActions(buildId, dataTable, factTableDef, notesCol, dataValuesCol, factIdentifiers);
+      expect(stmts.filter((s) => s.includes('ALTER COLUMN'))).toHaveLength(0);
+    });
+
+    it('places ALTER COLUMN before action statements', () => {
+      const intYearCol = makeCol('year', 0, FactTableColumnType.Dimension, 'INTEGER');
+      const dataTable = makeDataTable(DataTableAction.ReplaceAll, matchingDescriptions);
+      const stmts = dataTableActions(buildId, dataTable, factTableDef, notesCol, dataValuesCol, [intYearCol]);
+      const alterIdx = stmts.findIndex((s) => s.includes('ALTER COLUMN'));
+      const deleteIdx = stmts.findIndex((s) => s.includes('DELETE FROM'));
+      expect(alterIdx).toBeLessThan(deleteIdx);
+    });
+
+    it('emits one ALTER COLUMN per mismatched fact identifier column', () => {
+      const intYearCol = makeCol('year', 0, FactTableColumnType.Dimension, 'INTEGER');
+      const bigintRegionCol = makeCol('region', 1, FactTableColumnType.Dimension, 'BIGINT');
+      const descriptions = [
+        makeDataTableDescription('year', 'year', 0),
+        makeDataTableDescription('region', 'region', 1)
+      ];
+      const dataTable = makeDataTable(DataTableAction.ReplaceAll, descriptions);
+      const stmts = dataTableActions(buildId, dataTable, factTableDef, notesCol, dataValuesCol, [
+        intYearCol,
+        bigintRegionCol
+      ]);
+      expect(stmts.filter((s) => s.includes('ALTER COLUMN') && s.includes('TYPE TEXT'))).toHaveLength(2);
+    });
+  });
 });
 
 // ===========================================================================

--- a/test/unit/services/cube-builder.test.ts
+++ b/test/unit/services/cube-builder.test.ts
@@ -792,9 +792,8 @@ describe('dataTableActions', () => {
       const intYearCol = makeCol('year', 0, FactTableColumnType.Dimension, 'INTEGER');
       const dataTable = makeDataTable(DataTableAction.ReplaceAll, matchingDescriptions);
       const stmts = dataTableActions(buildId, dataTable, factTableDef, notesCol, dataValuesCol, [intYearCol]);
-      const alterIdx = stmts.findIndex((s) => s.includes('ALTER COLUMN'));
-      const deleteIdx = stmts.findIndex((s) => s.includes('DELETE FROM'));
-      expect(alterIdx).toBeLessThan(deleteIdx);
+      expect(stmts[0]).toContain('ALTER COLUMN');
+      expect(stmts.some((s) => s.includes('DELETE FROM'))).toBe(true);
     });
 
     it('emits one ALTER COLUMN per mismatched fact identifier column', () => {

--- a/test/unit/services/revision.test.ts
+++ b/test/unit/services/revision.test.ts
@@ -313,6 +313,40 @@ describe('revision service', () => {
         attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add)
       ).rejects.toThrow('errors.data_table_validation_error');
     });
+
+    const SKIP_TYPES = [DimensionType.Text, DimensionType.Numeric, DimensionType.Symbol, DimensionType.NoteCodes];
+
+    for (const dimType of SKIP_TYPES) {
+      it(`skips lookup validation for ${dimType} dimensions`, async () => {
+        mockDatasetGetById.mockResolvedValue(
+          makeDataset({
+            dimensions: [{ id: 'dim-1', type: dimType, factTableColumn: 'col1', save: jest.fn() }]
+          })
+        );
+        const revision = makeRevision();
+        const dataTable = makeDataTable();
+
+        await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+
+        // validateLookupTableReferenceValues is called once for the measure only, not for the skipped dimension
+        expect(mockValidateReference).toHaveBeenCalledTimes(1);
+        expect(mockCreateLookupTableDimension).not.toHaveBeenCalled();
+      });
+    }
+
+    it('does not add skipped-type dimensions to revision tasks', async () => {
+      mockDatasetGetById.mockResolvedValue(
+        makeDataset({
+          dimensions: [{ id: 'dim-1', type: DimensionType.Text, factTableColumn: 'col1', save: jest.fn() }]
+        })
+      );
+      const revision = makeRevision();
+      const dataTable = makeDataTable();
+
+      await attachUpdateDataTableToRevision('ds-1', revision as never, dataTable as never, DataTableAction.Add);
+
+      expect((revision.tasks as { dimensions: unknown[] }).dimensions).toHaveLength(0);
+    });
   });
 
   describe('createDateTableInValidationCube', () => {


### PR DESCRIPTION
Skip lookup table validation for dimension types that don't use lookup tables
(Text, Numeric, Symbol, NoteCodes), preventing false validation errors when
updating a dataset that previously used note codes or custom lookups.

Also alter the fact table column type to TEXT when a data table column's
datatype differs from the existing fact table column, allowing type changes
(e.g. removing a typed lookup and replacing with a plain text column) without
a hard failure.
