### PR TITLE
SW-1309 Add nightly cleanup cron job to perform various bits of clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN npm ci --omit=dev
 # copy in the built application source from the builder image
 COPY --from=builder --chown=node:node /app/dist ./dist
 
+# install only production dependencies, then remove npm — it isn't needed at
+# runtime (CMD runs node directly), and its bundled node-tar is what Trivy
+# flags for CVE-2026-59873. Deleting it drops the vulnerable copy from the image.
+RUN npm ci --omit=dev && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 HEALTHCHECK --interval=60s --timeout=3s --start-period=30s --retries=3 \
     CMD curl --fail http://localhost:3000/healthcheck/ || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,13 @@ WORKDIR /app
 
 COPY package*.json ./
 
-# install only production dependencies
-RUN npm ci --omit=dev
+# install only production dependencies then remove tar from NPM as we won't
+# installing further packages from this point and its flagged for CVE-2026-59873.
+# Deleting it drops the vulnerable copy from the image.
+RUN npm ci --omit=dev && rm -rf /usr/local/lib/node_modules/npm/node_modules/tar
 
 # copy in the built application source from the builder image
 COPY --from=builder --chown=node:node /app/dist ./dist
-
-# install only production dependencies, then remove npm — it isn't needed at
-# runtime (CMD runs node directly), and its bundled node-tar is what Trivy
-# flags for CVE-2026-59873. Deleting it drops the vulnerable copy from the image.
-RUN npm ci --omit=dev && \
-    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=30s --retries=3 \
     CMD curl --fail http://localhost:3000/healthcheck/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /app
 
 COPY package*.json ./
 
-# install only production dependencies then remove tar from NPM as we won't
-# installing further packages from this point and its flagged for CVE-2026-59873.
+# install only production dependencies, then remove tar from npm as we won't be
+# installing further packages from this point and it's flagged for CVE-2026-59873.
 # Deleting it drops the vulnerable copy from the image.
 RUN npm ci --omit=dev && rm -rf /usr/local/lib/node_modules/npm/node_modules/tar
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "nanoid": "^5.1.6",
+        "node-cron": "^4.6.0",
         "openid-client": "^6.8.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -8827,6 +8828,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "nanoid": "^5.1.6",
+    "node-cron": "^4.6.0",
     "openid-client": "^6.8.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -114,6 +114,15 @@ export interface AppConfig {
   cube_builder: {
     preserve_failed: boolean;
   };
+  cron: {
+    enabled: boolean;
+    timezone: string;
+    nightlyCleanupSchedule: string;
+  };
+  cleanup: {
+    staleBuildTimeoutMs: number;
+    staleTempFileTimeoutMs: number;
+  };
 }
 
 // list any optional properties here so we can ignore missing values when we check the config on boot

--- a/src/config/envs/ci.ts
+++ b/src/config/envs/ci.ts
@@ -64,6 +64,9 @@ export function getCIConfig(): AppConfig {
     duckdb: {
       threads: 2,
       memory: '256MB'
+    },
+    cron: {
+      enabled: false
     }
   });
 }

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -125,12 +125,16 @@ export const getDefaultConfig = (): AppConfig => {
       nightlyCleanupSchedule: process.env.CRON_NIGHTLY_CLEANUP_SCHEDULE || '0 4 * * *'
     },
     cleanup: {
-      staleBuildTimeoutMs: process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS
-        ? parseInt(process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS, 10)
-        : 6 * 60 * 60 * 1000,
-      staleTempFileTimeoutMs: process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS
-        ? parseInt(process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS, 10)
-        : ONE_DAY_MS
+      staleBuildTimeoutMs:
+        process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS &&
+        Number.isFinite(Number(process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS))
+          ? Number(process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS)
+          : 6 * 60 * 60 * 1000,
+      staleTempFileTimeoutMs:
+        process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS &&
+        Number.isFinite(Number(process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS))
+          ? Number(process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS)
+          : ONE_DAY_MS
     }
   };
 };

--- a/src/config/envs/default.ts
+++ b/src/config/envs/default.ts
@@ -118,6 +118,19 @@ export const getDefaultConfig = (): AppConfig => {
     },
     cube_builder: {
       preserve_failed: false
+    },
+    cron: {
+      enabled: process.env.CRON_ENABLED ? process.env.CRON_ENABLED.toLowerCase() === 'true' : true,
+      timezone: process.env.CRON_TIMEZONE || 'Europe/London',
+      nightlyCleanupSchedule: process.env.CRON_NIGHTLY_CLEANUP_SCHEDULE || '0 4 * * *'
+    },
+    cleanup: {
+      staleBuildTimeoutMs: process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS
+        ? parseInt(process.env.CLEANUP_STALE_BUILD_TIMEOUT_MS, 10)
+        : 6 * 60 * 60 * 1000,
+      staleTempFileTimeoutMs: process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS
+        ? parseInt(process.env.CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS, 10)
+        : ONE_DAY_MS
     }
   };
 };

--- a/src/controllers/translation.ts
+++ b/src/controllers/translation.ts
@@ -14,7 +14,7 @@ import { EventLog } from '../entities/event-log';
 import { collectTranslations } from '../utils/collect-translations';
 import { DatasetRepository, withMetadataForTranslation } from '../repositories/dataset';
 import { TempFile } from '../interfaces/temp-file';
-import { uploadAvScan } from '../services/virus-scanner';
+import { cleanupTmpFile, uploadAvScan } from '../services/virus-scanner';
 import { createAllCubeFiles } from '../services/cube-builder';
 
 // imported translation filename can be constant as we overwrite each time it's imported
