### PR TITLE
Prevent raw DB/driver error text from reaching anonymous API callers (SW-1314)

### DIFF
--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -444,7 +444,8 @@ export const getPublishedDatasetFilters = async (req: Request, res: Response, ne
     if (err instanceof NotFoundException || err instanceof BadRequestException) {
       return next(err);
     }
-    next(err);
+    logger.error(err, 'Error getting published dataset filters');
+    return next(new UnknownException());
   }
 };
 

--- a/src/controllers/consumer-v2.ts
+++ b/src/controllers/consumer-v2.ts
@@ -445,7 +445,7 @@ export const getPublishedDatasetFilters = async (req: Request, res: Response, ne
       return next(err);
     }
     logger.error(err, 'Error getting published dataset filters');
-    return next(new UnknownException());
+    return next(new UnknownException('errors.unknown_error'));
   }
 };
 

--- a/src/controllers/dataset.ts
+++ b/src/controllers/dataset.ts
@@ -486,7 +486,7 @@ export const updateSources = async (req: Request, res: Response, next: NextFunct
   const userId = req.user?.id;
 
   if (!sourceAssignment) {
-    next(new BadRequestException('Could not assign source types to import'));
+    next(new BadRequestException('errors.invalid_source_assignment'));
     return;
   }
 

--- a/src/middleware/translation.ts
+++ b/src/middleware/translation.ts
@@ -27,7 +27,13 @@ i18next
     },
     fallbackLng: config.language.fallback,
     preload: AVAILABLE_LANGUAGES,
-    debug: false
+    debug: false,
+    // Never echo an unrecognised key back to the caller verbatim — keys are sometimes
+    // derived from raw error messages (e.g. DB/driver errors), so returning them as-is
+    // would leak internal detail to API consumers. Return a fixed, generic string
+    // instead. This is a hardcoded literal (not a nested t() call) so it can never
+    // recurse back into this handler, regardless of locale/resource load state.
+    parseMissingKeyHandler: () => 'An unknown error occurred'
   });
 
 const t = i18next.t;

--- a/src/middleware/translation.ts
+++ b/src/middleware/translation.ts
@@ -11,6 +11,14 @@ import { config } from '../config';
 const AVAILABLE_LANGUAGES = config.language.availableTranslations;
 const SUPPORTED_LOCALES = config.language.supportedLocales;
 
+// Mirrors errors.unknown_error in the locale files. Hardcoded here (rather than a nested t() call)
+// so parseMissingKeyHandler can never recurse back into itself, regardless of locale/resource load
+// state, while still respecting the caller's requested language instead of always answering in English.
+const GENERIC_FALLBACK_MESSAGE: Record<string, string> = {
+  en: 'An unknown error occurred',
+  cy: 'Mae gwall anhysbys wedi digwydd'
+};
+
 i18next
   .use(Backend)
   .use(i18nextMiddleware.LanguageDetector)
@@ -30,10 +38,13 @@ i18next
     debug: false,
     // Never echo an unrecognised key back to the caller verbatim — keys are sometimes
     // derived from raw error messages (e.g. DB/driver errors), so returning them as-is
-    // would leak internal detail to API consumers. Return a fixed, generic string
-    // instead. This is a hardcoded literal (not a nested t() call) so it can never
-    // recurse back into this handler, regardless of locale/resource load state.
-    parseMissingKeyHandler: () => 'An unknown error occurred'
+    // would leak internal detail to API consumers. Return a fixed, generic string instead,
+    // still respecting the caller's requested language (options.lng) so Welsh callers don't
+    // see English for a missing key.
+    parseMissingKeyHandler: (_key, _defaultValue, options) => {
+      const lng = String(options?.lng ?? config.language.fallback).toLowerCase();
+      return lng.startsWith('cy') ? GENERIC_FALLBACK_MESSAGE.cy : GENERIC_FALLBACK_MESSAGE.en;
+    }
   });
 
 const t = i18next.t;

