### PR TITLE
SW-1302: Apply ensureNoOpenPublishRequest consistently across all edit routes

### DIFF
--- a/src/routes/dimension.ts
+++ b/src/routes/dimension.ts
@@ -18,6 +18,7 @@ import { NotFoundException } from '../exceptions/not-found.exception';
 import { DimensionRepository } from '../repositories/dimension';
 import { fileStreaming } from '../middleware/file-streaming';
 import { longTimeout } from '../middleware/timeout';
+import { ensureNoOpenPublishRequest } from '../middleware/ensure-no-open-publish-request';
 
 export const loadDimension = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const dimensionIdError = await hasError(dimensionIdValidator(), req);
@@ -55,7 +56,7 @@ router.get('/by-id/:dimension_id', loadDimension, getDimensionInfo);
 
 // DELETE /dataset/:dataset_id/dimension/id/:dimension_id/reset
 // Resets the dimensions type back to "Raw" and removes the extractor
-router.delete('/by-id/:dimension_id/reset', loadDimension, resetDimension);
+router.delete('/by-id/:dimension_id/reset', ensureNoOpenPublishRequest, loadDimension, resetDimension);
 
 // GET /dataset/:dataset_id/dimension/id/:dimension_id/preview
 // Returns details of a dimension and a preview of the data
@@ -66,16 +67,29 @@ router.get('/by-id/:dimension_id/preview', loadDimension, sendDimensionPreview);
 // POST /:dataset_id/dimension/by-id/:dimension_id/lookup
 // Attaches a lookup table to do a dimension and validates
 // the lookup table.
-router.post('/by-id/:dimension_id/lookup', longTimeout, fileStreaming(), loadDimension, attachLookupTableToDimension);
+router.post(
+  '/by-id/:dimension_id/lookup',
+  ensureNoOpenPublishRequest,
+  longTimeout,
+  fileStreaming(),
+  loadDimension,
+  attachLookupTableToDimension
+);
 
 // PATCH /dataset/:dataset_id/dimension/id/:dimension_id/
 // Takes a patch request and validates the request against the fact table
 // If it fails, it sends back an error
-router.patch('/by-id/:dimension_id', jsonParser, loadDimension, updateDimension);
+router.patch('/by-id/:dimension_id', ensureNoOpenPublishRequest, jsonParser, loadDimension, updateDimension);
 
 // PATCH /:dataset_id/dimension/by-id/:dimension_id/meta
 // Updates the dimension metadata
-router.patch('/by-id/:dimension_id/metadata', jsonParser, loadDimension, updateDimensionMetadata);
+router.patch(
+  '/by-id/:dimension_id/metadata',
+  ensureNoOpenPublishRequest,
+  jsonParser,
+  loadDimension,
+  updateDimensionMetadata
+);
 
 router.get('/by-id/:dimension_id/lookup', loadDimension, getDimensionLookupTableInfo);
 

