### PR TITLE
SW-1301: Return 404 for unknown actions instead of silently doing not…

### DIFF
--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -660,7 +660,7 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
   const action = req.params.action as TaskAction;
 
   if (!Object.values(TaskAction).includes(action)) {
-    next(new NotFoundException(`Unknown action: ${action}`));
+    next(new NotFoundException('errors.dataset.invalid_action'));
     return;
   }
 
@@ -687,7 +687,7 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
       await taskService.requestUnarchive(datasetId, user, reason);
       break;
     default:
-      next(new NotFoundException(`Action not supported via this endpoint: ${action}`));
+      next(new NotFoundException('errors.dataset.invalid_action'));
       return;
   }
 

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -660,7 +660,7 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
   const action = req.params.action as TaskAction;
 
   if (!Object.values(TaskAction).includes(action)) {
-    next();
+    next(new NotFoundException(`Unknown action: ${action}`));
     return;
   }
 
@@ -686,6 +686,9 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
     case TaskAction.Unarchive:
       await taskService.requestUnarchive(datasetId, user, reason);
       break;
+    default:
+      next(new NotFoundException(`Action not supported via this endpoint: ${action}`));
+      return;
   }
 
   res.status(204).end();

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -687,7 +687,7 @@ export const datasetActionRequest = async (req: Request, res: Response, next: Ne
       await taskService.requestUnarchive(datasetId, user, reason);
       break;
     default:
-      next(new NotFoundException(`Action not supported via this endpoint: ${action}`));
+      next(new NotFoundException('errors.dataset_action.not_supported'));
       return;
   }
 

--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -72,6 +72,9 @@
     },
     "translation_file": {
       "invalid": "Nid yw’r allweddi ffeil cyfieithu a lanlwythwyd yn cyfateb â’r ffeil a allgludwyd"
+    },
+    "dataset": {
+      "invalid_action": "Gweithred annilys"
     }
   },
   "dimension_info": {

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -74,6 +74,9 @@
     },
     "translation_file": {
       "invalid": "Uploaded translation file keys do not match the exported file"
+    },
+    "dataset": {
+      "invalid_action": "Invalid action"
     }
   },
   "dimension_info": {

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -139,10 +139,6 @@ datasetRouter.patch('/:dataset_id/group', ensureNoOpenPublishRequest, jsonParser
 // List the event history for this dataset
 datasetRouter.get('/:dataset_id/history', getHistory);
 
-// POST /dataset/:dataset_id/:action
-// Request an action (publish, unpublish, archive, unarchive, withdraw) for this dataset
-datasetRouter.post('/:dataset_id/:action', jsonParser, datasetActionRequest);
-
 // apply revision child routes
 datasetRouter.use('/:dataset_id/revision', revisionRouter);
 
@@ -151,3 +147,8 @@ datasetRouter.use('/:dataset_id/dimension', dimensionRouter);
 
 // apply measure child routes
 datasetRouter.use('/:dataset_id/measure', measureRouter);
+
+// POST /dataset/:dataset_id/:action
+// Request an action (publish, unpublish, archive, unarchive, withdraw) for this dataset
+// Must be registered after specific sub-routers so that paths like /revision do not match :action first
+datasetRouter.post('/:dataset_id/:action', jsonParser, datasetActionRequest);

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -149,6 +149,6 @@ datasetRouter.use('/:dataset_id/dimension', dimensionRouter);
 datasetRouter.use('/:dataset_id/measure', measureRouter);
 
 // POST /dataset/:dataset_id/:action
-// Request an action (publish, unpublish, archive, unarchive, withdraw) for this dataset
-// Must be registered after specific sub-routers so that paths like /revision do not match :action first
+// Request an action (unpublish, archive, unarchive) for this dataset
+// Publish/withdraw are handled via revision endpoints
 datasetRouter.post('/:dataset_id/:action', jsonParser, datasetActionRequest);

--- a/test/unit/controllers/dataset.test.ts
+++ b/test/unit/controllers/dataset.test.ts
@@ -1446,13 +1446,13 @@ describe('Dataset controller', () => {
   });
 
   describe('datasetActionRequest', () => {
-    it('should call next() for invalid action (falls through to 404)', async () => {
-      const req = createMockRequest({ params: { action: 'invalid_action' } });
+    it('should call next with NotFoundException for an unknown action', async () => {
+      const req = createMockRequest({ params: { action: 'withdraw' } });
       const res = createMockResponse({ locals: { datasetId: uuidV4() } });
 
       await datasetActionRequest(req, res, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(NotFoundException));
     });
 
     it('should throw BadRequestException for publish action', async () => {


### PR DESCRIPTION
…hing

POST /dataset/:id/:action fell through to next() for any action not in TaskAction, making unsupported routes (e.g. /withdraw) a silent no-op.

- Return NotFoundException for unrecognised action values
- Add a default branch to the switch so any future TaskAction value that is not yet wired up also returns an error rather than a silent 204
- Update the controller unit test to assert the 404 behaviour