### PR TITLE
Fix config validation gaps around empty secrets and optional-property matching (SW-1313)

### DIFF
--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -116,14 +116,14 @@ export interface AppConfig {
   };
 }
 
-// list any optional properties here so we can ignore missing values when we check the config on boot
+// list any optional leaf properties here so we can ignore missing values when we check the config on boot.
+// matched against the final segment of the config path (eg. 'session.redisUrl' -> 'redisUrl'), never as a
+// substring, so this must only ever contain full property names.
 // it would be nice to get them directly from the interface, but interfaces are compile-time only
-export const optionalProperties = [
-  'redisUrl',
-  'redisPassword',
-  'entraid',
-  'blob',
-  'datalake',
-  'cube_builder',
-  'bypassToken'
-];
+export const optionalProperties = ['redisUrl', 'redisPassword', 'bypassToken'];
+
+// config blocks that hold real secrets/credentials which are only exercised once the corresponding auth
+// provider or storage backend is actually used. These can legitimately be left unset for local development
+// and CI (where that provider/backend isn't configured), but must always be present once deployed
+// (staging/production) - see checkConfig in check-config.ts.
+export const devOptionalBlocks = ['entraid', 'blob', 'datalake'];

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -124,6 +124,7 @@ export const optionalProperties = ['redisUrl', 'redisPassword', 'bypassToken'];
 
 // config blocks that hold real secrets/credentials which are only exercised once the corresponding auth
 // provider or storage backend is actually used. These can legitimately be left unset for local development
-// and CI (where that provider/backend isn't configured), but must always be present once deployed
-// (staging/production) - see checkConfig in check-config.ts.
+// and CI, but only while that specific provider/backend isn't the one selected (see isBlockInUse in
+// check-config.ts, which still requires eg. storage.datalake.* when storage.store === 'datalake', even
+// locally) - and must always be present once deployed (staging/production) regardless of selection.
 export const devOptionalBlocks = ['entraid', 'blob', 'datalake'];

--- a/src/config/check-config.ts
+++ b/src/config/check-config.ts
@@ -1,18 +1,36 @@
 import { logger } from '../utils/logger';
 import { walkObject, UnknownObject } from '../utils/walk-object';
 
-import { optionalProperties } from './app-config.interface';
+import { optionalProperties, devOptionalBlocks } from './app-config.interface';
+import { AppEnv } from './env.enum';
 
 import { config } from '.';
