### PR TITLE
SW-1301: Return 404 for unknown actions instead of silently doing nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+## Summary
+
+This is the frontend for a bilingual (English/Welsh) Welsh Government statistics platform.
+
+## Tech Stack
+
+- Node 24
+- TypeScript
+- JSX / TSX
+- GOV.UK Design System
+- Jest (unit tests)
+- PlayWright (e2e tests)
+
+## Available Tools
+
+These tools are installed globally on the system and can be used via CLI commands.
+- GitHub CLI `gh`
+- UUID generation `uuidgen | tr '[:upper:]' '[:lower:]'`
+- TypeScript Language Server (TypeScript LSP)
+- **agent-browser** — browser automation CLI (`agent-browser <command>`); use for visual/e2e testing tasks; prefer over Playwright MCP as it uses ~10x fewer tokens
+- **Atlassian CLI** — if `SW-<number>` is mentioned when discussing work, this is a Jira ticket id; fetch it with `acli jira workitem view SW-<number>`. Check auth with `acli auth status`; if unauthorized run `acli auth login`.
+
+## Code Navigation
+
+Prefer the **TypeScript LSP** (via `list_code_usages`) over `grep` or ad-hoc Python scripts when finding references,
+usages, or definitions. The LSP is precise, understands types and scope, and won't produce false positives from
+comments, strings, or coincidental name matches. Use `grep` only when searching for patterns the LSP can't express
+(e.g. raw string literals, file content searches).
+
+## Architecture
+
+**Two Express 5 servers** from one TypeScript codebase:
+
+- **Consumer** (`src/consumer/`) — public-facing: browse topics, search/view/filter/download published datasets (port 3100)
+- **Publisher** (`src/publisher/`) — authenticated CMS: create/upload/configure/publish/update datasets (port 3000)
+- **Shared** (`src/shared/`) — config, middleware, routes, DTOs, enums, i18n, views, utils
+
+**Views are server-side rendered** using `express-react-views` (.jsx files) with React 16 — no client-side hydration.
+Views use GOV.UK Frontend CSS classes as a base with additional modifications for Gov.Wales styling.
+
+### i18n
+
+Path-based detection (`/:lang` = `en-GB` or `cy-GB`). Translation files: `src/shared/i18n/en.json`, `src/shared/i18n/cy.json`.
+
+### Integration Points
+
+- **StatsWales Backend** — all data via `PublisherApi`/`ConsumerApi`; base URL from config
+- **Azure EntraID** — used for publisher authentication in all envs except CI which uses a form login with pre-defined test users
+
+## Testing Patterns
+
+- **Integration tests** (`tests/`): import the real Express app and drive with `supertest`
+- **Backend mocking**: MSW (`tests/mocks/backend.ts`) intercepts HTTP calls; lifecycle in `beforeAll`/`afterEach`/`afterAll`
+- **API unit tests**: spy on `global.fetch` with `jest.spyOn`
+- **Fixtures**: `tests/mocks/fixtures.ts`
+- **Env vars**: seeded in `tests/.jest/set-env-vars.ts`
+- **E2E**: Playwright in `tests-e2e/`, runs separately
+- **E2E Welsh coverage**: A single "Can switch to Welsh" test per page is sufficient. Don't create additional tests that recheck the same functionality but in Welsh.
+
+## Domain Knowledge
+
+- The first/initial revision of a dataset always has `revision_index = 1`.
+- Subsequent revisions have `revision_index = 0` while in draft state, then take the previous revision index + 1 on approval.
+
+## Creating Pull Requests
+
+Always write the PR body to a temporary file and pass it with `--body-file` — never pass a multiline body directly on the CLI, as the shell will hang in an uncloseable heredoc state:
+
+```bash
+cat > /tmp/pr-body.md << 'EOF'
+... body content ...
+EOF
+gh pr create --title "..." --body-file /tmp/pr-body.md --base main
+```
+
+## Memory
+
+Project-specific memory lives in `.claude/memory/` (gitignored). Start with `MEMORY.md` there for the index, then load topic files as relevant. Always read from and write to those files instead of the default auto memory path.
+
+## Final Steps
+
+Always run `npm run check` as a final step to ensure the code is properly formatted, can build and that the tests pass.
+Fix any issues before continuing.
+
+Never commit or push changes — the user handles all git commits manually.

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -660,7 +660,7 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
   const action = req.params.action as TaskAction;
 
   if (!Object.values(TaskAction).includes(action)) {
-    next();
+    next(new NotFoundException(`Unknown action: ${action}`));
     return;
   }
 
