### PR TITLE
SW-1299 Cast reference joins to VARCHAR to fix cube build type mismatch (42883)

### DIFF
--- a/src/services/cube-builder.ts
+++ b/src/services/cube-builder.ts
@@ -1408,7 +1408,7 @@ export function postgresMeasureFormats(): Map<string, MeasureFormat> {
   return measureFormats;
 }
 
-function setupMeasureAndDataValuesWithLookup(
+export function setupMeasureAndDataValuesWithLookup(
   buildId: string,
   measureTable: MeasureRow[],
   dataValuesColumn: FactTableColumn,
@@ -1515,7 +1515,10 @@ function setupMeasureAndDataValuesWithLookup(
   });
   joinStatements.push(
     pgformat(
-      'LEFT JOIN %I.measure on measure.reference=%I.%I AND measure.language=#LANG#',
+      // Cast both sides to VARCHAR: a data-table update can ALTER the fact_table
+      // column to TEXT (dataTableActions) while measure.reference keeps its original
+      // (e.g. numeric) type, which would otherwise fail with Postgres error 42883.
+      'LEFT JOIN %I.measure on CAST(measure.reference AS VARCHAR)=CAST(%I.%I AS VARCHAR) AND measure.language=#LANG#',
       buildId,
       FACT_TABLE_NAME,
       measureColumn.columnName
@@ -1686,7 +1689,10 @@ export function setupLookupTableDimension(
   });
   joinStatements.push(
     pgformat(
-      `LEFT JOIN %I.%I on %I.%I=%I.%I AND %I.language=#LANG#`,
+      // Cast both sides to VARCHAR for the same reason as the measure join above:
+      // a data-table update can leave the fact_table column type diverged from the
+      // lookup reference column type, which would fail with Postgres error 42883.
+      `LEFT JOIN %I.%I on CAST(%I.%I AS VARCHAR)=CAST(%I.%I AS VARCHAR) AND %I.language=#LANG#`,
       buildId,
       dimTable,
       dimTable,

--- a/test/unit/services/cube-builder.test.ts
+++ b/test/unit/services/cube-builder.test.ts
@@ -54,6 +54,7 @@ import {
   createLookupTableDimension,
   setupCubeBuilder,
   setupLookupTableDimension,
+  setupMeasureAndDataValuesWithLookup,
   updateFilterTableCounts,
   alterFilterTableBlock,
   FACT_TABLE_NAME,
@@ -898,6 +899,84 @@ describe('setupLookupTableDimension — filter table sort direction', () => {
       for (const stmt of inserts) {
         expect(stmt).toContain('CAST (sort_order AS BIGINT)');
       }
+    });
+  });
+});
+
+// ===========================================================================
+// Regression: reference joins must be type-safe.
+//
+// When a data-table update changes a fact-table column's inferred datatype,
+// dataTableActions ALTERs that fact_table column to TEXT (see PR #698 / SW-1290),
+// but the measure/lookup reference column keeps its original (e.g. numeric) type.
+// A raw `measure.reference = fact_table."MeasureCode"` join then has no matching
+// operator and Postgres aborts CREATE VIEW core_view with error 42883
+// ("operator does not exist / no operator matches"), which fails the cube build on
+// approval. Casting both sides of the join to VARCHAR makes it robust to the
+// mismatch (references are semantically codes, so text comparison is correct).
+describe('reference joins are type-safe (cast to VARCHAR)', () => {
+  describe('measure join', () => {
+    function measureJoinFor(measureColDatatype: string) {
+      const measureColumn = makeCol('MeasureCode', 0, FactTableColumnType.Measure, measureColDatatype);
+      const dataValuesColumn = makeCol('Data', 1, FactTableColumnType.DataValues, 'DOUBLE PRECISION');
+      const measureTable = [
+        makeMeasureRow({ reference: '1', language: 'en-gb', description: 'Count', format: DisplayType.Integer }),
+        makeMeasureRow({ reference: '1', language: 'cy-gb', description: 'Cyfrif', format: DisplayType.Integer })
+      ];
+      const args = makeSetupLookupArgs();
+      setupMeasureAndDataValuesWithLookup(
+        'b1',
+        measureTable,
+        dataValuesColumn,
+        measureColumn,
+        undefined,
+        args.coreCubeViewSelectBuilder,
+        args.viewConfig,
+        args.columnNames,
+        args.joinStatements,
+        args.orderByStatements
+      );
+      return args.joinStatements.find((s) => s.includes('.measure on'));
+    }
+
+    it('casts both sides of the measure join to VARCHAR (numeric measure code)', () => {
+      const join = measureJoinFor('INTEGER');
+      expect(join).toBeDefined();
+      expect(join).toContain('CAST(measure.reference AS VARCHAR)');
+      expect(join).toContain(`CAST(${FACT_TABLE_NAME}."MeasureCode" AS VARCHAR)`);
+    });
+
+    it('does not emit a raw uncast measure.reference comparison', () => {
+      const join = measureJoinFor('INTEGER');
+      expect(join).not.toContain(`measure.reference=${FACT_TABLE_NAME}`);
+    });
+  });
+
+  describe('lookup dimension join', () => {
+    function dimensionJoin(factColDatatype: string) {
+      const factTableCol = makeCol('OrgCode', 0, FactTableColumnType.Dimension, factColDatatype);
+      const dataset = makeDataset({ factTable: [factTableCol] });
+      const dimension = makeDimension(DimensionType.LookupTable, 'OrgCode');
+      const args = makeSetupLookupArgs();
+      setupLookupTableDimension(
+        'b1',
+        dataset,
+        dimension,
+        args.coreCubeViewSelectBuilder,
+        args.columnNames,
+        args.indexColumns,
+        args.joinStatements,
+        args.orderByStatements,
+        args.viewConfig
+      );
+      return args.joinStatements.find((s) => s.includes('LEFT JOIN'));
+    }
+
+    it('casts both sides of the dimension lookup join to VARCHAR', () => {
+      const join = dimensionJoin('INTEGER');
+      expect(join).toBeDefined();
+      expect(join).toContain('AS VARCHAR)=CAST(');
+      expect(join).toContain(`CAST(${FACT_TABLE_NAME}."OrgCode" AS VARCHAR)`);
     });
   });
 });


### PR DESCRIPTION
## SW-1299 — Cube build fails on approval with Postgres error 42883

Jira: https://marvellconsulting.atlassian.net/browse/SW-1299

### Symptom
Publishers could not approve several cubes (the NHS "Staff directly employed by the NHS" family). Approval failed while building the cube. The failed builds recorded in `build_log` show Postgres error **42883** (`op_error`, "No operator matches the given name and argument types") while creating `core_view_en`, at the join `measure.reference = fact_table."MeasureCode"`.

### Root cause
The cubes had a **quarterly data update** (new quarter's data). That changed the inferred datatype of the `MeasureCode` fact-table column. `dataTableActions` (added in SW-1290 / #698) then runs `ALTER TABLE fact_table ALTER COLUMN "MeasureCode" TYPE TEXT` whenever the incoming data-table column datatype differs from the stored one — but it does **not** touch the `measure` table, whose `reference` column is still built from the stored (numeric) `columnDatatype`.

The core-view join then compares `measure.reference` (numeric) with `fact_table."MeasureCode"` (text). Postgres has no `numeric = text` operator → **42883** → `CREATE VIEW core_view` aborts → the cube build fails → approval fails. Because these cubes are updated quarterly, this only surfaced on the first re-approval after #698 shipped (24 June).

### Fix
Cast **both sides** of the reference joins to `VARCHAR` in the core-view build:
- measure join (`setupMeasureAndDataValuesWithLookup`)
- lookup/date dimension join (`setupLookupTableDimension`)

References are semantically codes, so text comparison is correct, and this mirrors the pattern `dataTableActions` already uses for its own join. This covers every fact-identifier column type that `dataTableActions` can alter to TEXT — Measure, Dimension and Time. The `all_notes` join uses the NoteCodes column, which is not a fact identifier, so it is unaffected and left unchanged.

### Testing
- Added 3 unit tests that assert both join sites cast to `VARCHAR`. They fail on the current code, reproducing the exact production SQL (`measure.reference=fact_table."MeasureCode"`), and pass with the fix.
- Full `cube-builder` unit suite passes (103 tests). Lint clean.

### Effect
The affected NHS cubes will build and approve on their next attempt once this deploys.

### Not included (separate follow-ups)
- `approvePublication` has no try/catch, so build failures reach publishers as a bare 500 rather than a clear "cube build failed" message.
- Failures during `bootstrapCubeBuildProcess` write no `build_log` row (it runs before the build row is created), so those errors only appear in application logs.