@@ -133,6 +133,8 @@ export const validateImport = async (req: Request, res: Response, next: NextFunc
     }
     logger.error(error, 'Error importing translations');
     next(new UnknownException());
+  } finally {
+    cleanupTmpFile(tmpFile);
   }
 };
 

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -1,0 +1,26 @@
+import { schedule } from 'node-cron';
+
+import { logger } from '../utils/logger';
+import { config } from '../config';
+import { runNightlyCleanup } from '../services/cleanup';
+
+export function startScheduledJobs(): void {
+  if (!config.cron.enabled) {
+    logger.info('cron: scheduled jobs disabled');
+    return;
+  }
+
+  const { nightlyCleanupSchedule, timezone } = config.cron;
+
+  const task = schedule(
+    nightlyCleanupSchedule,
+    () => runNightlyCleanup(config.cleanup.staleBuildTimeoutMs, config.cleanup.staleTempFileTimeoutMs),
+    { name: 'nightly-cleanup', timezone, noOverlap: true }
+  );
+
+  task.on('task:failed', ({ error }) => {
+    logger.error(error, 'cron: nightly cleanup job threw unexpectedly');
+  });
+
+  logger.info(`cron: nightly cleanup scheduled ("${nightlyCleanupSchedule}", ${timezone})`);
+}

--- a/src/repositories/build-log.ts
+++ b/src/repositories/build-log.ts
@@ -1,7 +1,7 @@
 import { publisherDataSource } from '../db/publisher-source';
 import { BuildLog } from '../entities/dataset/build-log';
 import { CubeBuildType } from '../enums/cube-build-type';
-import { And, FindManyOptions, In, Not } from 'typeorm';
+import { And, FindManyOptions, In, LessThan, Not } from 'typeorm';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 
 export const BuildLogRepository = publisherDataSource.getRepository(BuildLog).extend({
@@ -43,6 +43,17 @@ export const BuildLogRepository = publisherDataSource.getRepository(BuildLog).ex
   async getAllActiveBuilds(): Promise<BuildLog[]> {
     return BuildLog.find({
       where: { status: And(Not(CubeBuildStatus.Completed), Not(CubeBuildStatus.Failed)) }
+    });
+  },
+
+  // builds still active (not completed/failed) long after they started have almost certainly been
+  // abandoned by a process crash or restart, rather than genuinely still running
+  async getStuckBuilds(startedBefore: Date): Promise<BuildLog[]> {
+    return BuildLog.find({
+      where: {
+        status: And(Not(CubeBuildStatus.Completed), Not(CubeBuildStatus.Failed)),
+        startedAt: LessThan(startedBefore)
+      }
     });
   }
 });

--- a/src/repositories/dataset.ts
+++ b/src/repositories/dataset.ts
@@ -294,5 +294,17 @@ export const DatasetRepository = publisherDataSource.getRepository(Dataset).exte
     dataset.replacementDatasetId = null;
     dataset.replacementAutoRedirect = false;
     return await this.save(dataset);