--- a/src/resources/locales/cy.json
+++ b/src/resources/locales/cy.json
@@ -43,7 +43,11 @@
     "download_from_filestore": "Gwall wrth lawrlwytho’r ffeil o’r storfa ffeiliau",
     "upload": {
       "no_title": "Ni ddarparwyd teitl ar gyfer y set ddata",
-      "no_csv": "Ni ddarparwyd data CSV"
+      "no_csv": "Ni ddarparwyd data CSV",
+      "failed_to_parse": "Methwyd â phrosesu’r ffeil a lanlwythwyd"
+    },
+    "file_validation": {
+      "datalake_upload_error": "Gwall wrth lanlwytho ffeil i’r storfa blob"
     },
     "dataset_id_invalid": "Mae id y set ddata yn annilys neu ar goll",
     "revision_id_invalid": "Mae’r id diwygio yn annilys neu ar goll",
@@ -54,6 +58,8 @@
     "info_update_error": "Ni fu modd diweddaru gwybodaeth y set ddata",
     "no_dataset": "Set ddata heb ei chanfod",
     "no_revision": "Diwygiad heb ei ganfod ar gyfer y set ddata",
+    "no_end_revision": "Diwygiad terfynol heb ei ganfod ar gyfer y set ddata",
+    "no_data_table": "Tabl data heb ei ganfod ar gyfer y diwygiad",
     "no_file_import": "Mewngludiad heb ei ganfod ar gyfer y set ddata",
     "upload_error": "Gwall wrth lanlwytho’r ffeil",
     "move_file_error": "Gwall wrth symud y ffeil o storfa blob dros dro i’r Llyn Data.  Rhowch gynnig arall ar hyn.",

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -45,7 +45,11 @@
     "download_from_filestore": "Error downloading file from file store",
     "upload": {
       "no_title": "No title for the dataset has been provided",
-      "no_csv": "No CSV data provided"
+      "no_csv": "No CSV data provided",
+      "failed_to_parse": "Failed to process the uploaded file"
+    },
+    "file_validation": {
+      "datalake_upload_error": "Error uploading file to blob storage"
     },
     "dataset_id_invalid": "Dataset id is invalid or missing",
     "revision_id_invalid": "Revision id is invalid or missing",
@@ -56,6 +60,8 @@
     "info_update_error": "Could not update the dataset info",
     "no_dataset": "Dataset could not be found",
     "no_revision": "No revision found for dataset",
+    "no_end_revision": "No end revision found for dataset",
+    "no_data_table": "No data table found for revision",
     "no_file_import": "No import found for dataset",
     "upload_error": "Error uploading the file",
     "move_file_error": "Error moving file from temporary blob storage to Data Lake. Please try again.",

--- a/src/routes/error-handler.ts
+++ b/src/routes/error-handler.ts
@@ -36,11 +36,24 @@ export const errorHandler: ErrorRequestHandler = (err: any, req: Request, res: R
       res.status(503);
       break;
 
+    // A recognised application exception (e.g. UnknownException) explicitly sets status
+    // 500 with a deliberate, developer-authored message/translation key, so it's safe to
+    // translate and return as-is, same as the other known-status branches above.
     case 500:
+      logger.error(err, `500 error detected for ${req.originalUrl}: ${message}`);
+      res.status(500);
+      break;
+
+    // Anything reaching here has no recognised app-assigned status — e.g. a raw
+    // TypeORM/pg or DuckDB driver error that was never wrapped in one of our own
+    // exception types. Never echo err.message to the client in this case, as it may
+    // contain raw DB/driver error detail (SQL fragments, table/column names, etc).
+    // The real error is still logged in full server-side, just above, for diagnosis.
     default:
       logger.error(err, `unknown error detected for ${req.originalUrl}: ${message}`);
       res.status(500);
-      break;
+      res.json({ error: t('errors.unknown_error', { lng: req.language }) });
+      return;
   }
 
   res.json({ error: t(message, { lng: req.language }) });

--- a/test/integration/routes/consumer-v2/filters-and-queries.test.ts
+++ b/test/integration/routes/consumer-v2/filters-and-queries.test.ts
@@ -12,6 +12,7 @@ import { getTestUser, getTestUserGroup } from '../../../helpers/get-test-user';
 import { seedPublishedDataset } from '../../../helpers/seed-published-dataset';
 import { FactTableColumnType } from '../../../../src/enums/fact-table-column-type';
 import BlobStorage from '../../../../src/services/blob-storage';
