### PR TITLE
SW-1294 Wrong cube being picked up by preview

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -313,9 +313,7 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
 
   try {
     const endRevision = await RevisionRepository.findOneBy({ id: dataset.endRevisionId });
-    const previewRevisionId = dataset.draftRevisionId
-      ? dataset.draftRevisionId
-      : resolvePreviewRevisionId(endRevision, dataset);
+    const previewRevisionId = resolvePreviewRevisionId(endRevision, dataset);
 
     if (!previewRevisionId) return next(new NotFoundException('errors.no_data_table'));
 

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -313,7 +313,9 @@ export const datasetPreview = async (req: Request, res: Response, next: NextFunc
 
   try {
     const endRevision = await RevisionRepository.findOneBy({ id: dataset.endRevisionId });
-    const previewRevisionId = resolvePreviewRevisionId(endRevision, dataset);
+    const previewRevisionId = dataset.draftRevisionId
+      ? dataset.draftRevisionId
+      : resolvePreviewRevisionId(endRevision, dataset);
 
     if (!previewRevisionId) return next(new NotFoundException('errors.no_data_table'));
 

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -15,9 +15,11 @@ export interface CoverageRange {
 // has its own data. Use this helper to decide which revision id to query; it returns undefined only when neither side
 // has a cube.
 export const resolvePreviewRevisionId = (
-  revision: Pick<Revision, 'id' | 'dataTableId'> | null | undefined,
+  revision: Pick<Revision, 'id' | 'revisionIndex' | 'dataTableId'> | null | undefined,
   dataset: Pick<Dataset, 'publishedRevisionId'> | null | undefined
 ): string | undefined => {
+  // This is an update revision so there will always be a complete cube here
+  if (revision?.revisionIndex === 0) return revision.id;
   if (revision?.dataTableId) return revision.id;
   return dataset?.publishedRevisionId;
 };

--- a/src/utils/revision.ts
+++ b/src/utils/revision.ts
@@ -10,10 +10,12 @@ export interface CoverageRange {
   endDate: Date | null;
 }
 
-// Fresh draft update revisions (cloned from the published revision via deepCloneRevision) have no data table id
-// yet, so anything that queries the per-revision schema must use the previously-published revision id until the draft
-// has its own data. Use this helper to decide which revision id to query; it returns undefined only when neither side
-// has a cube.
+// Draft update revisions (cloned from the published revision via deepCloneRevision) have revisionIndex 0 and have
+// no data table id of their own, but deepCloneRevision triggers a build that copies the cube from the previous
+// revision straight away, so their own revision id always has a queryable cube. Other draft revisions (e.g. the
+// first revision of a brand new dataset) have no cube until they get a data table id, so anything that queries the
+// per-revision schema must fall back to the previously-published revision id until then. Use this helper to decide
+// which revision id to query; it returns undefined only when neither side has a cube.
 export const resolvePreviewRevisionId = (
   revision: Pick<Revision, 'id' | 'revisionIndex' | 'dataTableId'> | null | undefined,
   dataset: Pick<Dataset, 'publishedRevisionId'> | null | undefined

--- a/test/unit/utils/revision.test.ts
+++ b/test/unit/utils/revision.test.ts
@@ -1,8 +1,14 @@
 import { ConsumerRevisionDTO } from '../../../src/dtos/consumer-revision-dto';
+import { Dataset } from '../../../src/entities/dataset/dataset';
 import { Dimension } from '../../../src/entities/dataset/dimension';
 import { Revision } from '../../../src/entities/dataset/revision';
 import { DimensionType } from '../../../src/enums/dimension-type';
-import { isPublished, revisionStartAndEndDateFinder, widenCoverageRange } from '../../../src/utils/revision';
+import {
+  isPublished,
+  resolvePreviewRevisionId,
+  revisionStartAndEndDateFinder,
+  widenCoverageRange
+} from '../../../src/utils/revision';
 
 describe('revision utils', () => {
   beforeEach(() => {
@@ -153,6 +159,57 @@ describe('revision utils', () => {
       // Range must stay 2020-2023, not narrow to 2021-2022
       expect(result.startDate).toEqual(new Date('2020-01-01'));
       expect(result.endDate).toEqual(new Date('2023-12-31'));
+    });
+  });
+
+  describe('resolvePreviewRevisionId', () => {
+    it('should return the revision id when revisionIndex is 0, even without a dataTableId', () => {
+      const revision = { id: 'draft-update-rev', revisionIndex: 0, dataTableId: null } as unknown as Revision;
+      const dataset = { publishedRevisionId: 'published-rev' } as unknown as Dataset;
+
+      expect(resolvePreviewRevisionId(revision, dataset)).toBe('draft-update-rev');
+    });
+
+    it('should prefer the revisionIndex === 0 branch over the published fallback', () => {
+      const revision = { id: 'draft-update-rev', revisionIndex: 0, dataTableId: undefined } as unknown as Revision;
+
+      expect(resolvePreviewRevisionId(revision, undefined)).toBe('draft-update-rev');
+    });
+
+    it('should return the revision id when it has a dataTableId and is not an update revision', () => {
+      const revision = { id: 'rev-with-cube', revisionIndex: 1, dataTableId: 'table-1' } as unknown as Revision;
+      const dataset = { publishedRevisionId: 'published-rev' } as unknown as Dataset;
+
+      expect(resolvePreviewRevisionId(revision, dataset)).toBe('rev-with-cube');
+    });
+
+    it('should fall back to the dataset publishedRevisionId when revision has no cube and is not index 0', () => {
+      const revision = { id: 'fresh-draft', revisionIndex: 2, dataTableId: null } as unknown as Revision;
+      const dataset = { publishedRevisionId: 'published-rev' } as unknown as Dataset;
+
+      expect(resolvePreviewRevisionId(revision, dataset)).toBe('published-rev');
+    });
+
+    it('should fall back to the dataset publishedRevisionId when revision is null', () => {
+      const dataset = { publishedRevisionId: 'published-rev' } as unknown as Dataset;
+
+      expect(resolvePreviewRevisionId(null, dataset)).toBe('published-rev');
+    });
+
+    it('should fall back to the dataset publishedRevisionId when revision is undefined', () => {
+      const dataset = { publishedRevisionId: 'published-rev' } as unknown as Dataset;
+
+      expect(resolvePreviewRevisionId(undefined, dataset)).toBe('published-rev');
+    });
+
+    it('should return undefined when neither revision nor dataset has a usable id', () => {
+      const revision = { id: 'fresh-draft', revisionIndex: 2, dataTableId: null } as unknown as Revision;
+
+      expect(resolvePreviewRevisionId(revision, undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when both revision and dataset are missing', () => {
+      expect(resolvePreviewRevisionId(null, null)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
The wrong cube is being picked up whenever a publisher requests a preview.  This makes sure the preview cube is draftRevisionId when this is present.