### PR TITLE
SW-1303: Correct Task.datasetId column type from text to uuid

### DIFF
--- a/src/entities/task/task.ts
+++ b/src/entities/task/task.ts
@@ -37,7 +37,7 @@ export class Task extends BaseEntity {
   open: boolean;
 
   @Index('IDX_task_dataset_id')
-  @Column({ name: 'dataset_id', type: 'text', nullable: true })
+  @Column({ name: 'dataset_id', type: 'uuid', nullable: true })
   datasetId?: string;
 
   @ManyToOne(() => Dataset, (dataset) => dataset.tasks, { nullable: true, onDelete: 'CASCADE' })


### PR DESCRIPTION
The dataset_id column is a uuid in the database but was declared as text in the TypeORM entity, causing a type mismatch that could produce subtle driver-level binding errors under strict PostgreSQL type checking.