+import { PublishedDatasetRepository } from '../../../../src/repositories/published-dataset';
 
 jest.mock('../../../../src/services/blob-storage');
 BlobStorage.prototype.listFiles = jest.fn().mockReturnValue([]);
@@ -119,6 +120,24 @@ describe('Consumer V2 — filters + query-store endpoints', () => {
     it('returns 404 for a malformed UUID', async () => {
       const res = await request(app).get('/v2/not-a-uuid/filters');
       expect(res.status).toBe(404);
+    });
+
+    it('returns a generic error message (not raw DB/driver text) when a downstream call fails', async () => {
+      // Simulate a raw TypeORM/pg driver style failure surfacing from a downstream call, to
+      // confirm the anonymous, public-facing caller never receives internal error detail.
+      const dbError = new Error('relation "12345678-1234-4123-8123-123456789012"."fact_table" does not exist');
+      const spy = jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(dbError);
+
+      try {
+        const res = await request(app).get(`/v2/${DATASET_ID}/filters`);
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('An unknown error occurred');
+        expect(res.body.error).not.toContain('relation');
+        expect(res.body.error).not.toContain('fact_table');
+        expect(JSON.stringify(res.body)).not.toContain(dbError.message);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 

--- a/test/integration/routes/consumer-v2/filters-and-queries.test.ts
+++ b/test/integration/routes/consumer-v2/filters-and-queries.test.ts
@@ -139,6 +139,20 @@ describe('Consumer V2 — filters + query-store endpoints', () => {
         spy.mockRestore();
       }
     });
+
+    it('returns the generic error message in Welsh for a Welsh caller, instead of always answering in English', async () => {
+      const dbError = new Error('relation "12345678-1234-4123-8123-123456789012"."fact_table" does not exist');
+      const spy = jest.spyOn(PublishedDatasetRepository, 'getById').mockRejectedValueOnce(dbError);
+
+      try {
+        const res = await request(app).get(`/v2/${DATASET_ID}/filters`).query({ lang: 'cy' });
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('Mae gwall anhysbys wedi digwydd');
+        expect(JSON.stringify(res.body)).not.toContain(dbError.message);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe('POST /v2/:dataset_id/data — generate filter ID', () => {

--- a/test/integration/routes/publisher-journey.test.ts
+++ b/test/integration/routes/publisher-journey.test.ts
@@ -92,7 +92,7 @@ describe('API Endpoints', () => {
       const dataset = await datasetService.createNew('Test Dataset 1', userGroup.id!, user);
       const res = await request(app).post(`/dataset/${dataset.id}/data`).set(getAuthHeader(user));
       expect(res.status).toBe(400);
-      expect(res.body).toEqual({ error: 'errors.upload.failed_to_parse' });
+      expect(res.body).toEqual({ error: 'Failed to process the uploaded file' });
       await Dataset.remove(dataset);
     });
 
@@ -292,7 +292,7 @@ describe('API Endpoints', () => {
         .get(`/dataset/${testDatasetId}/revision/by-id/${testRevisionId}/data-table/preview`)
         .set(getAuthHeader(user));
       expect(res.status).toBe(404);
-      expect(res.body).toEqual({ error: 'errors.no_data_table' });
+      expect(res.body).toEqual({ error: 'No data table found for revision' });
       createdRevisions.push(testRevisionId);
     });
   });
@@ -351,7 +351,7 @@ describe('API Endpoints', () => {
         .set(getAuthHeader(user));
 
       expect(res.status).toBe(400);
-      expect(res.body).toEqual({ error: 'errors.upload.failed_to_parse' });
+      expect(res.body).toEqual({ error: 'Failed to process the uploaded file' });
       createdRevisions.push(testRevisionId);
     });
 
@@ -420,7 +420,7 @@ describe('API Endpoints', () => {
         .set(getAuthHeader(user))
         .attach('csv', csvFile);
       expect(res.status).toBe(500);
-      expect(res.body).toEqual({ error: 'errors.file_validation.datalake_upload_error' });
+      expect(res.body).toEqual({ error: 'Error uploading file to blob storage' });
       createdRevisions.push(testRevisionId);
     });
   });

--- a/test/integration/routes/view-dataset-contents.test.ts
+++ b/test/integration/routes/view-dataset-contents.test.ts
@@ -71,7 +71,7 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
       .query({ page_number: 2, page_size: 100 });
 
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: 'errors.no_end_revision' });
+    expect(res.body).toEqual({ error: 'No end revision found for dataset' });
   });
 
   test('Get file view returns 404 when a not valid UUID is supplied', async () => {

--- a/test/integration/routes/view-dataset-contents.test.ts
+++ b/test/integration/routes/view-dataset-contents.test.ts
@@ -62,7 +62,7 @@ describe('API Endpoints for viewing the contents of a dataset', () => {
     expect(res.body.data[23]).toEqual(['201314', '522', 4636, '1', '1', null]);
   });
 
-  test('Get a dataset view returns 500 if there is no revision on the dataset', async () => {
+  test('Get a dataset view returns 404 if there is no revision on the dataset', async () => {
     const dataset = await DatasetRepository.create({ createdBy: user, userGroupId: userGroup.id }).save();
 
     const res = await request(app)

--- a/test/unit/controllers/consumer-v2.test.ts
+++ b/test/unit/controllers/consumer-v2.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { NotFoundException } from '../../../src/exceptions/not-found.exception';
+import { UnknownException } from '../../../src/exceptions/unknown.exception';
 import { Dataset } from '../../../src/entities/dataset/dataset';
 import { Revision } from '../../../src/entities/dataset/revision';
 import { uuidV4 } from '../../../src/utils/uuid';
@@ -389,6 +390,30 @@ describe('consumer-v2 controller - scheduled publish date handling', () => {
       await getPublishedDatasetFilters(req, res, mockNext);
 
       expect(mockGetFilterTableQuery).toHaveBeenCalledWith(publishedRev.id, 2, 'en');
+    });
+
+    it('should call next with a generic UnknownException (not the raw DB error) when a downstream call fails', async () => {
+      const dataset = createMockDataset();
+      const publishedRev = createMockRevision();
+      const req = createMockRequest({ language: 'en' } as Partial<Request>);
+      const res = createMockResponse({ locals: { datasetId: dataset.id, dataset } });
+
+      mockGetLatestByDatasetId.mockResolvedValue(publishedRev);
+      mockGetFilterTableQuery.mockResolvedValue('SELECT 1');
+
+      // Simulate a raw TypeORM/pg driver style error (e.g. QueryFailedError), which must
+      // never be forwarded to the anonymous, public-facing caller verbatim.
+      const dbError = new Error('relation "12345678-1234-4123-8123-123456789012"."fact_table" does not exist');
+      mockPublishedDatasetGetById.mockRejectedValue(dbError);
+
+      await getPublishedDatasetFilters(req, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      const errArg = mockNext.mock.calls[0][0];
+      expect(errArg).toBeInstanceOf(UnknownException);
+      expect(errArg).not.toBe(dbError);
+      expect(String(errArg.message)).not.toContain('relation');
+      expect(String(errArg.message)).not.toContain('fact_table');
     });
   });
 });


### PR DESCRIPTION
getPublishedDatasetFilters (an anonymous, cors() * endpoint) re-wrapped only NotFoundException/BadRequestException; any other error - a raw TypeORM/pg or DuckDB error - fell through to a bare next(err), and the error handler's default branch passed err.message through t(), which i18next then echoed back verbatim for unrecognised keys, leaking SQL fragments and table/column names to unauthenticated callers. The unguarded catch now wraps in UnknownException(), matching sibling handlers in the same file. The error handler's catch-all branch (anything with no recognised app-assigned status) now always returns a fixed generic message and never touches err.message, and i18next's parseMissingKeyHandler returns a fixed string instead of echoing unknown keys. This also surfaced a pre-existing, unrelated bug: four error translation keys used by existing exceptions had no entries in the locale files and were only "working" by accident via the verbatim-echo behaviour just removed - backfilled those keys (English and Welsh) and fixed one call site that was passing a raw English sentence as a translation key.