+  },
+
+  // revision ids whose cube schema is still "live" for their dataset - the current draft being
+  // edited and/or the current published revision - as distinct from every other revision a dataset
+  // has ever had, whose cube schema is only kept around for historical record
+  async getActiveRevisionIds(): Promise<string[]> {
+    const rows: { revision_id: string }[] = await this.query(
+      `SELECT draft_revision_id AS revision_id FROM dataset WHERE draft_revision_id IS NOT NULL
+       UNION
+       SELECT published_revision_id AS revision_id FROM dataset WHERE published_revision_id IS NOT NULL`
+    );
+    return rows.map((row) => row.revision_id);
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import app from './app';
 import { logger } from './utils/logger';
 import { initPassport } from './middleware/passport-auth';
 import { dbManager } from './db/database-manager';
+import { startScheduledJobs } from './jobs/scheduler';
 
 // Without these, an unawaited promise rejection (e.g. an abandoned pg pool acquisition)
 // terminates the process under Node's default --unhandled-rejections=throw, with no log
@@ -27,6 +28,7 @@ Promise.resolve()
     await dbManager.initDataSources();
     await dbManager.initEntitySubscriber();
     await initPassport();
+    startScheduledJobs();
   })
   .then(() => {
     app.listen(PORT, async () => {

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -136,7 +136,7 @@ export async function cleanupSupersededMaterializedViews(): Promise<void> {
 
       for (const { schemaname, matviewname } of staleMatviews) {
         try {
-          await cubeRunner.query(pgformat('DROP MATERIALIZED VIEW IF EXISTS %I.%I', schemaname, matviewname));
+          await cubeRunner.query(pgformat('DROP MATERIALIZED VIEW IF EXISTS %I.%I CASCADE', schemaname, matviewname));
         } catch (err) {
           logger.error(err, `cleanup: failed to drop materialized view ${schemaname}.${matviewname}`);
         }

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -113,8 +113,8 @@ export async function cleanupSupersededMaterializedViews(): Promise<void> {
     const cubeRunner = dbManager.getCubeDataSource().createQueryRunner();
     try {
       const matviews: { schemaname: string; matviewname: string }[] = await cubeRunner.query(
-        `SELECT schemaname, matviewname FROM pg_matviews WHERE matviewname LIKE $1`,
-        ['core_view_mat_%']
+        `SELECT schemaname, matviewname FROM pg_matviews WHERE matviewname LIKE $1 ESCAPE '\\'`,
+        ['core\\_view\\_mat\\_%']
       );
 
       const staleMatviews = matviews.filter((matview) => !keepSchemas.has(matview.schemaname));

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -142,9 +142,7 @@ export async function cleanupSupersededMaterializedViews(): Promise<void> {
         }
       }
     } finally {
-      await cubeRunner
-        .release()
-        .catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
+      await cubeRunner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
     }
   });
 }

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -6,7 +6,9 @@ import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
 
 import { logger } from '../utils/logger';
 import { dbManager } from '../db/database-manager';
+import { withAdvisoryLock } from '../utils/advisory-lock';
 import { BuildLogRepository } from '../repositories/build-log';
+import { DatasetRepository } from '../repositories/dataset';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 import { CubeBuildType } from '../enums/cube-build-type';
 
@@ -21,6 +23,10 @@ const UNRENAMED_BUILD_STATUSES = [CubeBuildStatus.Queued, CubeBuildStatus.Buildi
 // files written by the AV scanner (src/services/virus-scanner.ts) directly into the OS temp dir,
 // named as 32 hex chars with no extension - anything else in the temp dir is left alone
 const TMP_FILENAME_PATTERN = /^[0-9a-f]{32}$/;
+
+// arbitrary constant identifying this job's advisory lock; only needs to be unique among any
+// other advisory locks this app takes out (there are none today)
+const MATERIALIZED_VIEW_CLEANUP_LOCK_KEY = 8234179;
 
 export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<void> {
   const cutoff = new Date(Date.now() - staleAfterMs);
@@ -91,12 +97,56 @@ export async function cleanupStaleTempFiles(staleAfterMs: number): Promise<void>
   }
 }
 
+// drops the materialized views (core_view_mat_<lang>) for revision cube schemas that are no
+// longer a dataset's current draft or published revision. The underlying schema and its base
+// tables are left in place - only the materialized view is removed - so this does not affect the
+// public API (which only ever reads the current published revision), but it does mean an editor
+// can no longer preview/download that specific superseded revision until its cube is rebuilt.
+// Runs behind an advisory lock since every app replica shares one Postgres database and would
+// otherwise all perform the same (harmless but wasteful) work concurrently.
+export async function cleanupSupersededMaterializedViews(): Promise<void> {
+  await withAdvisoryLock(dbManager.getPublisherDataSource(), MATERIALIZED_VIEW_CLEANUP_LOCK_KEY, async () => {
+    const keepSchemas = new Set(await DatasetRepository.getActiveRevisionIds());
+
+    const cubeRunner = dbManager.getCubeDataSource().createQueryRunner();
+    try {
+      const matviews: { schemaname: string; matviewname: string }[] = await cubeRunner.query(
+        `SELECT schemaname, matviewname FROM pg_matviews WHERE matviewname LIKE $1`,
+        ['core_view_mat_%']
+      );
+
+      const staleMatviews = matviews.filter((matview) => !keepSchemas.has(matview.schemaname));
+
+      if (staleMatviews.length === 0) {
+        logger.info('cleanup: no superseded cube materialized views found');
+        return;
+      }
+
+      const staleSchemaCount = new Set(staleMatviews.map((matview) => matview.schemaname)).size;
+      logger.warn(
+        `cleanup: dropping ${staleMatviews.length} materialized view(s) across ${staleSchemaCount} superseded revision(s)`
+      );
+
+      for (const { schemaname, matviewname } of staleMatviews) {
+        try {
+          await cubeRunner.query(pgformat('DROP MATERIALIZED VIEW IF EXISTS %I.%I', schemaname, matviewname));
+        } catch (err) {
+          logger.error(err, `cleanup: failed to drop materialized view ${schemaname}.${matviewname}`);
+        }
+      }
+    } finally {
+      void cubeRunner.release();
+    }
+  });
+}
+
 export async function runNightlyCleanup(staleBuildTimeoutMs: number, staleTempFileTimeoutMs: number): Promise<void> {
   logger.info('cleanup: starting nightly cleanup job');
 
   const results = await Promise.allSettled([
     cleanupOrphanedCubeBuilds(staleBuildTimeoutMs),
-    cleanupStaleTempFiles(staleTempFileTimeoutMs)
+    cleanupStaleTempFiles(staleTempFileTimeoutMs),
+    cleanupSupersededMaterializedViews()
   ]);
 
   for (const result of results) {

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -1,0 +1,109 @@
+import os from 'node:os';
+import path from 'node:path';
+import { readdir, stat, unlink } from 'node:fs/promises';
+
+import { format as pgformat } from '@scaleleap/pg-format/lib/pg-format';
+
+import { logger } from '../utils/logger';
+import { dbManager } from '../db/database-manager';
+import { BuildLogRepository } from '../repositories/build-log';
+import { CubeBuildStatus } from '../enums/cube-build-status';
+import { CubeBuildType } from '../enums/cube-build-type';
+
+// only these build types create a cube schema named after their own build id; bulk orchestrator
+// builds (AllCubes/DraftCubes/AllFilterTables) have no schema of their own to drop
+const SCHEMA_OWNING_BUILD_TYPES = [CubeBuildType.BaseCube, CubeBuildType.ValidationCube, CubeBuildType.FullCube];
+
+// schema is renamed from the build id to the revision id once building finishes (see cube-builder.ts),
+// so a build stuck in one of these earlier statuses still owns a schema named after its build id
+const UNRENAMED_BUILD_STATUSES = [CubeBuildStatus.Queued, CubeBuildStatus.Building, CubeBuildStatus.SchemaRename];
+
+// files written by the AV scanner (src/services/virus-scanner.ts) directly into the OS temp dir,
+// named as 32 hex chars with no extension - anything else in the temp dir is left alone
+const TMP_FILENAME_PATTERN = /^[0-9a-f]{32}$/;
+
+export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<void> {
+  const cutoff = new Date(Date.now() - staleAfterMs);
+  const stuckBuilds = await BuildLogRepository.getStuckBuilds(cutoff);
+
+  if (stuckBuilds.length === 0) {
+    logger.info('cleanup: no orphaned cube builds found');
+    return;
+  }
+
+  logger.warn(`cleanup: found ${stuckBuilds.length} orphaned cube build(s) started before ${cutoff.toISOString()}`);
+
+  for (const build of stuckBuilds) {
+    if (SCHEMA_OWNING_BUILD_TYPES.includes(build.type) && UNRENAMED_BUILD_STATUSES.includes(build.status)) {
+      const runner = dbManager.getCubeDataSource().createQueryRunner();
+      try {
+        await runner.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', build.id));
+        logger.info(`cleanup: dropped orphaned cube schema for build ${build.id}`);
+      } catch (err) {
+        logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
+      } finally {
+        void runner.release();
+      }
+    }
+
+    build.completeBuild(
+      CubeBuildStatus.Failed,
+      undefined,
+      'Build timed out and was reconciled by the nightly cleanup job'
+    );
+    await build.save();
+  }
+}
+
+export async function cleanupStaleTempFiles(staleAfterMs: number): Promise<void> {
+  const tmpDir = os.tmpdir();
+  const cutoff = Date.now() - staleAfterMs;
+
+  let entries: string[];
+  try {
+    entries = await readdir(tmpDir);
+  } catch (err) {
+    logger.error(err, `cleanup: failed to read temp directory ${tmpDir}`);
+    return;
+  }
+
+  let removed = 0;
+
+  for (const entry of entries) {
+    if (!TMP_FILENAME_PATTERN.test(entry)) continue;
+
+    const filePath = path.join(tmpDir, entry);
+
+    try {
+      const stats = await stat(filePath);
+      if (!stats.isFile() || stats.mtimeMs > cutoff) continue;
+      await unlink(filePath);
+      removed++;
+    } catch {
+      // may already have been cleaned up by the request that created it - ignore
+    }
+  }
+
+  if (removed > 0) {
+    logger.info(`cleanup: removed ${removed} stale temp file(s) from ${tmpDir}`);
+  } else {
+    logger.info('cleanup: no stale temp files found');
+  }
+}
+
+export async function runNightlyCleanup(staleBuildTimeoutMs: number, staleTempFileTimeoutMs: number): Promise<void> {
+  logger.info('cleanup: starting nightly cleanup job');
+
+  const results = await Promise.allSettled([
+    cleanupOrphanedCubeBuilds(staleBuildTimeoutMs),
+    cleanupStaleTempFiles(staleTempFileTimeoutMs)
+  ]);
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      logger.error(result.reason, 'cleanup: a nightly cleanup task failed');
+    }
+  }
+
+  logger.info('cleanup: nightly cleanup job complete');
+}

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -43,27 +43,29 @@ export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<v
 
     logger.warn(`cleanup: found ${stuckBuilds.length} orphaned cube build(s) started before ${cutoff.toISOString()}`);
 
-    for (const build of stuckBuilds) {
-      if (SCHEMA_OWNING_BUILD_TYPES.includes(build.type) && UNRENAMED_BUILD_STATUSES.includes(build.status)) {
-        const runner = dbManager.getCubeDataSource().createQueryRunner();
-        try {
-          await runner.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', build.id));
-          logger.info(`cleanup: dropped orphaned cube schema for build ${build.id}`);
-        } catch (err) {
-          logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
-        } finally {
-          await runner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
+    const cubeRunner = dbManager.getCubeDataSource().createQueryRunner();
+    try {
+      for (const build of stuckBuilds) {
+        if (SCHEMA_OWNING_BUILD_TYPES.includes(build.type) && UNRENAMED_BUILD_STATUSES.includes(build.status)) {
+          try {
+            await cubeRunner.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', build.id));
+            logger.info(`cleanup: dropped orphaned cube schema for build ${build.id}`);
+          } catch (err) {
+            logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
+          }
         }
-      }
 
-      build.completeBuild(
-        CubeBuildStatus.Failed,
-        undefined,
-        'Build timed out and was reconciled by the nightly cleanup job'
-      );
-      await build
-        .save()
-        .catch((err) => logger.error(err, `cleanup: failed to persist failed status for build ${build.id}`));
+        build.completeBuild(
+          CubeBuildStatus.Failed,
+          undefined,
+          'Build timed out and was reconciled by the nightly cleanup job'
+        );
+        await build
+          .save()
+          .catch((err) => logger.error(err, `cleanup: failed to persist failed status for build ${build.id}`));
+      }
+    } finally {
+      await cubeRunner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
     }
   });
 }

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -142,7 +142,9 @@ export async function cleanupSupersededMaterializedViews(): Promise<void> {
         }
       }
     } finally {
-      void cubeRunner.release();
+      await cubeRunner
+        .release()
+        .catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
     }
   });
 }

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -24,43 +24,48 @@ const UNRENAMED_BUILD_STATUSES = [CubeBuildStatus.Queued, CubeBuildStatus.Buildi
 // named as 32 hex chars with no extension - anything else in the temp dir is left alone
 const TMP_FILENAME_PATTERN = /^[0-9a-f]{32}$/;
 
-// arbitrary constant identifying this job's advisory lock; only needs to be unique among any
-// other advisory locks this app takes out (there are none today)
+// arbitrary constants identifying each job's advisory lock; only need to be unique among any
+// other advisory locks this app takes out
+const ORPHANED_BUILD_CLEANUP_LOCK_KEY = 8234178;
 const MATERIALIZED_VIEW_CLEANUP_LOCK_KEY = 8234179;
 
+// Runs behind an advisory lock since every app replica shares one Postgres database and would
+// otherwise all race to reconcile (and drop cube schemas for) the same stuck builds concurrently.
 export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<void> {
-  const cutoff = new Date(Date.now() - staleAfterMs);
-  const stuckBuilds = await BuildLogRepository.getStuckBuilds(cutoff);
+  await withAdvisoryLock(dbManager.getPublisherDataSource(), ORPHANED_BUILD_CLEANUP_LOCK_KEY, async () => {
+    const cutoff = new Date(Date.now() - staleAfterMs);
+    const stuckBuilds = await BuildLogRepository.getStuckBuilds(cutoff);
 
-  if (stuckBuilds.length === 0) {
-    logger.info('cleanup: no orphaned cube builds found');
-    return;
-  }
-
-  logger.warn(`cleanup: found ${stuckBuilds.length} orphaned cube build(s) started before ${cutoff.toISOString()}`);
-
-  for (const build of stuckBuilds) {
-    if (SCHEMA_OWNING_BUILD_TYPES.includes(build.type) && UNRENAMED_BUILD_STATUSES.includes(build.status)) {
-      const runner = dbManager.getCubeDataSource().createQueryRunner();
-      try {
-        await runner.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', build.id));
-        logger.info(`cleanup: dropped orphaned cube schema for build ${build.id}`);
-      } catch (err) {
-        logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
-      } finally {
-        await runner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
-      }
+    if (stuckBuilds.length === 0) {
+      logger.info('cleanup: no orphaned cube builds found');
+      return;
     }
 
-    build.completeBuild(
-      CubeBuildStatus.Failed,
-      undefined,
-      'Build timed out and was reconciled by the nightly cleanup job'
-    );
-    await build
-      .save()
-      .catch((err) => logger.error(err, `cleanup: failed to persist failed status for build ${build.id}`));
-  }
+    logger.warn(`cleanup: found ${stuckBuilds.length} orphaned cube build(s) started before ${cutoff.toISOString()}`);
+
+    for (const build of stuckBuilds) {
+      if (SCHEMA_OWNING_BUILD_TYPES.includes(build.type) && UNRENAMED_BUILD_STATUSES.includes(build.status)) {
+        const runner = dbManager.getCubeDataSource().createQueryRunner();
+        try {
+          await runner.query(pgformat('DROP SCHEMA IF EXISTS %I CASCADE', build.id));
+          logger.info(`cleanup: dropped orphaned cube schema for build ${build.id}`);
+        } catch (err) {
+          logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
+        } finally {
+          await runner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
+        }
+      }
+
+      build.completeBuild(
+        CubeBuildStatus.Failed,
+        undefined,
+        'Build timed out and was reconciled by the nightly cleanup job'
+      );
+      await build
+        .save()
+        .catch((err) => logger.error(err, `cleanup: failed to persist failed status for build ${build.id}`));
+    }
+  });
 }
 
 export async function cleanupStaleTempFiles(staleAfterMs: number): Promise<void> {

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -57,7 +57,9 @@ export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<v
       undefined,
       'Build timed out and was reconciled by the nightly cleanup job'
     );
-    await build.save();
+    await build
+      .save()
+      .catch((err) => logger.error(err, `cleanup: failed to persist failed status for build ${build.id}`));
   }
 }
 

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -48,7 +48,7 @@ export async function cleanupOrphanedCubeBuilds(staleAfterMs: number): Promise<v
       } catch (err) {
         logger.error(err, `cleanup: failed to drop orphaned cube schema for build ${build.id}`);
       } finally {
-        void runner.release();
+        await runner.release().catch((err) => logger.error(err, 'cleanup: failed to release cube query runner'));
       }
     }
 

