### PR TITLE
SW-1304 Fix SQL injection in measure lookup table matcher

### DIFF
--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -8,6 +8,8 @@ import { DatasetDTO } from '../dtos/dataset-dto';
 import { MeasureLookupPatchDTO } from '../dtos/measure-lookup-patch-dto';
 import { NotFoundException } from '../exceptions/not-found.exception';
 import { UnknownException } from '../exceptions/unknown.exception';
+import { BadRequestException } from '../exceptions/bad-request.exception';
+import { dtoValidator } from '../validators/dto-validator';
 import { getMeasurePreview, validateMeasureLookupTable } from '../services/measure-handler';
 import { validateAndUpload } from '../services/incoming-file-processor';
 import { DimensionMetadataDTO } from '../dtos/dimension-metadata-dto';
@@ -79,7 +81,7 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
   try {
     const dataTable = await validateAndUpload(tmpFile, dataset.id, 'lookup_table');
     const lang = req.language.toLowerCase();
-    const tableMatcher = req.body as MeasureLookupPatchDTO;
+    const tableMatcher = await dtoValidator(MeasureLookupPatchDTO, req.body);
     const result = await validateMeasureLookupTable(dataTable, dataset, tmpFile.path, lang, tableMatcher);
     if ((result as ViewErrDTO).status) {
       const error = result as ViewErrDTO;
@@ -100,6 +102,10 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
     res.status((result as ViewErrDTO).status || 200);
     res.json(result);
   } catch (err) {
+    if (err instanceof BadRequestException) {
+      next(err);
+      return;
+    }
     logger.error(err, `An error occurred trying to process and upload the file`);
     next(new UnknownException('errors.upload_error'));
     return;

--- a/src/controllers/measure.ts
+++ b/src/controllers/measure.ts
@@ -79,9 +79,9 @@ export const attachLookupTableToMeasure = async (req: Request, res: Response, ne
   let build: BuildLog;
 
   try {
+    const tableMatcher = await dtoValidator(MeasureLookupPatchDTO, req.body);
     const dataTable = await validateAndUpload(tmpFile, dataset.id, 'lookup_table');
     const lang = req.language.toLowerCase();
-    const tableMatcher = await dtoValidator(MeasureLookupPatchDTO, req.body);
     const result = await validateMeasureLookupTable(dataTable, dataset, tmpFile.path, lang, tableMatcher);
     if ((result as ViewErrDTO).status) {
       const error = result as ViewErrDTO;

--- a/src/dtos/measure-lookup-patch-dto.ts
+++ b/src/dtos/measure-lookup-patch-dto.ts
@@ -1,10 +1,37 @@
-export interface MeasureLookupPatchDTO {
-  join_column: string;
-  description_columns: string[];
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class MeasureLookupPatchDTO {
+  @IsOptional()
+  @IsString()
+  join_column?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  description_columns?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
   notes_columns?: string[];
+
+  @IsOptional()
+  @IsString()
   sort_column?: string;
-  measure_type_column: string;
-  format_column: string;
-  decimal_column: string;
-  language_column: string;
+
+  @IsOptional()
+  @IsString()
+  measure_type_column?: string;
+
+  @IsOptional()
+  @IsString()
+  format_column?: string;
+
+  @IsOptional()
+  @IsString()
+  decimal_column?: string;
+
+  @IsOptional()
+  @IsString()
+  language_column?: string;
 }

--- a/src/exceptions/validation-exception.ts
+++ b/src/exceptions/validation-exception.ts
@@ -17,12 +17,14 @@ export enum FileValidationErrorType {
 export class FileValidationException extends Error {
   status = 400;
   errorTag: string;
-  message: string;
   type: FileValidationErrorType;
   extension: never;
 
   constructor(message: string, type: FileValidationErrorType, status = 400) {
     super(message);
+    // Class field declarations (even untyped ones like `message: string`) are defined immediately after
+    // super() returns, which would otherwise clobber the message Error's own constructor just set.
+    this.message = message;
     this.type = type;
     this.errorTag = `errors.file_validation.${type}`;
     this.status = status;

--- a/src/exceptions/validation-exception.ts
+++ b/src/exceptions/validation-exception.ts
@@ -22,9 +22,6 @@ export class FileValidationException extends Error {
 
   constructor(message: string, type: FileValidationErrorType, status = 400) {
     super(message);
-    // Class field declarations (even untyped ones like `message: string`) are defined immediately after
-    // super() returns, which would otherwise clobber the message Error's own constructor just set.
-    this.message = message;
     this.type = type;
     this.errorTag = `errors.file_validation.${type}`;
     this.status = status;

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -92,6 +92,21 @@ async function cleanUpMeasure(measureId: string): Promise<void> {
   }
 }
 
+// Ensures a user-supplied table matcher column name matches one of the actual uploaded headers before it is
+// allowed anywhere near SQL construction. Without this, an attacker-controlled string with no corresponding
+// header would flow straight into an identifier position (CWE-89, SW-1304).
+function findMatchedColumn(protoLookupTable: DataTable, columnName: string | undefined): string | undefined {
+  if (!columnName) return undefined;
+  const match = protoLookupTable.dataTableDescriptions.find((info) => info.columnName === columnName);
+  if (!match) {
+    throw new FileValidationException(
+      'errors.measure_validation.unknown_matcher_column',
+      FileValidationErrorType.InvalidCsv
+    );
+  }
+  return match.columnName;
+}
+
 function createExtractor(
   protoLookupTable: DataTable,
   tableLanguage: Locale,
@@ -101,23 +116,31 @@ function createExtractor(
     logger.debug('Using user supplied table matcher to match columns');
     return {
       tableLanguage,
-      sortColumn: tableMatcher?.sort_column,
-      formatColumn: tableMatcher?.format_column,
-      decimalColumn: tableMatcher?.decimal_column,
-      measureTypeColumn: tableMatcher?.measure_type_column,
-      descriptionColumns: tableMatcher.description_columns.map(
-        (desc) =>
-          protoLookupTable.dataTableDescriptions
-            .filter((info) => info.columnName === desc)
-            .map((info) => columnIdentification(info))[0]
-      ),
-      notesColumns: tableMatcher.notes_columns?.map(
-        (desc) =>
-          protoLookupTable.dataTableDescriptions
-            .filter((info) => info.columnName === desc)
-            .map((info) => columnIdentification(info))[0]
-      ),
-      languageColumn: tableMatcher?.language_column,
+      sortColumn: findMatchedColumn(protoLookupTable, tableMatcher?.sort_column),
+      formatColumn: findMatchedColumn(protoLookupTable, tableMatcher?.format_column),
+      decimalColumn: findMatchedColumn(protoLookupTable, tableMatcher?.decimal_column),
+      measureTypeColumn: findMatchedColumn(protoLookupTable, tableMatcher?.measure_type_column),
+      descriptionColumns: tableMatcher.description_columns.map((desc) => {
+        const info = protoLookupTable.dataTableDescriptions.find((info) => info.columnName === desc);
+        if (!info) {
+          throw new FileValidationException(
+            'errors.measure_validation.unknown_matcher_column',
+            FileValidationErrorType.InvalidCsv
+          );
+        }
+        return columnIdentification(info);
+      }),
+      notesColumns: tableMatcher.notes_columns?.map((desc) => {
+        const info = protoLookupTable.dataTableDescriptions.find((info) => info.columnName === desc);
+        if (!info) {
+          throw new FileValidationException(
+            'errors.measure_validation.unknown_matcher_column',
+            FileValidationErrorType.InvalidCsv
+          );
+        }
+        return columnIdentification(info);
+      }),
+      languageColumn: findMatchedColumn(protoLookupTable, tableMatcher?.language_column),
       isSW2Format: !tableMatcher?.language_column
     };
   } else {
@@ -218,16 +241,16 @@ async function createMeasureTable(
     logger.debug(`Setting up measure insert query`);
     let formatColumn = 'NULL AS format,';
     if (extractor.formatColumn) {
-      formatColumn = `"${extractor.formatColumn}"`;
+      formatColumn = pgformat('%I', extractor.formatColumn);
     } else if (!extractor.formatColumn && !extractor.decimalColumn) {
       formatColumn = `'text'`;
     } else if (!extractor.formatColumn && extractor.decimalColumn) {
-      formatColumn = `CASE WHEN "${extractor.decimalColumn}" > 0 THEN 'float' ELSE 'integer' END`;
+      formatColumn = pgformat('CASE WHEN %I > 0 THEN %L ELSE %L END', extractor.decimalColumn, 'float', 'integer');
     }
-    const decimalColumnDef = extractor.decimalColumn ? `"${extractor.decimalColumn}"` : 'NULL';
-    const sortOrderDef = extractor.sortColumn ? `"${extractor.sortColumn}"` : 'NULL';
-    const measureTypeDef = extractor.measureTypeColumn ? `"${extractor.measureTypeColumn}"` : 'NULL';
-    const hierarchyDef = extractor.hierarchyColumn ? `"${extractor.hierarchyColumn}"` : 'NULL';
+    const decimalColumnDef = extractor.decimalColumn ? pgformat('%I', extractor.decimalColumn) : 'NULL';
+    const sortOrderDef = extractor.sortColumn ? pgformat('%I', extractor.sortColumn) : 'NULL';
+    const measureTypeDef = extractor.measureTypeColumn ? pgformat('%I', extractor.measureTypeColumn) : 'NULL';
+    const hierarchyDef = extractor.hierarchyColumn ? pgformat('%I', extractor.hierarchyColumn) : 'NULL';
     let notesColumnDef = 'NULL';
     let buildMeasureViewQuery: string;
     if (extractor.isSW2Format) {
@@ -241,7 +264,7 @@ async function createMeasureTable(
         if (extractor.notesColumns) {
           const notesCol = extractor.notesColumns.find((col) => col.lang === locale.toLowerCase())?.name;
           if (notesCol) {
-            notesColumnDef = `"${notesCol}"`;
+            notesColumnDef = pgformat('%I', notesCol);
           }
         }
         viewComponents.push(
@@ -264,7 +287,7 @@ async function createMeasureTable(
       buildMeasureViewQuery = `${viewComponents.join('\nUNION\n')}`;
     } else {
       if (extractor.notesColumns && extractor.notesColumns.length > 0) {
-        notesColumnDef = `"${extractor.notesColumns[0].name}"`;
+        notesColumnDef = pgformat('%I', extractor.notesColumns[0].name);
       } else {
         notesColumnDef = 'NULL';
       }

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -506,7 +506,9 @@ export const validateMeasureLookupTable = async (
     extractor = createExtractor(protoLookupTable, tableLanguage, tableMatcher);
   } catch (error) {
     logger.error(error, `Something went wrong trying to create the measure lookup table extractor`);
-    return viewErrorGenerators(400, dataset.id, 'csv', 'errors.measure_validation.no_description_columns', {
+    const errorKey =
+      error instanceof FileValidationException ? error.message : 'errors.measure_validation.no_description_columns';
+    return viewErrorGenerators(400, dataset.id, 'csv', errorKey, {
       mismatch: false
     });
   }

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -245,7 +245,7 @@ async function createMeasureTable(
     await loadFileIntoCube(duckdb, fileType, path, tmpTableName, 'memory');
     const viewComponents: string[] = [];
     logger.debug(`Setting up measure insert query`);
-    let formatColumn = 'NULL AS format,';
+    let formatColumn = 'NULL';
     if (extractor.formatColumn) {
       formatColumn = pgformat('%I', extractor.formatColumn);
     } else if (!extractor.formatColumn && !extractor.decimalColumn) {

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -489,8 +489,12 @@ export const validateMeasureLookupTable = async (
   let confirmedJoinColumn: string | undefined;
   try {
     confirmedJoinColumn = lookForJoinColumn(protoLookupTable, measure.factTableColumn, tableLanguage, tableMatcher);
-  } catch (_err) {
-    return viewErrorGenerators(400, dataset.id, 'csv', 'errors.measure_validation.no_join_column', {
+  } catch (err) {
+    const errorKey =
+      err instanceof Error && err.message === 'errors.measure_validation.unknown_matcher_column'
+        ? err.message
+        : 'errors.measure_validation.no_join_column';
+    return viewErrorGenerators(400, dataset.id, 'csv', errorKey, {
       mismatch: false
     });
   }

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -114,6 +114,12 @@ function createExtractor(
 ): MeasureLookupTableExtractor {
   if (tableMatcher?.description_columns) {
     logger.debug('Using user supplied table matcher to match columns');
+    if (tableMatcher.description_columns.length === 0) {
+      throw new FileValidationException(
+        'errors.measure_validation.no_description_columns',
+        FileValidationErrorType.InvalidCsv
+      );
+    }
     return {
       tableLanguage,
       sortColumn: findMatchedColumn(protoLookupTable, tableMatcher?.sort_column),

--- a/src/services/measure-handler.ts
+++ b/src/services/measure-handler.ts
@@ -267,10 +267,11 @@ async function createMeasureTable(
         );
       }
       for (const locale of SUPPORTED_LOCALES) {
+        let localeNotesColumnDef = 'NULL';
         if (extractor.notesColumns) {
           const notesCol = extractor.notesColumns.find((col) => col.lang === locale.toLowerCase())?.name;
           if (notesCol) {
-            notesColumnDef = pgformat('%I', notesCol);
+            localeNotesColumnDef = pgformat('%I', notesCol);
           }
         }
         viewComponents.push(
@@ -279,7 +280,7 @@ async function createMeasureTable(
             joinColumn,
             locale.toLowerCase(),
             extractor.descriptionColumns.find((col) => col.lang === locale.toLowerCase())?.name,
-            notesColumnDef,
+            localeNotesColumnDef,
             sortOrderDef,
             formatColumn,
             decimalColumnDef,

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -115,9 +115,7 @@ export const lookForJoinColumn = (
       (col) => col.columnName === tableMatcher.join_column
     );
     if (!joinColumnMatch) {
-      throw new Error(
-        `Table matcher supplied join_column "${tableMatcher.join_column}" does not match an uploaded column`
-      );
+      throw new Error('errors.measure_validation.unknown_matcher_column');
     }
     return joinColumnMatch.columnName;
   }

--- a/src/utils/lookup-table-utils.ts
+++ b/src/utils/lookup-table-utils.ts
@@ -110,7 +110,17 @@ export const lookForJoinColumn = (
     col.columnName.toLowerCase().includes(t('lookup_column_headers.refcode', { lng: tableLanguage }).toLowerCase())
   );
 
-  if (tableMatcher?.join_column) return tableMatcher.join_column;
+  if (tableMatcher?.join_column) {
+    const joinColumnMatch = protoLookupTable.dataTableDescriptions.find(
+      (col) => col.columnName === tableMatcher.join_column
+    );
+    if (!joinColumnMatch) {
+      throw new Error(
+        `Table matcher supplied join_column "${tableMatcher.join_column}" does not match an uploaded column`
+      );
+    }
+    return joinColumnMatch.columnName;
+  }
   if (refCol) return refCol.columnName;
   if (refCodeCol) return refCodeCol.columnName;
 

--- a/test/unit/controllers/measure.test.ts
+++ b/test/unit/controllers/measure.test.ts
@@ -378,6 +378,22 @@ describe('Measure controller', () => {
       expect(mockCleanupTmpFile).toHaveBeenCalled();
     });
 
+    it('rejects a malformed table matcher body before validating the lookup table', async () => {
+      mockUploadAvScan.mockResolvedValue({ path: '/tmp/lookup.csv' });
+      mockGetById.mockResolvedValue({ id: uuidV4(), measure: { id: uuidV4() }, draftRevision: { id: uuidV4() } });
+      mockValidateAndUpload.mockResolvedValue({ id: 'data-table' });
+
+      // description_columns must be a string[]; sending a plain string should fail DTO validation
+      const req = createMockRequest({ body: { description_columns: 'description_en' } as never });
+      const res = createMockResponse();
+      await attachLookupTableToMeasure(req, res, mockNext);
+
+      expect(mockValidateMeasureLookupTable).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toMatchObject({ name: 'BadRequestException', status: 400 });
+      expect(mockCleanupTmpFile).toHaveBeenCalled();
+    });
+
     it('starts a build and returns the result when validation succeeds', async () => {
       const dataset = { id: uuidV4(), measure: { id: uuidV4() }, draftRevision: { id: uuidV4() } };
       mockUploadAvScan.mockResolvedValue({ path: '/tmp/lookup.csv' });

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -950,6 +950,30 @@ describe('validateMeasureLookupTable', () => {
       expect(mockRelease).toHaveBeenCalled();
     });
 
+    it('rejects a table matcher column that does not match an uploaded header (SW-1304 regression)', async () => {
+      // Crafted value from the SW-1304 exploit repro: breaks out of the quoted identifier and
+      // attempts to inject a sub-select. Since it isn't a real header, it must be rejected before
+      // DuckDB ever sees it.
+      const injectionPayload = `x" > 0 THEN 'float' ELSE (SELECT content FROM read_text('/etc/passwd')) END, "y`;
+      const maliciousMatcher: MeasureLookupPatchDTO = {
+        description_columns: ['description_en'],
+        language_column: 'lang_col',
+        decimal_column: injectionPayload
+      };
+      const dataset = makeDataset();
+
+      const result = (await validateMeasureLookupTable(
+        validProtoTable,
+        dataset,
+        '/tmp/file.csv',
+        'en-GB',
+        maliciousMatcher
+      )) as ViewErrDTO;
+
+      expect(result.status).toBe(400);
+      expect(mockDuckdbRun).not.toHaveBeenCalled();
+    });
+
     it('handles isSW2Format=true when two locale description columns are provided', async () => {
       // SW2 format: two description columns (one per locale), no language_column
       const sw2tableMatcher: MeasureLookupPatchDTO = {

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -1036,5 +1036,30 @@ describe('validateMeasureLookupTable', () => {
 
       expect(result).toMatchObject({ current_page: 1 });
     });
+
+    it('does not leak one locale notes column into another locale in the SW2 branch (regression)', async () => {
+      // Notes are only supplied for English. Without a per-iteration reset, the Welsh SELECT would
+      // incorrectly reuse the English notes column instead of falling back to NULL.
+      const sw2tableMatcher: MeasureLookupPatchDTO = {
+        description_columns: ['description_en', 'description_cy'],
+        notes_columns: ['notes_en']
+        // no language_column → isSW2Format = true
+      };
+      const sw2ProtoTable = makeProtoLookupTable(['description_en', 'description_cy', 'ref_code', 'notes_en']);
+
+      setupHappyPathMocks();
+      const dataset = makeDataset();
+
+      await validateMeasureLookupTable(sw2ProtoTable, dataset, '/tmp/file.csv', 'en-GB', sw2tableMatcher);
+
+      const insertCall = mockDuckdbRun.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO')
+      );
+      expect(insertCall).toBeDefined();
+      const [insertSql] = insertCall as [string];
+
+      expect(insertSql).toMatch(/'en-gb' AS language, description_en AS description, notes_en AS notes/);
+      expect(insertSql).toMatch(/'cy-gb' AS language, description_cy AS description, NULL AS notes/);
+    });
   });
 });

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -640,6 +640,24 @@ describe('validateMeasureLookupTable', () => {
       expect(result.errors[0].message.key).toBe('errors.measure_validation.no_join_column');
     });
 
+    it('propagates the unknown_matcher_column key when lookForJoinColumn rejects an invalid join_column', async () => {
+      const dataset = makeDataset();
+      (lookForJoinColumn as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('errors.measure_validation.unknown_matcher_column');
+      });
+
+      const result = (await validateMeasureLookupTable(
+        validProtoTable,
+        dataset,
+        '/tmp/file.csv',
+        'en-GB',
+        tableMatcher
+      )) as ViewErrDTO;
+
+      expect(result.status).toBe(400);
+      expect(result.errors[0].message.key).toBe('errors.measure_validation.unknown_matcher_column');
+    });
+
     it('returns 400 error when lookForJoinColumn returns undefined', async () => {
       const dataset = makeDataset();
       (lookForJoinColumn as jest.Mock).mockReturnValueOnce(undefined);

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -618,6 +618,7 @@ describe('validateMeasureLookupTable', () => {
       )) as ViewErrDTO;
 
       expect(result.status).toBe(400);
+      expect(result.errors[0].message.key).toBe('errors.measure_validation.no_description_columns');
       expect(mockDuckdbRun).not.toHaveBeenCalled();
     });
 
@@ -992,6 +993,7 @@ describe('validateMeasureLookupTable', () => {
       )) as ViewErrDTO;
 
       expect(result.status).toBe(400);
+      expect(result.errors[0].message.key).toBe('errors.measure_validation.unknown_matcher_column');
       expect(mockDuckdbRun).not.toHaveBeenCalled();
     });
 

--- a/test/unit/services/measure-handler.test.ts
+++ b/test/unit/services/measure-handler.test.ts
@@ -600,6 +600,27 @@ describe('validateMeasureLookupTable', () => {
       expect(result.errors[0].message.key).toBe('errors.measure_validation.no_description_columns');
     });
 
+    it('returns 400 error when a table matcher supplies an empty description_columns array', async () => {
+      // Truthy but empty array: without an explicit length check this bypasses the
+      // "no description columns" guard and previously blew up later on descriptionColumns[0].name.
+      const emptyDescriptionsMatcher: MeasureLookupPatchDTO = {
+        description_columns: [],
+        language_column: 'lang_col'
+      };
+      const dataset = makeDataset();
+
+      const result = (await validateMeasureLookupTable(
+        validProtoTable,
+        dataset,
+        '/tmp/file.csv',
+        'en-GB',
+        emptyDescriptionsMatcher
+      )) as ViewErrDTO;
+
+      expect(result.status).toBe(400);
+      expect(mockDuckdbRun).not.toHaveBeenCalled();
+    });
+
     it('returns 400 error when lookForJoinColumn throws', async () => {
       const dataset = makeDataset();
       (lookForJoinColumn as jest.Mock).mockImplementationOnce(() => {

--- a/test/unit/utils/lookup-table-utils.test.ts
+++ b/test/unit/utils/lookup-table-utils.test.ts
@@ -52,10 +52,12 @@ describe('lookForJoinColumn', () => {
     expect(result).toBe('ref_code');
   });
 
-  it('throws when the matcher-supplied join_column does not match any uploaded header', () => {
+  it('throws the unknown_matcher_column key when the matcher-supplied join_column does not match any uploaded header', () => {
     const tableMatcher: MeasureLookupPatchDTO = { join_column: 'x" OR 1=1 --' };
 
-    expect(() => lookForJoinColumn(protoLookupTable, 'measure_col', Locale.English, tableMatcher)).toThrow();
+    expect(() => lookForJoinColumn(protoLookupTable, 'measure_col', Locale.English, tableMatcher)).toThrow(
+      'errors.measure_validation.unknown_matcher_column'
+    );
   });
 
   it('falls back to a column starting with "ref" when no matcher is supplied', () => {

--- a/test/unit/utils/lookup-table-utils.test.ts
+++ b/test/unit/utils/lookup-table-utils.test.ts
@@ -1,0 +1,66 @@
+jest.mock('i18next', () => ({
+  t: jest.fn((key: string) => {
+    const parts = key.split('.');
+    return parts[parts.length - 1] ?? key;
+  })
+}));
+
+jest.mock('../../../src/middleware/translation', () => ({
+  SUPPORTED_LOCALES: ['en-GB', 'cy-GB']
+}));
+
+import { lookForJoinColumn } from '../../../src/utils/lookup-table-utils';
+import { DataTable } from '../../../src/entities/dataset/data-table';
+import { DataTableDescription } from '../../../src/entities/dataset/data-table-description';
+import { FileType } from '../../../src/enums/file-type';
+import { Locale } from '../../../src/enums/locale';
+import { MeasureLookupPatchDTO } from '../../../src/dtos/measure-lookup-patch-dto';
+
+function makeDataTableDescription(columnName: string, idx = 0): DataTableDescription {
+  return {
+    id: 'dt-1',
+    columnName,
+    columnIndex: idx,
+    columnDatatype: 'VARCHAR',
+    factTableColumn: null
+  } as unknown as DataTableDescription;
+}
+
+function makeProtoLookupTable(descriptionColumnNames: string[]): DataTable {
+  return {
+    id: 'dt-1',
+    filename: 'lookup.csv',
+    originalFilename: 'lookup.csv',
+    mimeType: 'text/csv',
+    fileType: FileType.Csv,
+    encoding: 'utf-8',
+    hash: 'abc123',
+    dataTableDescriptions: descriptionColumnNames.map((name, i) => makeDataTableDescription(name, i)),
+    action: 'add',
+    sourceLocation: 'datalake'
+  } as unknown as DataTable;
+}
+
+describe('lookForJoinColumn', () => {
+  const protoLookupTable = makeProtoLookupTable(['ref_code', 'description_en']);
+
+  it('returns the matcher-supplied join_column when it matches an uploaded header', () => {
+    const tableMatcher: MeasureLookupPatchDTO = { join_column: 'ref_code' };
+
+    const result = lookForJoinColumn(protoLookupTable, 'measure_col', Locale.English, tableMatcher);
+
+    expect(result).toBe('ref_code');
+  });
+
+  it('throws when the matcher-supplied join_column does not match any uploaded header', () => {
+    const tableMatcher: MeasureLookupPatchDTO = { join_column: 'x" OR 1=1 --' };
+
+    expect(() => lookForJoinColumn(protoLookupTable, 'measure_col', Locale.English, tableMatcher)).toThrow();
+  });
+
+  it('falls back to a column starting with "ref" when no matcher is supplied', () => {
+    const result = lookForJoinColumn(protoLookupTable, 'measure_col', Locale.English);
+
+    expect(result).toBe('ref_code');
+  });
+});


### PR DESCRIPTION
createMeasureTable built DuckDB identifiers by interpolating user-supplied column names into raw template literals before passing them through pgformat's unescaped %s, letting an authenticated publisher break out of the quoting and inject arbitrary SQL (CWE-89). All column identifiers now go through pgformat's %I, and any matcher-supplied column name is checked against the uploaded file's actual headers before use. The measure lookup patch body is also now validated with a class-validator DTO via dtoValidator instead of an unchecked cast.