@@ -686,6 +686,9 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
     case TaskAction.Unarchive:
       await taskService.requestUnarchive(datasetId, user, reason);
       break;
+    default:
+      next(new NotFoundException(`Action not supported via this endpoint: ${action}`));
+      return;
   }
 
   res.status(204).end();

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -62,11 +62,15 @@ export const taskDecision = async (req: Request, res: Response, next: NextFuncti
           // task is resolved and closed
           await req.datasetService.approvePublication(dataset.id, dataset.draftRevisionId, user);
           task = await taskService.update(task.id, TaskStatus.Approved, false, user);
+          // close any duplicate sibling publish tasks so the dataset can't be left "pending approval"
+          await taskService.closeOpenPublishTasks(dataset.id, user, task.id);
         }
         if (dto.decision === 'reject') {
           // task left open so it can be re-submitted
           await req.datasetService.rejectPublication(dataset.id, dataset.draftRevisionId);
           task = await taskService.update(task.id, TaskStatus.Rejected, true, user, dto.reason);
+          // close any duplicate sibling publish tasks, keeping only the rejected one open
+          await taskService.closeOpenPublishTasks(dataset.id, user, task.id);
         }
         break;
 

--- a/src/migrations/1784116138829-one-open-publish-task-per-dataset.ts
+++ b/src/migrations/1784116138829-one-open-publish-task-per-dataset.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class OneOpenPublishTaskPerDataset1784116138829 implements MigrationInterface {
+  name = 'OneOpenPublishTaskPerDataset1784116138829';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Close orphaned open publish tasks whose revision has already been approved. These are the
+    // tasks behind SW-1300: the revision is live but the (duplicate) task was never closed, so the
+    // dataset falsely reports "update pending approval".
+    await queryRunner.query(`
+      UPDATE "task" t
+      SET "open" = false, "status" = 'withdrawn'
+      FROM "revision" r
+      WHERE t."action" = 'publish'
+        AND t."open" = true
+        AND r."id" = (t."metadata"->>'revisionId')::uuid
+        AND r."approved_at" IS NOT NULL
+    `);
+
+    // Deduplicate any remaining datasets that still have more than one open publish task, keeping
+    // only the most recently created one so the unique index below can be created.
+    await queryRunner.query(`
+      UPDATE "task"
+      SET "open" = false, "status" = 'withdrawn'
+      WHERE "action" = 'publish'
+        AND "open" = true
+        AND "id" NOT IN (
+          SELECT DISTINCT ON ("dataset_id") "id"
+          FROM "task"
+          WHERE "action" = 'publish' AND "open" = true
+          ORDER BY "dataset_id", "created_at" DESC
+        )
+    `);
+
+    // Backstop: guarantee at most one open publish task per dataset, closing the submit race that
+    // allowed duplicates to be created in the first place.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_task_one_open_publish_per_dataset"
+      ON "task" ("dataset_id")
+      WHERE "action" = 'publish' AND "open" = true
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_task_one_open_publish_per_dataset"`);
+  }
+}

--- a/src/services/dataset.ts
+++ b/src/services/dataset.ts
@@ -1,4 +1,4 @@
-import { In, JsonContains } from 'typeorm';
+import { In, JsonContains, QueryFailedError } from 'typeorm';
 
 import { format as pgformat } from '@scaleleap/pg-format';
 import { RevisionMetadataDTO } from '../dtos/revision-metadata-dto';
@@ -275,7 +275,26 @@ export class DatasetService {
       return; // resubmission of a rejected task
     }
 
