### PR TITLE
Fix broken access control on build log endpoints (SW-1310)

### DIFF
--- a/src/controllers/build-log.ts
+++ b/src/controllers/build-log.ts
@@ -2,14 +2,27 @@ import { NextFunction, Request, Response } from 'express';
 import { BuildLog } from '../entities/dataset/build-log';
 import { BuiltLogEntryDto } from '../dtos/build-log';
 import { NotFoundException } from '../exceptions/not-found.exception';
+import { ForbiddenException } from '../exceptions/forbidden.exception';
 import { logger } from '../utils/logger';
 import { CubeBuildStatus } from '../enums/cube-build-status';
 import { CubeBuildType } from '../enums/cube-build-type';
+import { GlobalRole } from '../enums/global-role';
 import { BuildLogRepository } from '../repositories/build-log';
 import { buildStatusValidator, buildTypeValidator, hasError } from '../validators';
 import { BadRequestException } from '../exceptions/bad-request.exception';
+import { getUserGroupIdsForUser } from '../utils/get-permissions-for-user';
 
 export const getBuildLog = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const globalRoles = req.user?.globalRoles ?? [];
+  const isServiceAdminOrDeveloper =
+    globalRoles.includes(GlobalRole.ServiceAdmin) || globalRoles.includes(GlobalRole.Developer);
+
+  if (!isServiceAdminOrDeveloper) {
+    logger.warn(`User ${req.user?.id} is not a service admin or developer, denying access to the build log`);
+    next(new ForbiddenException('errors.build_log_not_permitted'));
+    return;
+  }
+
   const pageSize = req.query.size ? Number.parseInt(req.query.size as string) : 30;
   const pageNo = req.query.page ? Number.parseInt(req.query.page as string) * pageSize : 0;
   const typeError = req.query.type ? await hasError(buildTypeValidator(), req) : false;
@@ -39,11 +52,35 @@ export const getBuiltLogEntry = async (req: Request, res: Response): Promise<voi
   if (!buildId) {
     throw new NotFoundException('Build not found.');
   }
+
+  let build: BuildLog;
+
   try {
-    const build = await BuildLog.findOneByOrFail({ id: buildId });
-    res.status(200).send(BuiltLogEntryDto.fromBuildLogFull(build));
+    build = await BuildLog.findOneOrFail({
+      where: { id: buildId },
+      relations: { revision: { dataset: true } }
+    });
   } catch (err) {
     logger.warn(err, `Failed to get build log entry with id ${buildId}`);
     throw new NotFoundException('Build not found.');
   }
+
+  // when reached via the nested revision route, the build must belong to the revision
+  // the caller has already been authorised for (res.locals.revision_id is set by loadRevision)
+  if (res.locals.revision_id && build.revisionId !== res.locals.revision_id) {
+    throw new NotFoundException('Build not found.');
+  }
+
+  const datasetUserGroupId = build.revision?.dataset?.userGroupId;
+  const userGroupIds = getUserGroupIdsForUser(req.user!);
+  const isDeveloper = req.user?.globalRoles.includes(GlobalRole.Developer);
+
+  if (isDeveloper) {
+    logger.warn(`User ${req.user?.id} is a developer, skipping group permissions check`);
+  } else if (!datasetUserGroupId || !userGroupIds?.includes(datasetUserGroupId)) {
+    logger.warn(`User does not have access to build ${buildId}`);
+    throw new ForbiddenException('errors.dataset_not_in_users_groups');
+  }
+
+  res.status(200).send(BuiltLogEntryDto.fromBuildLogFull(build));
 };

--- a/test/unit/controllers/build-log.test.ts
+++ b/test/unit/controllers/build-log.test.ts
@@ -2,8 +2,12 @@ import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestException } from '../../../src/exceptions/bad-request.exception';
 import { NotFoundException } from '../../../src/exceptions/not-found.exception';
+import { ForbiddenException } from '../../../src/exceptions/forbidden.exception';
 import { CubeBuildStatus } from '../../../src/enums/cube-build-status';
 import { CubeBuildType } from '../../../src/enums/cube-build-type';