--- a/src/routes/dimension.ts
+++ b/src/routes/dimension.ts
@@ -69,8 +69,8 @@ router.get('/by-id/:dimension_id/preview', loadDimension, sendDimensionPreview);
 // the lookup table.
 router.post(
   '/by-id/:dimension_id/lookup',
-  ensureNoOpenPublishRequest,
   longTimeout,
+  ensureNoOpenPublishRequest,
   fileStreaming(),
   loadDimension,
   attachLookupTableToDimension

--- a/src/routes/measure.ts
+++ b/src/routes/measure.ts
@@ -13,6 +13,7 @@ import {
 } from '../controllers/measure';
 import { fileStreaming } from '../middleware/file-streaming';
 import { longTimeout } from '../middleware/timeout';
+import { ensureNoOpenPublishRequest } from '../middleware/ensure-no-open-publish-request';
 
 const jsonParser = express.json();
 
@@ -24,10 +25,10 @@ router.get('/', getMeasureInfo);
 
 // POST /:dataset_id/measure
 // Attaches a measure lookup table to a dataset and validates it.
-router.post('/', longTimeout, fileStreaming(), attachLookupTableToMeasure);
+router.post('/', ensureNoOpenPublishRequest, longTimeout, fileStreaming(), attachLookupTableToMeasure);
 
 // DELETE /dataset/:dataset_id/measure/reset
-router.delete('/reset', resetMeasure);
+router.delete('/reset', ensureNoOpenPublishRequest, resetMeasure);
 
 // GET /dataset/:dataset_id/dimension/id/:dimension_id/preview
 // Returns details of a dimension and a preview of the data
@@ -35,9 +36,9 @@ router.delete('/reset', resetMeasure);
 // preview as opposed to view which returns interpreted values.
 router.get('/preview', getPreviewOfMeasure);
 
-// PATCH /:dataset_id/dimension/by-id/:dimension_id/meta
-// Updates the dimension metadata
-router.patch('/metadata', jsonParser, updateMeasureMetadata);
+// PATCH /:dataset_id/measure/metadata
+// Updates the measure metadata
+router.patch('/metadata', ensureNoOpenPublishRequest, jsonParser, updateMeasureMetadata);
 
 router.get('/lookup', getMeasureLookupTableInfo);
 

--- a/src/routes/measure.ts
+++ b/src/routes/measure.ts
@@ -25,7 +25,7 @@ router.get('/', getMeasureInfo);
 
 // POST /:dataset_id/measure
 // Attaches a measure lookup table to a dataset and validates it.
-router.post('/', ensureNoOpenPublishRequest, longTimeout, fileStreaming(), attachLookupTableToMeasure);
+router.post('/', longTimeout, ensureNoOpenPublishRequest, fileStreaming(), attachLookupTableToMeasure);
 
 // DELETE /dataset/:dataset_id/measure/reset
 router.delete('/reset', ensureNoOpenPublishRequest, resetMeasure);

--- a/src/routes/revision.ts
+++ b/src/routes/revision.ts
@@ -31,6 +31,7 @@ import { RevisionRepository, withMetadataAndProviders } from '../repositories/re
 import { fileStreaming } from '../middleware/file-streaming';
 import { longTimeout } from '../middleware/timeout';
 import { getBuiltLogEntry } from '../controllers/build-log';
+import { ensureNoOpenPublishRequest } from '../middleware/ensure-no-open-publish-request';
 
 // middleware that loads the revision and stores it in res.locals
 // leave relations undefined to load the default relations
@@ -68,11 +69,11 @@ export const revisionRouter = router;
 
 // POST
 // Create a new revision for an update
-router.post('/', createNewRevision);
+router.post('/', ensureNoOpenPublishRequest, createNewRevision);
 
 // DELETE /dataset/:dataset_id/revision/by-id/:revision_id
 // Deletes a revision provided it is not published
-router.delete('/by-id/:revision_id', loadRevision({}), deleteDraftRevision);
+router.delete('/by-id/:revision_id', ensureNoOpenPublishRequest, loadRevision({}), deleteDraftRevision);
 
 // POST /dataset/:dataset_id/revision/by-id/:revision_id
 // Regenerates the revision cube
@@ -90,7 +91,14 @@ router.get('/by-id/:revision_id/preview/filters', loadRevision(), getRevisionPre
 
 // POST /dataset/:dataset_id/revision/id/:revision_id/data-table
 // Upload an updated data file for the revision
-router.post('/by-id/:revision_id/data-table', longTimeout, loadRevision(), fileStreaming(), updateDataTable);
+router.post(
+  '/by-id/:revision_id/data-table',
+  ensureNoOpenPublishRequest,
+  longTimeout,
+  loadRevision(),
+  fileStreaming(),
+  updateDataTable
+);
 
 // GET /dataset/:dataset_id/revision/by-id/:revision_id/data-table
 // Returns details of a data-table
@@ -103,7 +111,7 @@ router.get('/by-id/:revision_id/data-table/preview', loadRevision(), getDataTabl
 // PATCH /dataset/:dataset_id/revision/by-id/:revision_id/data-table/confirm
 // returns a JSON object with the current state of the revision including the data-table
 // and sources created from the data-table.
-router.patch('/by-id/:revision_id/data-table/confirm', loadRevision(), confirmFactTable);
+router.patch('/by-id/:revision_id/data-table/confirm', ensureNoOpenPublishRequest, loadRevision(), confirmFactTable);
 
 // GET /dataset/:dataset_id/revision/id/:revision_id/data-table/id/:fact_table_id/raw
 // Returns the original uploaded file back to the client
@@ -112,11 +120,22 @@ router.get('/by-id/:revision_id/data-table/raw', loadRevision(), downloadRawFact
 // DELETE /:dataset_id/revision/by-id/:revision_id/data-table
 // Removes the import record and associated file from BlobStorage clearing the way
 // for the user to upload a new file for the dataset.
-router.delete('/by-id/:revision_id/data-table', loadRevision(), removeFactTableFromRevision);
+router.delete(
+  '/by-id/:revision_id/data-table',
+  ensureNoOpenPublishRequest,
+  loadRevision(),
+  removeFactTableFromRevision
+);
 
 // PATCH /dataset/:dataset_id/revision/by-id/:revision_id/publish-at
 // Updates the publishAt date for the specified revision
-router.patch('/by-id/:revision_id/publish-at', loadRevision(), jsonParser, updateRevisionPublicationDate);
+router.patch(
+  '/by-id/:revision_id/publish-at',
+  ensureNoOpenPublishRequest,
+  loadRevision(),
+  jsonParser,
+  updateRevisionPublicationDate
+);
 
 // POST /dataset/:dataset_id/revision/by-id/<revision id>/approve
 // Approve the dataset's latest revision for publication

--- a/src/routes/revision.ts
+++ b/src/routes/revision.ts
@@ -93,8 +93,8 @@ router.get('/by-id/:revision_id/preview/filters', loadRevision(), getRevisionPre
 // Upload an updated data file for the revision
 router.post(
   '/by-id/:revision_id/data-table',
-  ensureNoOpenPublishRequest,
   longTimeout,
+  ensureNoOpenPublishRequest,
   loadRevision(),
   fileStreaming(),
   updateDataTable


### PR DESCRIPTION
The edit-lock middleware was present on dataset-level write routes but absent from all write routes in the revision, dimension, and measure sub-routers, allowing edits to proceed while a publish request was pending review.

Add ensureNoOpenPublishRequest to:
- revision: createNewRevision, deleteDraftRevision, updateDataTable, confirmFactTable, removeFactTableFromRevision, updateRevisionPublicationDate
- dimension: resetDimension, attachLookupTableToDimension, updateDimension, updateDimensionMetadata
- measure: attachLookupTableToMeasure, resetMeasure, updateMeasureMetadata

Left unguarded intentionally: regenerateRevisionCube (technical re-compute, not a data change), submitForPublication and withdrawFromPublication (they operate on the publish request itself).