-    await this.taskService.create(datasetId, TaskAction.Publish, user, undefined, { revisionId });
+    const pendingPublishTask = await this.getPendingPublishTask(datasetId);
+
+    if (pendingPublishTask) {
+      // already awaiting approval — treat a duplicate submission (e.g. a double click) as a no-op
+      // rather than creating a second open publish task
+      logger.info(`Dataset ${datasetId} already has a pending publish task; ignoring duplicate submission`);
+      return;
+    }
+
+    try {
+      await this.taskService.create(datasetId, TaskAction.Publish, user, undefined, { revisionId });
+    } catch (err) {
+      // Backstop for the concurrent-submit race: a partial unique index guarantees at most one
+      // open publish task per dataset, so a duplicate insert means another request won the race.
+      if (err instanceof QueryFailedError && err.message.includes('violates unique constraint')) {
+        logger.warn(`Concurrent publish submission detected for dataset ${datasetId}; ignoring duplicate`);
+        return;
+      }
+      throw err;
+    }
   }
 
   async withdrawFromPublication(datasetId: string, revisionId: string, user: User): Promise<void> {
@@ -299,11 +318,14 @@ export class DatasetService {
       await this.fileService.delete(draftRevision.onlineCubeFilename, datasetId);
     }
 
-    const pendingPublicationTask = await this.getPendingPublishTask(datasetId);
+    const openPublishTasks = (await this.getOpenTasks(datasetId)).filter((task) => task.action === TaskAction.Publish);
 
-    if (pendingPublicationTask) {
-      await this.taskService.withdrawPending(pendingPublicationTask.id, user);
+    if (openPublishTasks.length > 0) {
+      // close every open publish task (there should only be one, but close any duplicates too)
+      await this.taskService.closeOpenPublishTasks(datasetId, user);
     } else {
+      // the dataset was previously approved so its publish task is already closed; record a
+      // closed withdraw task so the event still appears in the dataset history
       await this.taskService.withdrawApproved(datasetId, draftRevision.id, user);
     }
   }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -34,13 +34,6 @@ export class TaskService {
     return await Task.findOneOrFail({ where: { id: taskId }, relations });
   }
 
-  async withdrawPending(taskId: string, user: User): Promise<Task> {
-    logger.info(`Withdrawing pending task ${taskId}`);
-    const task = await Task.findOneByOrFail({ id: taskId });
-    const updatedTask = Task.merge(task, { status: TaskStatus.Withdrawn, open: false, updatedBy: user });
-    return await updatedTask.save();
-  }
-
   async withdrawApproved(datasetId: string, revisionId: string, user: User): Promise<Task> {
     logger.info(`Withdrawing an approved but unpublished dataset`);
 
@@ -168,6 +161,18 @@ export class TaskService {
     const task = await this.getById(taskId, { dataset: true });
     logger.info(`Rejecting unarchive for dataset ${task.dataset?.id}`);
     return this.update(task.id, TaskStatus.Rejected, false, user, reason);
+  }
+
+  async closeOpenPublishTasks(datasetId: string, user: User, exceptTaskId?: string): Promise<void> {
+    const openPublishTasks = (await this.getTasksForDataset(datasetId, true)).filter(
+      (task) => task.action === TaskAction.Publish && task.id !== exceptTaskId
+    );
+
+    for (const task of openPublishTasks) {
+      logger.info(`Closing open publish task ${task.id} for dataset ${datasetId}`);
+      Task.merge(task, { status: TaskStatus.Withdrawn, open: false, updatedBy: user });
+      await task.save();
+    }
   }
 
   async update(taskId: string, status: TaskStatus, open: boolean, user: User, comment?: string | null): Promise<Task> {

--- a/test/integration/services/submit-for-publication.test.ts
+++ b/test/integration/services/submit-for-publication.test.ts
@@ -1,0 +1,132 @@
+// SW-1300 — a dataset could end up with more than one open "publish" task in `requested`
+// status. When one was approved (publishing the revision), the sibling open task was left
+// open, so getPublishingStatus kept returning UpdatePendingApproval even though the revision
+// was already approved and live. These tests exercise the real DB (so the partial unique
+// index migration is applied) to prove it is impossible to accumulate duplicate open publish
+// tasks via the two races called out in the ticket: near-simultaneous submits and rapid
+// submit → withdraw → resubmit.
+
+import { QueryFailedError } from 'typeorm';
+
+import { ensureWorkerDataSources, resetDatabase } from '../../helpers/reset-database';
+import { Dataset } from '../../../src/entities/dataset/dataset';
+import { Revision } from '../../../src/entities/dataset/revision';
+import { Task } from '../../../src/entities/task/task';
+import { User } from '../../../src/entities/user/user';
+import { DatasetService } from '../../../src/services/dataset';
+import { TaskAction } from '../../../src/enums/task-action';
+import { TaskStatus } from '../../../src/enums/task-status';
+import { Locale } from '../../../src/enums/locale';
+import { StorageService } from '../../../src/interfaces/storage-service';
+import { getTestUser } from '../../helpers/get-test-user';
+import { uuidV4 } from '../../../src/utils/uuid';
+
+const fileService = { delete: jest.fn().mockResolvedValue(undefined) } as unknown as StorageService;
+
+interface Seeded {
+  datasetId: string;
+  revisionId: string;
+  user: User;
+  service: DatasetService;
+}
+
+async function seedDraftDataset(): Promise<Seeded> {
+  const user = await getTestUser('sw1300-user').save();
+
+  const datasetId = uuidV4();
+  const revisionId = uuidV4();
+
+  const dataset = new Dataset();
+  dataset.id = datasetId;
+  dataset.createdBy = user;
+  await dataset.save();
+
+  const revision = new Revision();
+  revision.id = revisionId;
+  revision.datasetId = datasetId;
+  revision.createdBy = user;
+  revision.revisionIndex = 1;
+  revision.publishAt = null;
+  revision.approvedAt = null;
+  revision.unpublishedAt = null;
+  await revision.save();
+
+  dataset.draftRevision = revision;
+  dataset.startRevision = revision;
+  dataset.endRevision = revision;
+  await dataset.save();
+
+  const service = new DatasetService(Locale.EnglishGb, fileService);
+
+  return { datasetId, revisionId, user, service };
+}
+
+function countOpenPublishTasks(datasetId: string): Promise<number> {
+  return Task.count({ where: { datasetId, action: TaskAction.Publish, open: true } });
+}
+
+describe('SW-1300 — at most one open publish task per dataset', () => {
+  beforeAll(async () => {
+    await ensureWorkerDataSources();
+  });
+
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  it('near-simultaneous submissions create only one open publish task', async () => {
+    const { datasetId, revisionId, user, service } = await seedDraftDataset();
+
+    // Fire several submissions concurrently — without the partial unique index and the race
+    // handling in submitForPublication these would each insert their own open publish task.
+    await Promise.all(Array.from({ length: 5 }, () => service.submitForPublication(datasetId, revisionId, user)));
+
+    expect(await countOpenPublishTasks(datasetId)).toBe(1);
+  });
+
+  it('rapid submit → withdraw → resubmit leaves only one open publish task', async () => {
+    const { datasetId, revisionId, user, service } = await seedDraftDataset();
+
+    await service.submitForPublication(datasetId, revisionId, user);
+    expect(await countOpenPublishTasks(datasetId)).toBe(1);
+
+    await service.withdrawFromPublication(datasetId, revisionId, user);
+    expect(await countOpenPublishTasks(datasetId)).toBe(0);
+
+    await service.submitForPublication(datasetId, revisionId, user);
+    expect(await countOpenPublishTasks(datasetId)).toBe(1);
+  });
+
+  it('a duplicate submission after an existing pending task is a no-op', async () => {
+    const { datasetId, revisionId, user, service } = await seedDraftDataset();
+
+    await service.submitForPublication(datasetId, revisionId, user);
+    await service.submitForPublication(datasetId, revisionId, user);
+
+    expect(await countOpenPublishTasks(datasetId)).toBe(1);
+  });
+
+  it('the partial unique index rejects a second open publish task at the DB level', async () => {
+    const { datasetId, user } = await seedDraftDataset();
+
+    await Task.create({
+      datasetId,
+      action: TaskAction.Publish,
+      status: TaskStatus.Requested,
+      open: true,
+      createdBy: user
+    }).save();
+
+    await expect(
+      Task.create({
+        datasetId,
+        action: TaskAction.Publish,
+        status: TaskStatus.Requested,
+        open: true,
+        createdBy: user
+      }).save()
+    ).rejects.toBeInstanceOf(QueryFailedError);
+
+    expect(await countOpenPublishTasks(datasetId)).toBe(1);
+  });
+});

--- a/test/unit/controllers/dataset.test.ts
+++ b/test/unit/controllers/dataset.test.ts
@@ -1446,13 +1446,13 @@ describe('Dataset controller', () => {
   });
 
   describe('datasetActionRequest', () => {
-    it('should call next() for invalid action (falls through to 404)', async () => {
-      const req = createMockRequest({ params: { action: 'invalid_action' } });
+    it('should call next with NotFoundException for an unknown action', async () => {
+      const req = createMockRequest({ params: { action: 'withdraw' } });
       const res = createMockResponse({ locals: { datasetId: uuidV4() } });
 
       await datasetActionRequest(req, res, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(NotFoundException));
     });
 
     it('should throw BadRequestException for publish action', async () => {

--- a/test/unit/controllers/task.test.ts
+++ b/test/unit/controllers/task.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../../src/utils/logger', () => ({
 // Mock TaskService
 const mockGetTasksForDataset = jest.fn();
 const mockUpdate = jest.fn();
+const mockCloseOpenPublishTasks = jest.fn();
 const mockRejectUnpublish = jest.fn();
 const mockApproveArchive = jest.fn();
 const mockRejectArchive = jest.fn();
@@ -31,6 +32,7 @@ jest.mock('../../../src/services/task', () => ({
   TaskService: jest.fn().mockImplementation(() => ({
     getTasksForDataset: (...args: unknown[]) => mockGetTasksForDataset(...args),
     update: (...args: unknown[]) => mockUpdate(...args),
+    closeOpenPublishTasks: (...args: unknown[]) => mockCloseOpenPublishTasks(...args),
     rejectUnpublish: (...args: unknown[]) => mockRejectUnpublish(...args),
     approveArchive: (...args: unknown[]) => mockApproveArchive(...args),
     rejectArchive: (...args: unknown[]) => mockRejectArchive(...args),
@@ -314,6 +316,7 @@ describe('Task controller', () => {
 
         expect(approvePublication).toHaveBeenCalledWith(dataset.id, dataset.draftRevisionId, user);
         expect(mockUpdate).toHaveBeenCalledWith(task.id, TaskStatus.Approved, false, user);
+        expect(mockCloseOpenPublishTasks).toHaveBeenCalledWith(dataset.id, user, task.id);
         expect(res.json).toHaveBeenCalledWith(taskDTO);
       });
 
@@ -348,6 +351,7 @@ describe('Task controller', () => {
 
         expect(rejectPublication).toHaveBeenCalledWith(dataset.id, dataset.draftRevisionId);
         expect(mockUpdate).toHaveBeenCalledWith(task.id, TaskStatus.Rejected, true, user, 'Not ready');
+        expect(mockCloseOpenPublishTasks).toHaveBeenCalledWith(dataset.id, user, task.id);
         expect(res.json).toHaveBeenCalledWith(taskDTO);
       });
     });

--- a/test/unit/services/dataset.test.ts
+++ b/test/unit/services/dataset.test.ts
@@ -1,3 +1,5 @@
+import { QueryFailedError } from 'typeorm';
+
 import { Locale } from '../../../src/enums/locale';
 import { TaskAction } from '../../../src/enums/task-action';
 import { TaskStatus } from '../../../src/enums/task-status';
@@ -72,14 +74,14 @@ jest.mock('../../../src/repositories/user-group', () => ({
 // --- TaskService (instantiated in the constructor) ---
 const mockTaskCreate = jest.fn();
 const mockTaskUpdate = jest.fn();
-const mockTaskWithdrawPending = jest.fn();
+const mockTaskCloseOpenPublishTasks = jest.fn();
 const mockTaskWithdrawApproved = jest.fn();
 const mockTaskGetTasksForDataset = jest.fn();
 jest.mock('../../../src/services/task', () => ({
   TaskService: jest.fn().mockImplementation(() => ({
     create: (...a: unknown[]) => mockTaskCreate(...a),
     update: (...a: unknown[]) => mockTaskUpdate(...a),
-    withdrawPending: (...a: unknown[]) => mockTaskWithdrawPending(...a),
+    closeOpenPublishTasks: (...a: unknown[]) => mockTaskCloseOpenPublishTasks(...a),
     withdrawApproved: (...a: unknown[]) => mockTaskWithdrawApproved(...a),
     getTasksForDataset: (...a: unknown[]) => mockTaskGetTasksForDataset(...a)
   }))
@@ -411,6 +413,38 @@ describe('DatasetService', () => {
       expect(mockTaskCreate).not.toHaveBeenCalled();
     });
 
+    it('is a no-op when a pending publish task already exists (duplicate submission)', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockTaskGetTasksForDataset.mockResolvedValue([
+        { id: 'task-1', action: TaskAction.Publish, status: TaskStatus.Requested }
+      ]);
+
+      await service.submitForPublication('ds-1', 'rev-1', user);
+
+      expect(mockTaskCreate).not.toHaveBeenCalled();
+      expect(mockTaskUpdate).not.toHaveBeenCalled();
+    });
+
+    it('swallows a unique-constraint violation from a concurrent submission', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockTaskGetTasksForDataset.mockResolvedValue([]);
+      mockTaskCreate.mockRejectedValueOnce(
+        new QueryFailedError('INSERT', undefined, new Error('duplicate key value violates unique constraint'))
+      );
+
+      await expect(service.submitForPublication('ds-1', 'rev-1', user)).resolves.toBeUndefined();
+    });
+
+    it('rethrows errors from task creation that are not unique-constraint violations', async () => {
+      mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'rev-1' } });
+      mockTaskGetTasksForDataset.mockResolvedValue([]);
+      mockTaskCreate.mockRejectedValueOnce(new Error('database exploded'));
+
+      const err = await captureError(service.submitForPublication('ds-1', 'rev-1', user));
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe('database exploded');
+    });
+
     it('throws when the revision id does not match the draft revision', async () => {
       mockDatasetGetById.mockResolvedValue({ id: 'ds-1', draftRevision: { id: 'other' } });
       const err = await captureError(service.submitForPublication('ds-1', 'rev-1', user));
@@ -419,21 +453,23 @@ describe('DatasetService', () => {
   });
 
   describe('withdrawFromPublication', () => {
-    it('withdraws a pending publication and deletes the online cube file', async () => {
+    it('closes every open publish task and deletes the online cube file', async () => {
       mockDatasetGetById.mockResolvedValue({ id: 'ds-1', endRevision: {}, tasks: [] });
       mockGetPublishingStatus.mockReturnValue(PublishingStatus.PendingApproval);
       mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1', onlineCubeFilename: 'cube.duckdb' });
       mockTaskGetTasksForDataset.mockResolvedValue([
-        { id: 'task-1', action: TaskAction.Publish, status: TaskStatus.Requested }
+        { id: 'task-1', action: TaskAction.Publish, status: TaskStatus.Requested },
+        { id: 'task-2', action: TaskAction.Publish, status: TaskStatus.Requested }
       ]);
 
       await service.withdrawFromPublication('ds-1', 'rev-1', user);
 
       expect(fileService.delete).toHaveBeenCalledWith('cube.duckdb', 'ds-1');
-      expect(mockTaskWithdrawPending).toHaveBeenCalledWith('task-1', user);
+      expect(mockTaskCloseOpenPublishTasks).toHaveBeenCalledWith('ds-1', user);
+      expect(mockTaskWithdrawApproved).not.toHaveBeenCalled();
     });
 
-    it('withdraws an approved (but unpublished) publication when there is no pending task', async () => {
+    it('withdraws an approved (but unpublished) publication when there is no open publish task', async () => {
       mockDatasetGetById.mockResolvedValue({ id: 'ds-1', endRevision: {}, tasks: [] });
       mockGetPublishingStatus.mockReturnValue(PublishingStatus.Scheduled);
       mockRevRevertToDraft.mockResolvedValue({ id: 'rev-1' });
@@ -442,6 +478,7 @@ describe('DatasetService', () => {
       await service.withdrawFromPublication('ds-1', 'rev-1', user);
 
       expect(mockTaskWithdrawApproved).toHaveBeenCalledWith('ds-1', 'rev-1', user);
+      expect(mockTaskCloseOpenPublishTasks).not.toHaveBeenCalled();
     });
 
     it('throws when there is no pending publication to withdraw', async () => {

--- a/test/unit/services/task.test.ts
+++ b/test/unit/services/task.test.ts
@@ -161,19 +161,48 @@ describe('TaskService', () => {
     });
   });
 
-  describe('withdrawPending', () => {
-    it('sets status Withdrawn and closes the task', async () => {
-      const existing = makeTask({ id: 'task-1' });
-      mockTaskFindOneByOrFail.mockResolvedValueOnce(existing);
+  describe('closeOpenPublishTasks', () => {
+    it('closes every open publish task for the dataset', async () => {
+      const t1 = makeTask({ id: 'task-1', action: TaskAction.Publish });
+      const t2 = makeTask({ id: 'task-2', action: TaskAction.Publish });
+      mockTaskFind.mockResolvedValueOnce([t1, t2]);
 
-      await service.withdrawPending('task-1', user);
+      await service.closeOpenPublishTasks('ds-1', user);
 
-      expect(mockTaskMerge).toHaveBeenCalledWith(existing, {
+      expect(mockTaskMerge).toHaveBeenCalledWith(t1, {
         status: TaskStatus.Withdrawn,
         open: false,
         updatedBy: user
       });
-      expect(existing.save).toHaveBeenCalled();
+      expect(mockTaskMerge).toHaveBeenCalledWith(t2, {
+        status: TaskStatus.Withdrawn,
+        open: false,
+        updatedBy: user
+      });
+      expect(t1.save).toHaveBeenCalled();
+      expect(t2.save).toHaveBeenCalled();
+    });
+
+    it('skips the excepted task and ignores non-publish tasks', async () => {
+      const keep = makeTask({ id: 'keep', action: TaskAction.Publish });
+      const sibling = makeTask({ id: 'sibling', action: TaskAction.Publish });
+      const unpublish = makeTask({ id: 'unpub', action: TaskAction.Unpublish });
+      mockTaskFind.mockResolvedValueOnce([keep, sibling, unpublish]);
+
+      await service.closeOpenPublishTasks('ds-1', user, 'keep');
+
+      expect(sibling.save).toHaveBeenCalled();
+      expect(keep.save).not.toHaveBeenCalled();
+      expect(unpublish.save).not.toHaveBeenCalled();
+    });
+
+    it('only requests open tasks', async () => {
+      mockTaskFind.mockResolvedValueOnce([]);
+      await service.closeOpenPublishTasks('ds-1', user);
+      expect(mockTaskFind).toHaveBeenCalledWith({
+        where: { datasetId: 'ds-1', open: true },
+        order: { createdAt: 'DESC' }
+      });
     });
   });
 


### PR DESCRIPTION
POST /dataset/:id/:action fell through to next() for any action not in
TaskAction, making unsupported routes (e.g. /withdraw) a silent no-op.

- Return NotFoundException for unrecognised action values
- Add a default branch to the switch so any future TaskAction value
  that is not yet wired up also returns an error rather than a silent 204
- Update the controller unit test to assert the 404 behaviour