+import { GlobalRole } from '../../../src/enums/global-role';
+import { User } from '../../../src/entities/user/user';
+import { UserGroupRole } from '../../../src/entities/user/user-group-role';
 import { uuidV4 } from '../../../src/utils/uuid';
 
 jest.mock('../../../src/utils/logger', () => ({
@@ -17,10 +21,10 @@ jest.mock('../../../src/repositories/build-log', () => ({
   }
 }));
 
-const mockFindOneByOrFail = jest.fn();
+const mockFindOneOrFail = jest.fn();
 jest.mock('../../../src/entities/dataset/build-log', () => ({
   BuildLog: {
-    findOneByOrFail: (...args: unknown[]) => mockFindOneByOrFail(...args)
+    findOneOrFail: (...args: unknown[]) => mockFindOneOrFail(...args)
   }
 }));
 
@@ -43,12 +47,38 @@ jest.mock('../../../src/validators', () => ({
 
 import { getBuildLog, getBuiltLogEntry } from '../../../src/controllers/build-log';
 
-function createMockRequest(overrides: Partial<Request> = {}): Request {
-  return { params: {}, query: {}, ...overrides } as unknown as Request;
+function createMockUser(overrides: Partial<User> = {}): User {
+  const user = new User();
+  user.id = uuidV4();
+  user.name = 'Test User';
+  user.email = 'test@example.com';
+  user.globalRoles = [];
+  user.groupRoles = [];
+  Object.assign(user, overrides);
+  return user;
 }
 
-function createMockResponse(): Response {
-  const res = { status: jest.fn(), send: jest.fn() } as unknown as Response;
+function createMockGroupRole(groupId: string): UserGroupRole {
+  const groupRole = new UserGroupRole();
+  groupRole.groupId = groupId;
+  return groupRole;
+}
+
+// default test user can access everything: ServiceAdmin satisfies the getBuildLog role gate and
+// Developer bypasses the getBuiltLogEntry group check, keeping tests that aren't about authorisation
+// focused on their own behaviour. Tests that specifically exercise access control override this.
+function createMockRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    locals: {},
+    user: createMockUser({ globalRoles: [GlobalRole.ServiceAdmin, GlobalRole.Developer] }),
+    ...overrides
+  } as unknown as Request;
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  const res = { status: jest.fn(), send: jest.fn(), locals: {}, ...overrides } as unknown as Response;
   (res.status as jest.Mock).mockReturnValue(res);
   (res.send as jest.Mock).mockReturnValue(res);
   return res;
@@ -125,12 +155,55 @@ describe('Build log controller', () => {
       expect(mockNext.mock.calls[0][0]).toBeInstanceOf(BadRequestException);
       expect(mockGetBy).not.toHaveBeenCalled();
     });
+
+    it('rejects with Forbidden when the caller is neither a service admin nor a developer', async () => {
+      const req = createMockRequest({ user: createMockUser({ globalRoles: [] }) });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext.mock.calls[0][0]).toBeInstanceOf(ForbiddenException);
+      expect(mockGetBy).not.toHaveBeenCalled();
+    });
+
+    it('allows a service admin to list build logs', async () => {
+      mockGetBy.mockResolvedValue([]);
+      const req = createMockRequest({ user: createMockUser({ globalRoles: [GlobalRole.ServiceAdmin] }) });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockGetBy).toHaveBeenCalled();
+    });
+
+    it('allows a developer to list build logs', async () => {
+      mockGetBy.mockResolvedValue([]);
+      const req = createMockRequest({ user: createMockUser({ globalRoles: [GlobalRole.Developer] }) });
+      const res = createMockResponse();
+
+      await getBuildLog(req, res, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockGetBy).toHaveBeenCalled();
+    });
   });
 
   describe('getBuiltLogEntry', () => {
-    it('returns the full build log entry DTO when found', async () => {
-      const build = { id: uuidV4() };
-      mockFindOneByOrFail.mockResolvedValue(build);
+    function createMockBuild(overrides: { revisionId?: string; userGroupId?: string | null } = {}) {
+      const revisionId = overrides.revisionId ?? uuidV4();
+      const userGroupId = overrides.userGroupId === undefined ? 'group-a' : overrides.userGroupId;
+      return {
+        id: uuidV4(),
+        revisionId,
+        revision: { id: revisionId, dataset: userGroupId ? { userGroupId } : null }
+      };
+    }
+
+    it('returns the full build log entry DTO when found (developer bypasses group check)', async () => {
+      const build = createMockBuild({ userGroupId: 'some-other-group' });
+      mockFindOneOrFail.mockResolvedValue(build);
       mockFromBuildLogFull.mockReturnValue({ dto: build.id });
 
       const req = createMockRequest({ params: { build_id: build.id } });
@@ -138,7 +211,97 @@ describe('Build log controller', () => {
 
       await getBuiltLogEntry(req, res);
 
-      expect(mockFindOneByOrFail).toHaveBeenCalledWith({ id: build.id });
+      expect(mockFindOneOrFail).toHaveBeenCalledWith({
+        where: { id: build.id },
+        relations: { revision: { dataset: true } }
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith({ dto: build.id });
+    });
+
+    it('returns the entry when the caller belongs to the dataset group (non-developer)', async () => {
+      const build = createMockBuild({ userGroupId: 'group-a' });
+      mockFindOneOrFail.mockResolvedValue(build);
+      mockFromBuildLogFull.mockReturnValue({ dto: build.id });
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [createMockGroupRole('group-a')] })
+      });
+      const res = createMockResponse();
+
+      await getBuiltLogEntry(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith({ dto: build.id });
+    });
+
+    it('throws Forbidden when a group-A user requests a group-B build (IDOR on /build/:id)', async () => {
+      const build = createMockBuild({ userGroupId: 'group-b' });
+      mockFindOneOrFail.mockResolvedValue(build);
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [createMockGroupRole('group-a')] })
+      });
+      const res = createMockResponse();
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(ForbiddenException);
+      expect(res.send).not.toHaveBeenCalled();
+    });
+
+    it('throws Forbidden when the caller has no group membership at all', async () => {
+      const build = createMockBuild({ userGroupId: 'group-b' });
+      mockFindOneOrFail.mockResolvedValue(build);
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [] })
+      });
+      const res = createMockResponse();
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws Forbidden when the build has no associated dataset and the caller is not a developer', async () => {
+      const build = createMockBuild({ userGroupId: null });
+      mockFindOneOrFail.mockResolvedValue(build);
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [createMockGroupRole('group-a')] })
+      });
+      const res = createMockResponse();
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws NotFound on the nested revision route when the build belongs to a different revision', async () => {
+      const build = createMockBuild({ revisionId: uuidV4(), userGroupId: 'group-a' });
+      mockFindOneOrFail.mockResolvedValue(build);
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [createMockGroupRole('group-a')] })
+      });
+      const res = createMockResponse({ locals: { revision_id: uuidV4() } });
+
+      await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('succeeds on the nested revision route when the build belongs to the authorised revision', async () => {
+      const build = createMockBuild({ userGroupId: 'group-a' });
+      mockFindOneOrFail.mockResolvedValue(build);
+      mockFromBuildLogFull.mockReturnValue({ dto: build.id });
+
+      const req = createMockRequest({
+        params: { build_id: build.id },
+        user: createMockUser({ globalRoles: [], groupRoles: [createMockGroupRole('group-a')] })
+      });
+      const res = createMockResponse({ locals: { revision_id: build.revisionId } });
+
+      await getBuiltLogEntry(req, res);
+
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith({ dto: build.id });
     });
@@ -148,11 +311,11 @@ describe('Build log controller', () => {
       const res = createMockResponse();
 
       await expect(getBuiltLogEntry(req, res)).rejects.toBeInstanceOf(NotFoundException);
-      expect(mockFindOneByOrFail).not.toHaveBeenCalled();
+      expect(mockFindOneOrFail).not.toHaveBeenCalled();
     });
 
     it('throws NotFound when the build cannot be loaded', async () => {
-      mockFindOneByOrFail.mockRejectedValue(new Error('not in db'));
+      mockFindOneOrFail.mockRejectedValue(new Error('not in db'));
 
       const req = createMockRequest({ params: { build_id: uuidV4() } });
       const res = createMockResponse();


### PR DESCRIPTION
getBuildLog listed every dataset's build history to any authenticated caller with no role check, and getBuiltLogEntry returned any build's generated cube SQL and error output - including for unpublished/draft datasets - without verifying the caller belonged to the dataset's group, or that the build actually belonged to the revision requested via the nested revision route. getBuildLog is now restricted to ServiceAdmin/Developer, and getBuiltLogEntry checks the caller's group membership against the build's dataset (mirroring the existing datasetAuth checks, with a Developer bypass) and asserts the build's revision matches the nested route's revision id.