### PR TITLE
Fix stored XSS in pivot HTML output (SW-1305)

### DIFF
--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import { escape } from 'lodash';
 
 import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
 import { QueryStore } from '../entities/query-store';
@@ -321,7 +322,7 @@ async function pivotToHtml(
     return;
   }
   columnOrder.forEach((key) => {
-    res.write(`<th>${key}</th>`);
+    res.write(`<th>${escape(key)}</th>`);
   });
   res.write('</tr></thead><tbody>');
   for await (const rows of pivot.yieldRows()) {
@@ -330,9 +331,9 @@ async function pivotToHtml(
       columnMapping.forEach((srcIdx, i) => {
         const value = row[srcIdx];
         if (i === 0) {
-          res.write(`<th>${value === null ? '' : value}</th>`);
+          res.write(`<th>${value === null ? '' : escape(String(value))}</th>`);
         } else {
-          res.write(`<td>${value === null ? '' : value}</td>`);
+          res.write(`<td>${value === null ? '' : escape(String(value))}</td>`);
         }
       });
       res.write('</tr>');

--- a/test/unit/services/pivots.test.ts
+++ b/test/unit/services/pivots.test.ts
@@ -613,6 +613,29 @@ describe('pivots service', () => {
         expect(output).toContain('<tbody>');
         expect(output).toContain('</tbody>');
       });
+
+      it('escapes script tags and event handlers in cell values and headers (SW-1305 regression)', async () => {
+        const columns = ['Area', '<script>alert(1)</script>'];
+        const rows: DuckDBValue[][] = [['<img src=x onerror=alert(1)>', 'safe']];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Html });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+
+        expect(output).not.toContain('<script>alert(1)</script>');
+        expect(output).not.toContain('<img src=x onerror=alert(1)>');
+        expect(output).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+        expect(output).toContain('&lt;img src=x onerror=alert(1)&gt;');
+      });
     });
 
     describe('Frontend output', () => {


### PR DESCRIPTION
pivotToHtml wrote dataset cell values and column headers directly into <th>/<td> elements with no escaping, unlike the non-pivot HTML path which already uses lodash.escape. Since the pivot endpoint is reachable anonymously and the values are publisher-controlled, this let a <script>/<img onerror> payload placed in a dataset value or column label execute in any visitor's browser. Both headers and cell values are now escaped with lodash's escape before being written to the response.