+
+// local dev and CI don't necessarily have every auth provider/storage backend configured
+// (eg. Entra ID or Azure storage credentials), so devOptionalBlocks are only enforced once deployed
+const DEV_LIKE_ENVS: AppEnv[] = [AppEnv.Local, AppEnv.Ci];
+
+// treat blank/whitespace-only strings the same as a missing value, otherwise an empty env var
+// (eg. `SESSION_SECRET=`) would silently satisfy the check
+const isMissing = (value: unknown): boolean =>
+  value === undefined || (typeof value === 'string' && value.trim() === '');
 
 export const checkConfig = (): void => {
   logger.info('Checking app config...');
 
+  const devLikeEnv = DEV_LIKE_ENVS.includes(config.env);
+
   walkObject(config as unknown as UnknownObject, ({ value, location, isLeaf }) => {
     const configPath = location.join('.');
-    const optional = optionalProperties.some((prop) => configPath.includes(prop));
+    const leafName = location[location.length - 1];
 
-    if (isLeaf && !optional && value === undefined) {
+    // match on exact path segments only - never as a substring of configPath - so eg. 'blob' can't
+    // accidentally match an unrelated property that merely contains 'blob' somewhere in its name
+    const optional =
+      optionalProperties.includes(String(leafName)) ||
+      (devLikeEnv && devOptionalBlocks.some((block) => location.includes(block)));
+
+    if (isLeaf && !optional && isMissing(value)) {
       throw new Error(`${configPath} is invalid or missing, stopping server`);
     }
   });

--- a/src/config/check-config.ts
+++ b/src/config/check-config.ts
@@ -1,5 +1,7 @@
 import { logger } from '../utils/logger';
 import { walkObject, UnknownObject } from '../utils/walk-object';
+import { FileStore } from './file-store.enum';
+import { AuthProvider } from '../enums/auth-providers';
 
 import { optionalProperties, devOptionalBlocks } from './app-config.interface';
 import { AppEnv } from './env.enum';
@@ -15,6 +17,30 @@ const DEV_LIKE_ENVS: AppEnv[] = [AppEnv.Local, AppEnv.Ci];
 const isMissing = (value: unknown): boolean =>
   value === undefined || (typeof value === 'string' && value.trim() === '');
 
+// A devOptionalBlock is only actually optional in local/CI while it's unused. If the app is configured
+// to use that specific auth provider or storage backend (eg. storage.store === 'datalake'), its
+// credentials are required even in dev-like envs - otherwise checkConfig would pass locally/in CI and
+// only fail later, at first request, since getFileService() (called on every request via initServices)
+// eagerly constructs the selected storage backend.
+//
+// getFileService() picks the backend with `config.storage.store === FileStore.Blob ? Blob : DataLake` -
+// DataLake is its fallback for *any* non-Blob value, not just the literal 'datalake' - so 'datalake' is
+// mirrored here as "not Blob" rather than "exactly DataLake". Matching that fallback exactly means an
+// unvalidated/garbage FILE_STORE value (local.ts casts it with `as FileStore` and doesn't validate it
+// against the enum) still correctly requires datalake credentials, since that's what would actually run.
+const isBlockInUse = (block: string): boolean => {
+  switch (block) {
+    case 'blob':
+      return config.storage.store === FileStore.Blob;
+    case 'datalake':
+      return config.storage.store !== FileStore.Blob;
+    case 'entraid':
+      return config.auth.providers.includes(AuthProvider.EntraId);
+    default:
+      return false;
+  }
+};
+
 export const checkConfig = (): void => {
   logger.info('Checking app config...');
 
@@ -28,7 +54,7 @@ export const checkConfig = (): void => {
     // accidentally match an unrelated property that merely contains 'blob' somewhere in its name
     const optional =
       optionalProperties.includes(String(leafName)) ||
-      (devLikeEnv && devOptionalBlocks.some((block) => location.includes(block)));
+      (devLikeEnv && devOptionalBlocks.some((block) => location.includes(block) && !isBlockInUse(block)));
 
     if (isLeaf && !optional && isMissing(value)) {
       throw new Error(`${configPath} is invalid or missing, stopping server`);

--- a/test/unit/config/check-config.test.ts
+++ b/test/unit/config/check-config.test.ts
@@ -1,0 +1,163 @@
+import { set } from 'lodash';
+
+import { AppEnv } from '../../../src/config/env.enum';
+import { AppConfig } from '../../../src/config/app-config.interface';
+import { SessionStore } from '../../../src/config/session-store.enum';
+import { FileStore } from '../../../src/config/file-store.enum';
+import { AuthProvider } from '../../../src/enums/auth-providers';
+import { Locale } from '../../../src/enums/locale';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), trace: jest.fn() }
+}));
+
+// a fully populated, production-like config where every required leaf has a real value
+const buildValidConfig = (env: AppEnv = AppEnv.Prod): AppConfig => ({
+  env,
+  build: { gitSha: 'abc123' },
+  frontend: { port: 3000, url: 'https://example.com' },
+  backend: { port: 3001, url: 'https://api.example.com' },
+  healthcheck: { dbTimeoutMs: 2500, storageTimeoutMs: 2500 },
+  language: {
+    availableTranslations: [Locale.English, Locale.Welsh],
+    supportedLocales: [Locale.EnglishGb, Locale.WelshGb],
+    fallback: Locale.English
+  },
+  session: {
+    store: SessionStore.Redis,
+    secret: 'session-secret',
+    secure: true,
+    maxAge: 86400000,
+    redisUrl: 'redis://localhost',
+    redisPassword: 'redis-password'
+  },
+  logger: { level: 'info', memUsage: false },
+  rateLimit: { windowMs: 60000, maxRequests: 100, bypassToken: 'bypass-token' },
+  requestTimeout: { defaultMs: 30000, longMs: 300000 },
+  database: {
+    host: 'db-host',
+    port: 5432,
+    username: 'db-user',
+    password: 'db-password',
+    database: 'statswales',
+    ssl: true,
+    synchronize: false
+  },
+  auth: {
+    providers: [AuthProvider.EntraId],
+    jwt: {
+      secret: 'jwt-secret',
+      expiresIn: '6h',
+      secure: true,
+      cookieDomain: 'example.com'
+    },
+    entraid: {
+      url: 'https://login.microsoftonline.com/tenant',
+      clientId: 'entraid-client-id',
+      clientSecret: 'entraid-client-secret'
+    }
+  },
+  storage: {
+    store: FileStore.DataLake,
+    blob: {
+      url: 'https://account.blob.core.windows.net',
+      accountName: 'account',
+      accountKey: 'blob-account-key',
+      containerName: 'container'
+    },
+    datalake: {
+      url: 'https://account.dfs.core.windows.net',
+      accountName: 'account',
+      accountKey: 'datalake-account-key',
+      fileSystemName: 'filesystem'
+    }
+  },
+  duckdb: { threads: 1, memory: '256MB', writeTimeOut: 150, maxConcurrency: 5 },
+  clamav: { host: 'clamav', port: 3310, timeout: 60000 },
+  cube_builder: { preserve_failed: false }
+});
+
+// checkConfig reads `config` from the module scope of `src/config` at call time, so each test loads a
+// fresh, isolated copy of check-config.ts mocked against its own config object rather than mutating a
+// shared singleton
+const checkConfigFor = (config: AppConfig): (() => void) => {
+  let checkConfig!: () => void;
+
+  jest.isolateModules(() => {
+    jest.doMock('../../../src/config', () => ({ config }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    checkConfig = require('../../../src/config/check-config').checkConfig;
+  });
+
+  return checkConfig;
+};
+
+describe('checkConfig', () => {
+  it('does not throw for a fully populated production-like config', () => {
+    expect(() => checkConfigFor(buildValidConfig(AppEnv.Prod))()).not.toThrow();
+  });
+
+  describe.each([
+    ['storage.blob.accountKey', 'AZURE_BLOB_STORAGE_ACCOUNT_KEY'],
+    ['storage.datalake.accountKey', 'AZURE_DATALAKE_STORAGE_ACCOUNT_KEY'],
+    ['auth.entraid.clientSecret', 'ENTRAID_CLIENT_SECRET'],
+    ['session.secret', 'SESSION_SECRET']
+  ])('%s (%s)', (path) => {
+    it('fails boot in a prod-like config when the value is missing', () => {
+      const config = buildValidConfig(AppEnv.Prod);
+      set(config, path, undefined);
+
+      expect(() => checkConfigFor(config)()).toThrow(`${path} is invalid or missing`);
+    });
+
+    it('fails boot in a prod-like config when the value is an empty string', () => {
+      const config = buildValidConfig(AppEnv.Prod);
+      set(config, path, '');
+
+      expect(() => checkConfigFor(config)()).toThrow(`${path} is invalid or missing`);
+    });
+
+    it('fails boot in a prod-like config when the value is a blank/whitespace-only string', () => {
+      const config = buildValidConfig(AppEnv.Prod);
+      set(config, path, '   ');
+
+      expect(() => checkConfigFor(config)()).toThrow(`${path} is invalid or missing`);
+    });
+  });
+
+  describe('local/CI leniency for unconfigured auth providers and storage backends', () => {
+    it('does not throw when entraid/blob/datalake secrets are missing in a local config', () => {
+      const config = buildValidConfig(AppEnv.Local);
+      set(config, 'auth.entraid.clientSecret', undefined);
+      set(config, 'storage.blob.accountKey', undefined);
+      set(config, 'storage.datalake.accountKey', undefined);
+
+      expect(() => checkConfigFor(config)()).not.toThrow();
+    });
+
+    it('does not throw when entraid/blob/datalake secrets are missing in a CI config', () => {
+      const config = buildValidConfig(AppEnv.Ci);
+      set(config, 'auth.entraid.clientSecret', undefined);
+      set(config, 'storage.blob.accountKey', undefined);
+      set(config, 'storage.datalake.accountKey', undefined);
+
+      expect(() => checkConfigFor(config)()).not.toThrow();
+    });
+
+    it('still fails boot in a local config when session.secret is empty', () => {
+      const config = buildValidConfig(AppEnv.Local);
+      set(config, 'session.secret', '');
+
+      expect(() => checkConfigFor(config)()).toThrow('session.secret is invalid or missing');
+    });
+  });
+
+  it('does not throw for genuinely optional properties when missing', () => {
+    const config = buildValidConfig(AppEnv.Prod);
+    set(config, 'session.redisUrl', undefined);
+    set(config, 'session.redisPassword', undefined);
+    set(config, 'rateLimit.bypassToken', undefined);
+
+    expect(() => checkConfigFor(config)()).not.toThrow();
+  });
+});

--- a/test/unit/config/check-config.test.ts
+++ b/test/unit/config/check-config.test.ts
@@ -126,22 +126,61 @@ describe('checkConfig', () => {
   });
 
   describe('local/CI leniency for unconfigured auth providers and storage backends', () => {
-    it('does not throw when entraid/blob/datalake secrets are missing in a local config', () => {
+    // buildValidConfig defaults to storage.store: FileStore.DataLake and auth.providers: [AuthProvider.EntraId],
+    // so blob is the *unused* storage backend here - only its secret can be safely missing.
+    it('does not throw when the unused storage backend secret is missing in a local config', () => {
       const config = buildValidConfig(AppEnv.Local);
-      set(config, 'auth.entraid.clientSecret', undefined);
       set(config, 'storage.blob.accountKey', undefined);
-      set(config, 'storage.datalake.accountKey', undefined);
 
       expect(() => checkConfigFor(config)()).not.toThrow();
     });
 
-    it('does not throw when entraid/blob/datalake secrets are missing in a CI config', () => {
+    it('does not throw when the unused storage backend secret is missing in a CI config', () => {
       const config = buildValidConfig(AppEnv.Ci);
-      set(config, 'auth.entraid.clientSecret', undefined);
       set(config, 'storage.blob.accountKey', undefined);
-      set(config, 'storage.datalake.accountKey', undefined);
 
       expect(() => checkConfigFor(config)()).not.toThrow();
+    });
+
+    it('does not throw when entraid secrets are missing and EntraId is not an enabled auth provider', () => {
+      const config = buildValidConfig(AppEnv.Local);
+      config.auth.providers = [AuthProvider.Jwt];
+      set(config, 'auth.entraid.clientSecret', undefined);
+
+      expect(() => checkConfigFor(config)()).not.toThrow();
+    });
+
+    it('still fails boot in a local config when the *selected* storage backend is missing its secret', () => {
+      // storage.store is FileStore.DataLake by default, so datalake credentials are in use here
+      const config = buildValidConfig(AppEnv.Local);
+      set(config, 'storage.datalake.accountKey', undefined);
+
+      expect(() => checkConfigFor(config)()).toThrow('storage.datalake.accountKey is invalid or missing');
+    });
+
+    it('still fails boot in a CI config when the *selected* storage backend is missing its secret', () => {
+      const config = buildValidConfig(AppEnv.Ci);
+      set(config, 'storage.datalake.accountKey', undefined);
+
+      expect(() => checkConfigFor(config)()).toThrow('storage.datalake.accountKey is invalid or missing');
+    });
+
+    it('still fails boot in a local config when storage.store is an unrecognised value, since getFileService() falls back to datalake for anything that is not exactly "blob"', () => {
+      const config = buildValidConfig(AppEnv.Local);
+      // simulates an unvalidated/garbage FILE_STORE env var - local.ts casts it with `as FileStore`
+      // without validating it against the enum, so this reaches checkConfig as a non-empty string
+      config.storage.store = 'not-a-real-store' as FileStore;
+      set(config, 'storage.datalake.accountKey', undefined);
+
+      expect(() => checkConfigFor(config)()).toThrow('storage.datalake.accountKey is invalid or missing');
+    });
+
+    it('still fails boot in a local config when EntraId is an enabled auth provider but its secret is missing', () => {
+      // auth.providers includes AuthProvider.EntraId by default, so entraid credentials are in use here
+      const config = buildValidConfig(AppEnv.Local);
+      set(config, 'auth.entraid.clientSecret', undefined);
+
+      expect(() => checkConfigFor(config)()).toThrow('auth.entraid.clientSecret is invalid or missing');
     });
 
     it('still fails boot in a local config when session.secret is empty', () => {


### PR DESCRIPTION
Blank env vars (eg. SESSION_SECRET=) previously passed the boot-time config check because it only tested for undefined, and a substring match on optionalProperties caused every leaf under auth.entraid/storage.blob/storage.datalake to be silently treated as optional in every environment, including production. checkConfig now treats blank/whitespace strings as missing, matches optional properties by exact path segment instead of substring, and only exempts the entraid/blob/datalake blocks in local/CI where those providers aren't configured - staging and production now fail fast at boot if those secrets are absent.