--- a/src/utils/advisory-lock.ts
+++ b/src/utils/advisory-lock.ts
@@ -27,9 +27,11 @@ export async function withAdvisoryLock<T>(
     try {
       return await fn();
     } finally {
-      await runner.query('SELECT pg_advisory_unlock($1)', [lockKey]);
+      await runner
+        .query('SELECT pg_advisory_unlock($1)', [lockKey])
+        .catch((err) => logger.error(err, `advisory-lock: failed to release lock ${lockKey}`));
     }
   } finally {
-    await runner.release();
+    await runner.release().catch((err) => logger.error(err, 'advisory-lock: failed to release query runner'));
   }
 }

--- a/src/utils/advisory-lock.ts
+++ b/src/utils/advisory-lock.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+
+import { logger } from './logger';
+
+// A Postgres session-level advisory lock, held on a single dedicated connection for the
+// duration of `fn`. When multiple app replicas share one Postgres database, only the replica
+// that wins pg_try_advisory_lock runs `fn`; the rest skip it and return undefined. No TTL or
+// heartbeat bookkeeping is needed - Postgres releases the lock itself if the connection drops
+// (crash, restart), so it can never be left stuck held.
+export async function withAdvisoryLock<T>(
+  dataSource: DataSource,
+  lockKey: number,
+  fn: () => Promise<T>
+): Promise<T | undefined> {
+  const runner = dataSource.createQueryRunner();
+
+  try {
+    const [{ locked }]: [{ locked: boolean }] = await runner.query('SELECT pg_try_advisory_lock($1) AS locked', [
+      lockKey
+    ]);
+
+    if (!locked) {
+      logger.info(`advisory-lock: lock ${lockKey} is held by another replica, skipping`);
+      return undefined;
+    }
+
+    try {
+      return await fn();
+    } finally {
+      await runner.query('SELECT pg_advisory_unlock($1)', [lockKey]);
+    }
+  } finally {
+    await runner.release();
+  }
+}

