### PR TITLE
Update the Dockerfile to remove tar from npm node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ WORKDIR /app
 
 COPY package*.json ./
 
-# install only production dependencies
-RUN npm ci --omit=dev
+# install only production dependencies, then remove tar from npm as we won't be
+# installing further packages from this point and it's flagged for CVE-2026-59873.
+# Deleting it drops the vulnerable copy from the image.
+RUN npm ci --omit=dev && rm -rf /usr/local/lib/node_modules/npm/node_modules/tar
 
 # copy in the built application source from the builder image
 COPY --from=builder --chown=node:node /app/dist ./dist


### PR DESCRIPTION
There's a Trivy alert surround the version of tar bundled with NPM.  To fix the issue after we have finished installing packages we remove the tar module to satisfy Tricy.  The tar module is flagged in CVE-2026-59873.