### PR TITLE
Improve approval cube-build error handling and observability

### DIFF
--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -30,7 +30,7 @@
   "errors": {
     "unknown_error": "Mae gwall anhysbys wedi digwydd",
     "cube_builder": {
-      "cube_build_failed": "Ni ellid adeiladu'r ciwb. Rhowch gynnig arall arni, a chysylltwch â'r gwasanaeth cymorth os yw'r broblem yn parhau."
+      "cube_build_failed": "Ni allai'r ciwb gael ei adeiladu. Ceisiwch eto, a chysylltwch â chymorth os yw'r broblem yn parhau."
     },
     "missing": "Enw ffeil ar Goll",
     "problem": "Mae problem wedi codi",

--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -29,6 +29,9 @@
   },
   "errors": {
     "unknown_error": "Mae gwall anhysbys wedi digwydd",
+    "cube_builder": {
+      "cube_build_failed": "Ni ellid adeiladu'r ciwb. Rhowch gynnig arall arni, a chysylltwch â'r gwasanaeth cymorth os yw'r broblem yn parhau."
+    },
     "missing": "Enw ffeil ar Goll",
     "problem": "Mae problem wedi codi",
     "name_missing": "Mae Enw’r Set Ddata ar Goll",

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -31,6 +31,9 @@
   },
   "errors": {
     "unknown_error": "An unknown error occurred",
+    "cube_builder": {
+      "cube_build_failed": "The cube could not be built. Please try again, and contact support if the problem continues."
+    },
     "missing": "Filename Missing",
     "problem": "There is a problem",
     "name_missing": "Dataset Name Missing",

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -26,6 +26,10 @@ import { TasklistStateDTO } from '../dtos/tasklist-state-dto';
 import { EventLog } from '../entities/event-log';
 
 import { createAllCubeFiles } from './cube-builder';
+import { BuildLog } from '../entities/dataset/build-log';
+import { CubeBuildStatus } from '../enums/cube-build-status';
+import { CubeBuildType } from '../enums/cube-build-type';
+import { UnknownException } from '../exceptions/unknown.exception';
 import { validateAndUpload } from './incoming-file-processor';
 import { removeAllDimensions, removeMeasure } from './dimension-processor';
 import { UserGroupRepository } from '../repositories/user-group';
@@ -306,8 +310,25 @@ export class DatasetService {
 
   async approvePublication(datasetId: string, revisionId: string, user: User): Promise<Dataset> {
     const start = performance.now();
-    await bootstrapCubeBuildProcess(datasetId, revisionId);
-    await createAllCubeFiles(datasetId, revisionId, user.id, undefined, undefined, true);
+    // Open the build log before bootstrap so a failure in either the bootstrap or
+    // the build proper is recorded in build_log (bootstrap previously ran before any
+    // build_log row existed, so its failures were only visible in application logs).
+    const build = await BuildLog.startBuild({ id: revisionId }, CubeBuildType.FullCube, user.id);
+    try {
+      await bootstrapCubeBuildProcess(datasetId, revisionId);
+      await createAllCubeFiles(datasetId, revisionId, user.id, CubeBuildType.FullCube, build, true);
+    } catch (err) {
+      // createAllCubeFiles records and saves its own failure; only mark it here when the
+      // failure happened earlier (e.g. during bootstrap), so we don't clobber that detail.
+      if (build.status !== CubeBuildStatus.Failed && build.status !== CubeBuildStatus.Completed) {
+        const message = err instanceof Error ? err.message : String(err);
+        build.completeBuild(CubeBuildStatus.Failed, undefined, JSON.stringify({ message }));
+        await build.save();
+      }
+      logger.error(err, 'approvePublication: cube build failed during approval');
+      // Surface a clean, translated message instead of leaking the raw Postgres error.
+      throw new UnknownException('errors.cube_builder.cube_build_failed');
+    }
     const scheduledRevision = await RevisionRepository.approvePublication(revisionId, `${revisionId}.duckdb`, user);
     const approvedDataset = await DatasetRepository.publish(scheduledRevision);
     const time = Math.round(performance.now() - start);

--- a/test/unit/services/dataset.test.ts
+++ b/test/unit/services/dataset.test.ts
@@ -2,6 +2,7 @@ import { Locale } from '../../../src/enums/locale';
 import { TaskAction } from '../../../src/enums/task-action';
 import { TaskStatus } from '../../../src/enums/task-status';
 import { PublishingStatus } from '../../../src/enums/publishing-status';
+import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
 import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
 import { uuidV4 } from '../../../src/utils/uuid';
 import { User } from '../../../src/entities/user/user';
@@ -138,6 +139,13 @@ jest.mock('../../../src/services/cube-builder', () => ({
   createAllCubeFiles: (...a: unknown[]) => mockCreateAllCubeFiles(...a)
 }));
 
+const mockBuildLogStartBuild = jest.fn();
+jest.mock('../../../src/entities/dataset/build-log', () => ({
+  BuildLog: {
+    startBuild: (...a: unknown[]) => mockBuildLogStartBuild(...a)
+  }
+}));
+
 const mockValidateAndUpload = jest.fn();
 jest.mock('../../../src/services/incoming-file-processor', () => ({
   validateAndUpload: (...a: unknown[]) => mockValidateAndUpload(...a)
@@ -197,6 +205,18 @@ function withSave<T extends object>(obj: T): T & { save: jest.Mock } {
   const o = obj as T & { save: jest.Mock };
   o.save = jest.fn().mockResolvedValue(o);
   return o;
+}
+
+function makeBuildLog() {
+  const build = {
+    id: 'build-1',
+    status: CubeBuildStatus.Queued as CubeBuildStatus,
+    completeBuild: jest.fn(function (this: { status: CubeBuildStatus }, status: CubeBuildStatus) {
+      this.status = status;
+    }),
+    save: jest.fn().mockResolvedValue(undefined)
+  };
+  return build;
 }
 
 describe('DatasetService', () => {
@@ -433,6 +453,13 @@ describe('DatasetService', () => {
   });
 
   describe('approvePublication', () => {
+    let build: ReturnType<typeof makeBuildLog>;
+
+    beforeEach(() => {
+      build = makeBuildLog();
+      mockBuildLogStartBuild.mockResolvedValue(build);
+    });
+
     it('bootstraps, builds, approves and publishes', async () => {
       mockRevApprovePublication.mockResolvedValue({ id: 'rev-1' });
       mockDatasetPublish.mockResolvedValue({ id: 'ds-1', published: true });
@@ -442,6 +469,34 @@ describe('DatasetService', () => {
       expect(mockBootstrapCubeBuildProcess).toHaveBeenCalledWith('ds-1', 'rev-1');
       expect(mockCreateAllCubeFiles).toHaveBeenCalled();
       expect(result).toEqual({ id: 'ds-1', published: true });
+    });
+
+    it('marks the build failed and throws a generic 500 when the cube build fails, without publishing', async () => {
+      mockCreateAllCubeFiles.mockRejectedValueOnce(new Error('duplicate key value violates unique constraint'));
+
+      await expect(service.approvePublication('ds-1', 'rev-1', user)).rejects.toMatchObject({
+        message: 'errors.cube_builder.cube_build_failed',
+        status: 500
+      });
+
+      expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+      expect(build.save).toHaveBeenCalled();
+      // the raw Postgres error must not leak to the publisher
+      expect(mockRevApprovePublication).not.toHaveBeenCalled();
+      expect(mockDatasetPublish).not.toHaveBeenCalled();
+    });
+
+    it('records a failed build when the bootstrap step fails (before the build proper)', async () => {
+      mockBootstrapCubeBuildProcess.mockRejectedValueOnce(new Error('invalid input syntax for type bigint'));
+
+      await expect(service.approvePublication('ds-1', 'rev-1', user)).rejects.toMatchObject({
+        message: 'errors.cube_builder.cube_build_failed',
+        status: 500
+      });
+
+      expect(mockCreateAllCubeFiles).not.toHaveBeenCalled();
+      expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+      expect(build.save).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Improve approval cube-build error handling and observability

Follow-up to the SW-1299 investigation (#701). Two small, self-contained improvements to `DatasetService.approvePublication` — **error-handling and observability only; no change to how cubes are built.**

### Background
While diagnosing SW-1299 we found two gaps in the approval path:

1. **Bootstrap failures weren't recorded.** `bootstrapCubeBuildProcess` runs *before* `createAllCubeFiles` creates the `build_log` row, so a failure during bootstrap (e.g. rebuilding a lookup table) left **no `build_log` entry** — the error only appeared in application logs, making it hard to diagnose from the database.
2. **Publishers saw a raw 500.** `approvePublication` had no `try/catch`, so a cube-build error propagated to the Express error handler with no `status`, producing a 500 whose body was the **raw Postgres error string**.

### Changes
- Open the `BuildLog` row at the start of `approvePublication` (before bootstrap) and pass it into `createAllCubeFiles` (which already accepts an optional `build`). Wrap both the bootstrap and build steps in `try/catch`; on failure, if the row isn't already terminal, complete it as `Failed`. Net effect: a bootstrap-stage failure is now queryable in `build_log` exactly like a build-stage failure — one row per approval, no duplication.
- In that `catch`, log the real error and rethrow an `UnknownException('errors.cube_builder.cube_build_failed')`, so the publisher gets a clean **translated 500** instead of raw Postgres text. The publish/repository steps are left outside the `try` so their errors are unaffected.
- Add the `errors.cube_builder.cube_build_failed` key to `en.json` and `cy.json`.

### Decisions
- **Generic message, not classified.** A failed build shows a single "the cube could not be built — please try again / contact support" message; diagnosis happens via logs + `build_log`. (Classifying common data problems into specific 400 messages was considered and deferred.)

### ⚠️ Needs review
- The **Welsh** translation string is a first pass and should be checked by a Welsh speaker before release.

### Testing
- Unit tests on `approvePublication` (in `test/unit/services/dataset.test.ts`): happy path still publishes; a build failure and a bootstrap failure each mark the `build_log` row `Failed` and throw the generic translated 500 without publishing. Written test-first (they fail on the current code).
- `dataset` service suite (35 tests) and `task` controller suite (20 tests) pass. Lint clean; changed files typecheck.