--- a/test/unit/controllers/translation.test.ts
+++ b/test/unit/controllers/translation.test.ts
@@ -32,8 +32,10 @@ jest.mock('../../../src/entities/event-log', () => ({
 }));
 
 const mockUploadAvScan = jest.fn();
+const mockCleanupTmpFile = jest.fn();
 jest.mock('../../../src/services/virus-scanner', () => ({
-  uploadAvScan: (...args: unknown[]) => mockUploadAvScan(...args)
+  uploadAvScan: (...args: unknown[]) => mockUploadAvScan(...args),
+  cleanupTmpFile: (...args: unknown[]) => mockCleanupTmpFile(...args)
 }));
 
 const mockCreateAllCubeFiles = jest.fn();
@@ -183,6 +185,7 @@ describe('Translation controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({ id: dataset.id });
       expect(mockNext).not.toHaveBeenCalled();
+      expect(mockCleanupTmpFile).toHaveBeenCalledWith({ path: '/tmp/import.csv' });
     });
 
     it('forwards the av-scan error to next when the upload fails', async () => {
@@ -214,6 +217,7 @@ describe('Translation controller', () => {
       expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
       expect((mockNext.mock.calls[0][0] as unknown as Error).message).toBe('errors.translation_file.invalid.row_count');
       expect((req as any).fileService.saveStream).not.toHaveBeenCalled();
+      expect(mockCleanupTmpFile).toHaveBeenCalledWith({ path: '/tmp/import.csv' });
     });
 
     it('rejects with a keys error when a translation key is missing from the CSV', async () => {

--- a/test/unit/services/cleanup.test.ts
+++ b/test/unit/services/cleanup.test.ts
@@ -16,13 +16,26 @@ jest.mock('../../../src/db/database-manager', () => ({
   dbManager: {
     getCubeDataSource: jest.fn(() => ({
       createQueryRunner: jest.fn(() => ({ query: mockQuery, release: mockRelease }))
-    }))
+    })),
+    getPublisherDataSource: jest.fn()
   }
+}));
+
+// the lock's own acquire/release behaviour is covered by test/unit/utils/advisory-lock.test.ts;
+// here we only care that the wrapped work runs
+jest.mock('../../../src/utils/advisory-lock', () => ({
+  withAdvisoryLock: (_dataSource: unknown, _lockKey: number, fn: () => Promise<unknown>) => fn()
 }));
 
 jest.mock('../../../src/repositories/build-log', () => ({
   BuildLogRepository: {
     getStuckBuilds: jest.fn()
+  }
+}));
+
+jest.mock('../../../src/repositories/dataset', () => ({
+  DatasetRepository: {
+    getActiveRevisionIds: jest.fn()
   }
 }));
 
@@ -40,8 +53,13 @@ jest.mock('node:os', () => ({
 
 import { readdir, stat, unlink } from 'node:fs/promises';
 
-import { cleanupOrphanedCubeBuilds, cleanupStaleTempFiles } from '../../../src/services/cleanup';
+import {
+  cleanupOrphanedCubeBuilds,
+  cleanupStaleTempFiles,
+  cleanupSupersededMaterializedViews
+} from '../../../src/services/cleanup';
 import { BuildLogRepository } from '../../../src/repositories/build-log';
+import { DatasetRepository } from '../../../src/repositories/dataset';
 import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
 import { CubeBuildType } from '../../../src/enums/cube-build-type';
 
@@ -128,5 +146,39 @@ describe('cleanupStaleTempFiles', () => {
 
     await expect(cleanupStaleTempFiles(500)).resolves.not.toThrow();
     expect(unlink).not.toHaveBeenCalled();
+  });
+});
+
+describe('cleanupSupersededMaterializedViews', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('drops materialized views for schemas that are not a current draft or published revision', async () => {
+    (DatasetRepository.getActiveRevisionIds as jest.Mock).mockResolvedValue(['draft-rev', 'published-rev']);
+    mockQuery.mockResolvedValueOnce([
+      { schemaname: 'draft-rev', matviewname: 'core_view_mat_en' },
+      { schemaname: 'published-rev', matviewname: 'core_view_mat_en' },
+      { schemaname: 'old-rev', matviewname: 'core_view_mat_en' },
+      { schemaname: 'old-rev', matviewname: 'core_view_mat_cy' }
+    ]);
+
+    await cleanupSupersededMaterializedViews();
+
+    const dropCalls = mockQuery.mock.calls.filter(([sql]) => sql.startsWith('DROP MATERIALIZED VIEW'));
+    expect(dropCalls).toHaveLength(2);
+    expect(dropCalls.map(([sql]) => sql)).toEqual([
+      expect.stringContaining('old-rev'),
+      expect.stringContaining('old-rev')
+    ]);
+    expect(dropCalls.some(([sql]) => sql.includes('draft-rev'))).toBe(false);
+    expect(dropCalls.some(([sql]) => sql.includes('published-rev'))).toBe(false);
+  });
+
+  it('does nothing when every materialized view belongs to a current draft or published revision', async () => {
+    (DatasetRepository.getActiveRevisionIds as jest.Mock).mockResolvedValue(['draft-rev']);
+    mockQuery.mockResolvedValueOnce([{ schemaname: 'draft-rev', matviewname: 'core_view_mat_en' }]);
+
+    await cleanupSupersededMaterializedViews();
+
+    expect(mockQuery.mock.calls.some(([sql]) => sql.startsWith('DROP MATERIALIZED VIEW'))).toBe(false);
   });
 });

--- a/test/unit/services/cleanup.test.ts
+++ b/test/unit/services/cleanup.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../src/utils/logger', () => ({
 }));
 
 const mockQuery = jest.fn();
-const mockRelease = jest.fn();
+const mockRelease = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../../src/db/database-manager', () => ({
   dbManager: {
@@ -71,7 +71,7 @@ describe('cleanupOrphanedCubeBuilds', () => {
     type: CubeBuildType.FullCube,
     status: CubeBuildStatus.Building,
     completeBuild: jest.fn(),
-    save: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
     ...overrides
   });
 

--- a/test/unit/services/cleanup.test.ts
+++ b/test/unit/services/cleanup.test.ts
@@ -1,0 +1,132 @@
+// --- Mock setup (must come before imports) ---
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+
+jest.mock('../../../src/db/database-manager', () => ({
+  dbManager: {
+    getCubeDataSource: jest.fn(() => ({
+      createQueryRunner: jest.fn(() => ({ query: mockQuery, release: mockRelease }))
+    }))
+  }
+}));
+
+jest.mock('../../../src/repositories/build-log', () => ({
+  BuildLogRepository: {
+    getStuckBuilds: jest.fn()
+  }
+}));
+
+jest.mock('node:fs/promises', () => ({
+  readdir: jest.fn(),
+  stat: jest.fn(),
+  unlink: jest.fn()
+}));
+
+jest.mock('node:os', () => ({
+  tmpdir: jest.fn(() => '/tmp')
+}));
+
+// --- Imports after mocks ---
+
+import { readdir, stat, unlink } from 'node:fs/promises';
+
+import { cleanupOrphanedCubeBuilds, cleanupStaleTempFiles } from '../../../src/services/cleanup';
+import { BuildLogRepository } from '../../../src/repositories/build-log';
+import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
+import { CubeBuildType } from '../../../src/enums/cube-build-type';
+
+describe('cleanupOrphanedCubeBuilds', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  const makeBuild = (overrides: Partial<{ id: string; type: CubeBuildType; status: CubeBuildStatus }> = {}) => ({
+    id: 'build-id',
+    type: CubeBuildType.FullCube,
+    status: CubeBuildStatus.Building,
+    completeBuild: jest.fn(),
+    save: jest.fn(),
+    ...overrides
+  });
+
+  it('does nothing when there are no stuck builds', async () => {
+    (BuildLogRepository.getStuckBuilds as jest.Mock).mockResolvedValue([]);
+
+    await cleanupOrphanedCubeBuilds(1000);
+
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('drops the schema and fails the build when a schema-owning build is stuck before rename', async () => {
+    const build = makeBuild({ type: CubeBuildType.FullCube, status: CubeBuildStatus.Building });
+    (BuildLogRepository.getStuckBuilds as jest.Mock).mockResolvedValue([build]);
+
+    await cleanupOrphanedCubeBuilds(1000);
+
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('DROP SCHEMA IF EXISTS'));
+    expect(mockQuery.mock.calls[0][0]).toContain('build-id');
+    expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+    expect(build.save).toHaveBeenCalled();
+  });
+
+  it('does not drop a schema for a build stuck after the schema was already renamed', async () => {
+    const build = makeBuild({ type: CubeBuildType.FullCube, status: CubeBuildStatus.Materializing });
+    (BuildLogRepository.getStuckBuilds as jest.Mock).mockResolvedValue([build]);
+
+    await cleanupOrphanedCubeBuilds(1000);
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+  });
+
+  it('does not attempt a schema drop for bulk orchestrator build types', async () => {
+    const build = makeBuild({ type: CubeBuildType.AllCubes, status: CubeBuildStatus.Building });
+    (BuildLogRepository.getStuckBuilds as jest.Mock).mockResolvedValue([build]);
+
+    await cleanupOrphanedCubeBuilds(1000);
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(build.completeBuild).toHaveBeenCalledWith(CubeBuildStatus.Failed, undefined, expect.any(String));
+  });
+});
+
+describe('cleanupStaleTempFiles', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('only removes files matching the AV-scanner naming pattern that are older than the cutoff', async () => {
+    (readdir as jest.Mock).mockResolvedValue([
+      'a1b2c3d4e5f60718293a4b5c6d7e8f90', // matches pattern, stale
+      'a1b2c3d4e5f60718293a4b5c6d7e8f91', // matches pattern, fresh
+      'not-a-hex-name.txt', // does not match pattern
+      'duckdb_temp' // does not match pattern
+    ]);
+
+    const now = Date.now();
+    (stat as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath.endsWith('f90')) {
+        return Promise.resolve({ isFile: () => true, mtimeMs: now - 1000 });
+      }
+      return Promise.resolve({ isFile: () => true, mtimeMs: now });
+    });
+
+    await cleanupStaleTempFiles(500);
+
+    expect(unlink).toHaveBeenCalledTimes(1);
+    expect((unlink as jest.Mock).mock.calls[0][0]).toContain('f90');
+  });
+
+  it('does not throw when the temp directory cannot be read', async () => {
+    (readdir as jest.Mock).mockRejectedValue(new Error('permission denied'));
+
+    await expect(cleanupStaleTempFiles(500)).resolves.not.toThrow();
+    expect(unlink).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/utils/advisory-lock.test.ts
+++ b/test/unit/utils/advisory-lock.test.ts
@@ -13,7 +13,7 @@ describe('withAdvisoryLock', () => {
   });
 
   it('runs the callback and releases the lock when it acquires the lock', async () => {
-    const release = jest.fn();
+    const release = jest.fn().mockResolvedValue(undefined);
     const query = jest
       .fn()
       .mockResolvedValueOnce([{ locked: true }]) // pg_try_advisory_lock
@@ -31,7 +31,7 @@ describe('withAdvisoryLock', () => {
   });
 
   it('skips the callback and returns undefined when the lock is held elsewhere', async () => {
-    const release = jest.fn();
+    const release = jest.fn().mockResolvedValue(undefined);
     const query = jest.fn().mockResolvedValueOnce([{ locked: false }]);
     const dataSource = makeDataSource(query, release) as any;
     const fn = jest.fn();
@@ -45,7 +45,7 @@ describe('withAdvisoryLock', () => {
   });
 
   it('still releases the lock and the connection when the callback throws', async () => {
-    const release = jest.fn();
+    const release = jest.fn().mockResolvedValue(undefined);
     const query = jest
       .fn()
       .mockResolvedValueOnce([{ locked: true }])

--- a/test/unit/utils/advisory-lock.test.ts
+++ b/test/unit/utils/advisory-lock.test.ts
@@ -1,0 +1,61 @@
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+import { withAdvisoryLock } from '../../../src/utils/advisory-lock';
+
+describe('withAdvisoryLock', () => {
+  const makeDataSource = (query: jest.Mock, release: jest.Mock) => ({
+    createQueryRunner: jest.fn(() => ({ query, release }))
+  });
+
+  it('runs the callback and releases the lock when it acquires the lock', async () => {
+    const release = jest.fn();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ locked: true }]) // pg_try_advisory_lock
+      .mockResolvedValueOnce(undefined); // pg_advisory_unlock
+    const dataSource = makeDataSource(query, release) as any;
+    const fn = jest.fn().mockResolvedValue('result');
+
+    const result = await withAdvisoryLock(dataSource, 123, fn);
+
+    expect(result).toBe('result');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenNthCalledWith(1, 'SELECT pg_try_advisory_lock($1) AS locked', [123]);
+    expect(query).toHaveBeenNthCalledWith(2, 'SELECT pg_advisory_unlock($1)', [123]);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the callback and returns undefined when the lock is held elsewhere', async () => {
+    const release = jest.fn();
+    const query = jest.fn().mockResolvedValueOnce([{ locked: false }]);
+    const dataSource = makeDataSource(query, release) as any;
+    const fn = jest.fn();
+
+    const result = await withAdvisoryLock(dataSource, 123, fn);
+
+    expect(result).toBeUndefined();
+    expect(fn).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('still releases the lock and the connection when the callback throws', async () => {
+    const release = jest.fn();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce(undefined);
+    const dataSource = makeDataSource(query, release) as any;
+    const fn = jest.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(withAdvisoryLock(dataSource, 123, fn)).rejects.toThrow('boom');
+
+    expect(query).toHaveBeenNthCalledWith(2, 'SELECT pg_advisory_unlock($1)', [123]);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a nightly (4am Europe/London) cron job, via `node-cron`, that runs three cleanup tasks:

- **Orphaned cube builds** — `BuildLog` rows stuck in a non-terminal state (`Queued`/`Building`/`SchemaRename`/`Materializing`) past a timeout are marked `Failed`; if the build's schema was never renamed to its final revision id, that leftover `cube_db.<buildId>` schema is dropped.
- **Stale temp files** — sweeps `os.tmpdir()` for files matching the AV-scanner's naming pattern (32 hex chars, no extension) older than 24h. Also fixes a real leak: `translation.ts`'s `validateImport` never called `cleanupTmpFile()`, so every translation CSV import left its temp file behind permanently.
- **Superseded materialized views** — drops `core_view_mat_<lang>` materialized views for revision cube schemas that are no longer a dataset's current draft or published revision (base tables and the schema itself are untouched). Runs behind a Postgres advisory lock (`src/utils/advisory-lock.ts`) so that when the app runs as multiple replicas sharing one Postgres database, only one replica does the work.

All three tasks are independent (`Promise.allSettled`) so a failure in one doesn't block the others. The schedule, timezone, and per-task staleness timeouts are configurable via env vars (`CRON_ENABLED`, `CRON_NIGHTLY_CLEANUP_SCHEDULE`, `CRON_TIMEZONE`, `CLEANUP_STALE_BUILD_TIMEOUT_MS`, `CLEANUP_STALE_TEMP_FILE_TIMEOUT_MS`); disabled in CI.

## Known tradeoff

Once a superseded revision's materialized view is dropped, that specific historical revision can no longer be previewed/downloaded via the editor's by-revision-id routes until its cube is rebuilt — there's no non-materialized fallback view once a build completes. The public consumer API is unaffected, since it only ever reads the current published revision.

## Test plan

- [x] `tsc --noEmit` and `eslint .` clean
- [x] New unit tests: orphaned-build cleanup (schema-owning vs bulk build types, pre/post-rename status), temp-file sweep (pattern + age filtering, unreadable dir), advisory lock (acquire/release, skip-when-held, release-on-throw), materialized-view cleanup (keeps current draft/published, drops the rest)
- [x] Fixed `translation.ts` temp-file-leak regression covered by updated `translation.test.ts`
- [x] Full unit suite passes (1287 tests)
- [ ] Manually verify against a real Postgres/replica setup in staging before relying on it in prod
